### PR TITLE
Update triggers configuration and improve validators

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/auto-buy-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/auto-buy-validator.ts
@@ -54,7 +54,7 @@ const upsertErrorsValidation = paramsSchema
   )
   .refine(
     ({ executionPrice, triggerData }) => {
-      return triggerData.maxBuyPrice && triggerData.maxBuyPrice > executionPrice
+      return !triggerData.useMaxBuyPrice || triggerData.maxBuyPrice > executionPrice
     },
     {
       message: 'Execution price is bigger than max buy price',

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-buy.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-buy.ts
@@ -6,7 +6,7 @@ import {
   stringToBytes,
 } from 'viem'
 import { automationBotAbi } from '~abi'
-import { AaveAutoBuyTriggerData, PRICE_DECIMALS } from '~types'
+import { AaveAutoBuyTriggerData, maxUnit256, PRICE_DECIMALS } from '~types'
 import { DEFAULT_DEVIATION, MAX_COVERAGE_BASE } from './defaults'
 import { EncoderFunction } from './types'
 import { OPERATION_NAMES } from '@oasisdex/dma-library'
@@ -44,7 +44,7 @@ export const encodeAaveAutoBuy: EncoderFunction<AaveAutoBuyTriggerData> = (
     operationNameInBytes,
     triggerData.executionLTV,
     triggerData.targetLTV,
-    triggerData.maxBuyPrice,
+    triggerData.maxBuyPrice ?? maxUnit256,
     DEFAULT_DEVIATION, // 100 -> 1%
     triggerData.maxBaseFee,
   ])

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-sell.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-sell.ts
@@ -52,7 +52,7 @@ export const encodeAaveAutoSell: EncoderFunction<AaveAutoSellTriggerData> = (
     operationNameInBytes,
     triggerData.executionLTV,
     triggerData.targetLTV,
-    triggerData.minSellPrice,
+    triggerData.minSellPrice ?? 0n,
     DEFAULT_DEVIATION, // 100 -> 1%
     triggerData.maxBaseFee,
   ])

--- a/apps/summerfi-api/lib/setup-trigger-function/src/types/validators/aave-auto-buy.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/types/validators/aave-auto-buy.ts
@@ -24,7 +24,7 @@ export const aaveBasicBuyTriggerDataSchema = z
   })
   .refine(
     ({ maxBuyPrice, useMaxBuyPrice }) => {
-      return useMaxBuyPrice ? maxBuyPrice !== maxUnit256 : true
+      return useMaxBuyPrice ? maxBuyPrice !== maxUnit256 && maxBuyPrice !== undefined : true
     },
     {
       params: {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/types/validators/aave-auto-sell.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/types/validators/aave-auto-sell.ts
@@ -24,7 +24,7 @@ export const aaveBasicSellTriggerDataSchema = z
   })
   .refine(
     ({ minSellPrice, useMinSellPrice }) => {
-      return useMinSellPrice ? minSellPrice !== 0n : true
+      return useMinSellPrice ? minSellPrice !== 0n && minSellPrice !== undefined : true
     },
     {
       params: {

--- a/apps/summerfi-api/stacks/summer-stack.ts
+++ b/apps/summerfi-api/stacks/summer-stack.ts
@@ -1,6 +1,6 @@
 import { StackContext, Api } from 'sst/constructs'
 import { addTriggersConfig } from './triggers'
-// import { addSdkConfig } from './sdk'
+import { addSdkConfig } from './sdk'
 import { addMigrationsConfig } from './migrations'
 
 export function API(stackContext: StackContext) {

--- a/turbo.json
+++ b/turbo.json
@@ -46,6 +46,9 @@
     },
     "cicheck": {
       "dependsOn": ["prebuild", "build", "test", "lint"]
+    },
+    "deploy:staging": {
+      "dependsOn": ["cicheck", "^deploy:staging"]
     }
   }
 }


### PR DESCRIPTION
This commit adds a new 'deploy:staging' dependency in turbo.json configuration. Also, it modifies auto-buy-validator to apply the maxBuyPrice only when useMaxBuyPrice is true. Further, it removes the comment from sdk import statement in summer-stack.ts, and adds default values for minSellPrice and maxBuyPrice in the respective trigger encoders.