### PR TITLE
Change chainId validation logic in get-migrations-function

### DIFF
--- a/apps/summerfi-api/lib/get-migrations-function/src/index.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/index.ts
@@ -19,13 +19,20 @@ const paramsSchema = z
   .object({
     address: addressSchema,
     customRpcUrl: z.string().optional(),
-    chainId: z.number().optional(),
+    chainId: z
+      .string()
+      .optional()
+      .transform((val) => parseInt(val ?? '-1', 10)),
   })
   .refine(
     (params) => {
       if (params.customRpcUrl) {
-        return params.chainId !== undefined
+        return params.chainId !== undefined && params.chainId !== -1
       }
+      if (params.chainId !== undefined && params.chainId !== -1) {
+        return params.customRpcUrl !== undefined
+      }
+      return true
     },
     {
       message: 'customRpcUrl and chainId must be provided together',


### PR DESCRIPTION
Instead of accepting number, the chainId is now an optional string which is to be parsed into a number. This modification ensures that the customRpcUrl and chainId must be provided together and also adds a new validation to reject -1 as a chainId, thereby making sure that valid chainId and customRpcUrl are provided.