### PR TITLE
Update stop loss variable path in service container

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-trailing-stop-loss-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-trailing-stop-loss-service-container.ts
@@ -30,7 +30,7 @@ export interface GetAaveTrailingStopLossServiceContainerProps {
 }
 
 function getCurrentTrailingStopLoss(triggers: GetTriggersResponse): CurrentTriggerLike | undefined {
-  const currentStopLoss = triggers.triggers.aaveTrailingStopLossDMA
+  const currentStopLoss = triggers.triggerGroup.aaveStopLoss
 
   return currentStopLoss
     ? {


### PR DESCRIPTION
The variable path to retrieve the stop loss trigger for Aave was outdated in the getAaveTrailingStopLossServiceContainer function. This commit updates the path from 'triggers.aaveTrailingStopLossDMA' to 'triggers.triggerGroup.aaveStopLoss', ensuring the correct trigger is referenced.