### PR TITLE
better-tsconfig-with-paths-in-tests

### DIFF
--- a/apps/summerfi-api/lib/__template-function__/package.json
+++ b/apps/summerfi-api/lib/__template-function__/package.json
@@ -8,7 +8,8 @@
     "testw": "jest --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "build": "esbuild src/index.ts --bundle --minify --platform=node --target=node20 --outfile=dist/index.js --sourcemap"
+    "build": "tsc -b -v tsconfig.build.json",
+    "bundle": "esbuild src/index.ts --bundle --minify --platform=node --target=node20 --outfile=dist/index.js --sourcemap"
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^1.17.0",

--- a/apps/summerfi-api/lib/__template-function__/tests/tests.spec.ts
+++ b/apps/summerfi-api/lib/__template-function__/tests/tests.spec.ts
@@ -1,4 +1,4 @@
-import { handler } from '../src'
+import { handler } from '~src/index'
 
 describe('template', () => {
   it('template', async () => {

--- a/apps/summerfi-api/lib/__template-function__/tsconfig.build.json
+++ b/apps/summerfi-api/lib/__template-function__/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  // by using a separate tsconfig for build, we can set main tsconfig to
+  // include tests and use module paths in tests but build without tests
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/summerfi-api/lib/__template-function__/tsconfig.json
+++ b/apps/summerfi-api/lib/__template-function__/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "extends": "@summerfi/typescript-config/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
       "~src/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Added a new tsconfig.build.json to use during builds to emit only required files. This allow us to use paths in tests by setting root to "./" in the main ts config.