### PR TITLE
Update sell service container and enhance trigger query

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-sell-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-sell-service-container.ts
@@ -88,7 +88,7 @@ export const getAaveAutoSellServiceContainer: (
 
       const debtPriceInUSD = await getUsdAaveOraclePrice(trigger.position.debt, addresses, rpc)
 
-      const currentAutoBuy = triggers.triggers.aaveBasicBuy
+      const currentAutoBuy = triggers.triggers.aaveBasicSell
       const currentTrigger: CurrentTriggerLike | undefined = currentAutoBuy
         ? {
             triggerData: currentAutoBuy.triggerData as `0x${string}`,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-sell-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-sell-service-container.ts
@@ -88,11 +88,11 @@ export const getAaveAutoSellServiceContainer: (
 
       const debtPriceInUSD = await getUsdAaveOraclePrice(trigger.position.debt, addresses, rpc)
 
-      const currentAutoBuy = triggers.triggers.aaveBasicSell
-      const currentTrigger: CurrentTriggerLike | undefined = currentAutoBuy
+      const currentAutoSell = triggers.triggers.aaveBasicSell
+      const currentTrigger: CurrentTriggerLike | undefined = currentAutoSell
         ? {
-            triggerData: currentAutoBuy.triggerData as `0x${string}`,
-            id: safeParseBigInt(currentAutoBuy.triggerId) ?? 0n,
+            triggerData: currentAutoSell.triggerData as `0x${string}`,
+            id: safeParseBigInt(currentAutoSell.triggerId) ?? 0n,
           }
         : undefined
 

--- a/packages/automation-subgraph/queries/triggers.query.graphql
+++ b/packages/automation-subgraph/queries/triggers.query.graphql
@@ -1,5 +1,5 @@
 query Triggers($dpm: Bytes!) {
-  triggers(where: { account: $dpm, removedBlock: null }) {
+  triggers(where: { account: $dpm, removedBlock: null }, orderBy: addedTimestamp, orderDirection: desc) {
     account
     owner
     id


### PR DESCRIPTION
This commit replaces 'aaveBasicBuy' with 'aaveBasicSell' in get-aave-auto-sell-service-container.ts ensuring correct functionality. Additionally, it orders triggers by 'addedTimestamp' in a descending manner in triggers.query.graphql for more precise results.