### PR TITLE
Adjust executionPrice fallback in dma-aave-trailing-stop-loss

### DIFF
--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-trailing-stop-loss.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-trailing-stop-loss.ts
@@ -88,7 +88,7 @@ export const getDmaAaveTrailingStopLoss = async ({
       closeToCollateral: trigger.decodedData[trigger.decodedDataNames.indexOf('closeToCollateral')],
     },
     dynamicParams: {
-      executionPrice: dynamicParams.executionPrice?.toString(),
+      executionPrice: (dynamicParams.executionPrice ?? dynamicParams.originalPrice)?.toString(),
       originalExecutionPrice: dynamicParams.originalPrice?.toString(),
     },
   }


### PR DESCRIPTION
The executionPrice within dynamicParams in dma-aave-trailing-stop-loss.ts now falls back to originalPrice when it's not defined. This adjustment provides a more accurate executionPrice value when it's not initially set, increasing overall reliability of the app's trigger parsing.