### PR TITLE
Update logical operators in stop-loss check

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-current-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-current-stop-loss.ts
@@ -34,8 +34,8 @@ export function getCurrentStopLoss(
     }),
   )
 
-  if (executionLtv === undefined || executionPrice === undefined) {
-    logger?.warn('Execution LTV or price is not set on the trigger')
+  if (executionLtv === undefined && executionPrice === undefined) {
+    logger?.warn('Stop loss trigger has no executionLtv or executionPrice')
     return undefined
   }
 
@@ -43,7 +43,7 @@ export function getCurrentStopLoss(
     executionLtv ??
     calculateLtv({
       ...position,
-      collateralPriceInDebt: executionPrice,
+      collateralPriceInDebt: executionPrice!,
     })
 
   const stopLossExecutionPrice =


### PR DESCRIPTION
The previous logical operator checking for undefined values of executionLtv and executionPrice has been modified. The operator has been changed from OR (||) to AND (&&) to ensure both variables need to be undefined before warning is logged. Also, the non-null assertion operator has been added to ensure executionPrice will not be null.