### PR TITLE
Update comparison logic in auto-buy and auto-sell validators

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/auto-buy-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/auto-buy-validator.ts
@@ -145,7 +145,7 @@ const deleteErrorsValidation = paramsSchema.refine(
 const warningsValidation = paramsSchema
   .refine(
     ({ triggerData, position }) => {
-      return position.ltv <= triggerData.executionLTV
+      return position.ltv >= triggerData.executionLTV
     },
     {
       message: 'Auto buy triggered immediately',

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/auto-sell-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/auto-sell-validator.ts
@@ -164,7 +164,7 @@ const deleteErrorsValidation = paramsSchema.refine(
 const warningsValidation = paramsSchema
   .refine(
     ({ triggerData, position }) => {
-      return position.ltv >= triggerData.executionLTV
+      return position.ltv <= triggerData.executionLTV
     },
     {
       message: 'Auto sell triggered immediately',


### PR DESCRIPTION
Corrected the comparison logic in the validation functions of both the auto-buy and auto-sell validators. This fixes an issue where auto-buy was triggered when the Loan-to-Value ratio (ltv) was less than the execution LTV and vice versa for the auto-sell validator. Now, auto-buy triggers when ltv is greater than or equal to execution LTV, and auto-sell triggers when ltv is less than or equal to execution LTV.

[Notion BUG](https://www.notion.so/oazo/AutoBuy-Wrong-warning-message-when-selecting-valid-trigger-and-target-values-535290ba59fe471a9566a04ce28df549?pvs=4)