### PR TITLE
Add derivedPriceTimestamp field in schema and update queries

### DIFF
--- a/packages/prices-subgraph/queries/max-price.query.graphql
+++ b/packages/prices-subgraph/queries/max-price.query.graphql
@@ -16,7 +16,7 @@ query MaxPriceFrom($token: String!, $denomination: String!, $from: BigInt!) {
         ]}
         { tokenTimestamp_gt: $from }
       ]}
-    orderBy: derivedPrice
+    orderBy: derivedPriceTimestamp
     orderDirection: desc
     first: 1
   ) {

--- a/packages/prices-subgraph/queries/price-by-round-ids.query.graphql
+++ b/packages/prices-subgraph/queries/price-by-round-ids.query.graphql
@@ -4,7 +4,7 @@ query PriceByRoundIds($tokenRoundId: BigInt!, $denominationRoundId: BigInt!) {
       tokenRoundId: $tokenRoundId,
       denominationRoundId: $denominationRoundId
     }
-    orderBy: tokenTimestamp
+    orderBy: derivedPriceTimestamp
     orderDirection: desc
     first: 1
   ) {

--- a/packages/prices-subgraph/queries/prices.query.graphql
+++ b/packages/prices-subgraph/queries/prices.query.graphql
@@ -14,7 +14,7 @@ query Prices($token: String!, $denomination: String!) {
         }}
       ]}
     ]}
-    orderBy: tokenTimestamp
+    orderBy: derivedPriceTimestamp
     orderDirection: desc
     first: 1) {
     tokenRoundId

--- a/packages/prices-subgraph/schema.graphql
+++ b/packages/prices-subgraph/schema.graphql
@@ -356,6 +356,7 @@ type DerivedPrice {
   denominationRoundId: BigInt!
   denominationPrice: BigInt!
   derivedPrice: BigInt!
+  derivedPriceTimestamp: BigInt!
   oracle: DerivedOracle!
   oracleType: String!
   token: Token!
@@ -454,6 +455,14 @@ input DerivedPrice_filter {
   derivedPrice_lte: BigInt
   derivedPrice_in: [BigInt!]
   derivedPrice_not_in: [BigInt!]
+  derivedPriceTimestamp: BigInt
+  derivedPriceTimestamp_not: BigInt
+  derivedPriceTimestamp_gt: BigInt
+  derivedPriceTimestamp_lt: BigInt
+  derivedPriceTimestamp_gte: BigInt
+  derivedPriceTimestamp_lte: BigInt
+  derivedPriceTimestamp_in: [BigInt!]
+  derivedPriceTimestamp_not_in: [BigInt!]
   oracle: String
   oracle_not: String
   oracle_gt: String
@@ -588,6 +597,7 @@ enum DerivedPrice_orderBy {
   denominationRoundId
   denominationPrice
   derivedPrice
+  derivedPriceTimestamp
   oracle
   oracle__id
   oracle__description


### PR DESCRIPTION
A new field 'derivedPriceTimestamp' has been added to the price schema in the prices-subgraph. This field has been incorporated into related GraphQL queries and filters. Furthermore, various existing queries' ordering criterion has been changed to this new 'derivedPriceTimestamp' field for consistency and better performance.