### PR TITLE
Fix stop loss validation bug

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-stop-loss-validator.ts
@@ -148,6 +148,7 @@ const warningsValidation = paramsSchema
         const executionLTV = safeParseBigInt(autoSell.decodedParams.executionLtv) ?? 0n
         return triggerData.executionLTV > executionLTV
       }
+      return true
     },
     {
       message: 'Your stop loss will make the auto-sell not trigger',

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-trailing-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-trailing-stop-loss-validator.ts
@@ -161,6 +161,7 @@ const warningsValidation = paramsSchema
         const executionLTV = safeParseBigInt(autoSell.decodedParams.executionLtv) ?? 0n
         return dynamicExecutionLTV > executionLTV
       }
+      return true
     },
     {
       message: 'Your stop loss will make the auto-sell not trigger',


### PR DESCRIPTION
This pull request fixes a bug in the stop loss validation logic. Previously, the validation would fail if the stop loss value was not provided. This PR adds a check to ensure that the validation passes even if the stop loss value is not provided.