### PR TITLE
Improve chainId handling in get-migrations-function

### DIFF
--- a/apps/summerfi-api/lib/get-migrations-function/src/client.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/client.ts
@@ -48,7 +48,7 @@ export function createMigrationsClient(
       if (!isChainId(chainId)) {
         throw new Error(`Invalid chainId: ${chainId}`)
       }
-      if (customChainId !== chainId) {
+      if (customChainId && customChainId !== chainId) {
         return
       }
       supportedProtocolsIds.forEach((protocolId) => {

--- a/apps/summerfi-api/lib/get-migrations-function/src/index.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/index.ts
@@ -22,7 +22,12 @@ const paramsSchema = z
     chainId: z
       .string()
       .optional()
-      .transform((val) => parseInt(val ?? '-1', 10)),
+      .transform((val) => {
+        if (val === undefined) {
+          return undefined
+        }
+        return parseInt(val, 10)
+      }),
   })
   .refine(
     (params) => {


### PR DESCRIPTION
The `customChainId` check has been adjusted to only trigger if it has been declared. The handling of `chainId` in the `index.ts` has been modified to specifically account for `undefined` cases, preventing it from defaulting to `-1`. The refinement increases the reliability of these functions in apps/summerfli-api.