### PR TITLE
Implement chain verification and simplify request validation

### DIFF
--- a/apps/summerfi-api/lib/get-migrations-function/src/client.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/client.ts
@@ -61,6 +61,21 @@ export function createMigrationsClient(
             },
           })
 
+          const publicClient = createPublicClient({
+            chain,
+            transport,
+          })
+
+          const chainIdFromChain = await publicClient.getChainId()
+          if (chainIdFromChain !== chainId) {
+            return {
+              debtAssets: [],
+              collAssets: [],
+              chainId,
+              protocolId,
+            }
+          }
+
           const { collAssets, debtAssets } = await getAssets(transport, chain, protocolId, address)
           return {
             debtAssets,

--- a/apps/summerfi-api/lib/get-migrations-function/src/index.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from '@summerfi/serverless-shared/responses'
 import { addressSchema } from '@summerfi/serverless-shared/validators'
 import {
-  Address,
   PortfolioMigration,
   PortfolioMigrationsResponse,
 } from '@summerfi/serverless-shared/domain-types'
@@ -26,9 +25,6 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
   const { RPC_GATEWAY } = (event.stageVariables as Record<string, string>) || {
     RPC_GATEWAY: process.env.RPC_GATEWAY,
   }
-  // params
-  let address: Address | undefined
-  let customRpcUrl: string | undefined
 
   const params = paramsSchema.safeParse(event.queryStringParameters)
   if (!params.success) {
@@ -36,8 +32,8 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
     const message = getDefaultErrorMessage(params.error)
     return ResponseBadRequest(message)
   }
-  address = params.data.address
-  customRpcUrl = params.data.customRpcUrl
+  const address = params.data.address
+  const customRpcUrl = params.data.customRpcUrl
 
   try {
     if (!RPC_GATEWAY) {

--- a/apps/summerfi-api/lib/get-migrations-function/src/index.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/index.ts
@@ -26,21 +26,18 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
   const { RPC_GATEWAY } = (event.stageVariables as Record<string, string>) || {
     RPC_GATEWAY: process.env.RPC_GATEWAY,
   }
-
   // params
   let address: Address | undefined
   let customRpcUrl: string | undefined
 
-  // validation
-  try {
-    const params = paramsSchema.parse(event.queryStringParameters)
-    address = params.address
-    customRpcUrl = params.customRpcUrl
-  } catch (error) {
-    console.log(error)
-    const message = getDefaultErrorMessage(error)
+  const params = paramsSchema.safeParse(event.queryStringParameters)
+  if (!params.success) {
+    console.log(params.error)
+    const message = getDefaultErrorMessage(params.error)
     return ResponseBadRequest(message)
   }
+  address = params.data.address
+  customRpcUrl = params.data.customRpcUrl
 
   try {
     if (!RPC_GATEWAY) {


### PR DESCRIPTION
This commit introduces a step to verify the chain ID via a public client in the get-migrations-function in client.ts. If the chain ID doesn't match the expected chain, it now returns an empty object. Moreover, validation for address and customRpcUrl parameters in index.ts has been simplified, now using safeParse from Zod schema instead of the previous try-catch block.