### PR TITLE
Update trigger price calculations and modify GraphQL query

### DIFF
--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-trailing-stop-loss.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-trailing-stop-loss.ts
@@ -47,8 +47,8 @@ export const getDmaAaveTrailingStopLoss = async ({
 
   const trailingDistance =
     safeParseBigInt(trigger.decodedData[trigger.decodedDataNames.indexOf('trailingDistance')]) ?? 0n
-  const maxPrice = safeParseBigInt(maxPriceResponse?.derivedPrice.toString())
-  const originalPrice = safeParseBigInt(originalPriceResponse?.derivedPrice.toString())
+  let maxPrice = safeParseBigInt(maxPriceResponse?.derivedPrice.toString())
+  let originalPrice = safeParseBigInt(originalPriceResponse?.derivedPrice.toString())
 
   if (!maxPrice) {
     logger.warn('Max price not found for', { token, denomination, creationTimestamp })
@@ -63,9 +63,23 @@ export const getDmaAaveTrailingStopLoss = async ({
     })
   }
 
+  originalPrice = originalPrice ?? 0n
+
+  if (!maxPrice) {
+    maxPrice = originalPrice
+  }
+
+  if (maxPrice < originalPrice) {
+    logger.warn('Max price is less than original price, using original price as execution price', {
+      maxPrice,
+      originalPrice,
+    })
+    maxPrice = originalPrice
+  }
+
   const dynamicParams = {
-    executionPrice: maxPrice ? maxPrice - trailingDistance : undefined,
-    originalPrice: originalPrice ? originalPrice - trailingDistance : undefined,
+    executionPrice: maxPrice - trailingDistance,
+    originalPrice: originalPrice - trailingDistance,
   }
 
   return {

--- a/packages/prices-subgraph/queries/max-price.query.graphql
+++ b/packages/prices-subgraph/queries/max-price.query.graphql
@@ -14,9 +14,9 @@ query MaxPriceFrom($token: String!, $denomination: String!, $from: BigInt!) {
             relatedTokens_contains_nocase: [$denomination]
           }}
         ]}
-        { tokenTimestamp_gt: $from }
+        { derivedPriceTimestamp_gte: $from }
       ]}
-    orderBy: derivedPriceTimestamp
+    orderBy: derivedPrice
     orderDirection: desc
     first: 1
   ) {


### PR DESCRIPTION
Changed constant variables to let for 'maxPrice' and 'originalPrice' to handle missing or lesser 'maxPrice'. Updated code to use 'originalPrice' as 'maxPrice' in such cases. This ensures a valid 'executionPrice' and 'originalPrice' are always set in 'dynamicParams'. The 'max-price.query.graphql' file was also modified to use 'derivedPriceTimestamp_gte' and order by 'derivedPrice'.