### PR TITLE
Remove auto-sell and stop-loss triggers refinement checks

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-stop-loss-validator.ts
@@ -81,38 +81,6 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
-  .refine(
-    ({ triggers }) => {
-      const currentAutoSell = triggers.triggers.aaveBasicSell
-      if (currentAutoSell) {
-        const minSellPrice = safeParseBigInt(currentAutoSell.decodedParams.minSellPrice) ?? 0n
-        return minSellPrice > 0n
-      }
-      return true
-    },
-    {
-      message: 'Your Auto-Sell will make your stop loss not trigger.',
-      params: {
-        code: StopLossErrorCodes.StopLossNeverTriggeredWithNoAutoSellMinSellPrice,
-      },
-    },
-  )
-  .refine(
-    ({ triggers, executionPrice }) => {
-      const currentAutoSell = triggers.triggers.aaveBasicSell
-      if (currentAutoSell) {
-        const minSellPrice = safeParseBigInt(currentAutoSell.decodedParams.minSellPrice) ?? 0n
-        return minSellPrice > executionPrice
-      }
-      return true
-    },
-    {
-      message: 'Your Auto-Sell will make your stop loss not trigger.',
-      params: {
-        code: StopLossErrorCodes.StopLossNeverTriggeredWithLowerAutoSellMinSellPrice,
-      },
-    },
-  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-trailing-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-trailing-stop-loss-validator.ts
@@ -84,38 +84,6 @@ const upsertErrorsValidation = paramsSchema
     },
   )
   .refine(
-    ({ triggers }) => {
-      const currentAutoSell = triggers.triggers.aaveBasicSell
-      if (currentAutoSell) {
-        const minSellPrice = safeParseBigInt(currentAutoSell.decodedParams.minSellPrice) ?? 0n
-        return minSellPrice > 0n
-      }
-      return true
-    },
-    {
-      message: 'Your Auto-Sell will make your stop loss not trigger.',
-      params: {
-        code: StopLossErrorCodes.StopLossNeverTriggeredWithNoAutoSellMinSellPrice,
-      },
-    },
-  )
-  .refine(
-    ({ triggers, executionPrice }) => {
-      const currentAutoSell = triggers.triggers.aaveBasicSell
-      if (currentAutoSell) {
-        const minSellPrice = safeParseBigInt(currentAutoSell.decodedParams.minSellPrice) ?? 0n
-        return minSellPrice > executionPrice
-      }
-      return true
-    },
-    {
-      message: 'Your Auto-Sell will make your stop loss not trigger.',
-      params: {
-        code: StopLossErrorCodes.StopLossNeverTriggeredWithLowerAutoSellMinSellPrice,
-      },
-    },
-  )
-  .refine(
     ({ latestPrice }) => {
       return latestPrice !== undefined
     },


### PR DESCRIPTION
Several redundant validation checks have been removed from the stop-loss and auto-sell triggers, particularly those that cross-reference one trigger against another. These were unnecessary as each trigger should execute independently based on its own defined conditions and actions. This simplifies the overall validation process.