### PR TITLE
Add AAVE3 protocol to additional chains

### DIFF
--- a/apps/summerfi-api/lib/get-migrations-function/src/migrations-config.ts
+++ b/apps/summerfi-api/lib/get-migrations-function/src/migrations-config.ts
@@ -7,8 +7,8 @@ export type IMigrationConfig = Record<ChainId, ProtocolId[]>
  */
 export const MigrationConfig: IMigrationConfig = {
   [ChainId.MAINNET]: [ProtocolId.AAVE3, ProtocolId.SPARK],
-  [ChainId.ARBITRUM]: [],
-  [ChainId.OPTIMISM]: [],
-  [ChainId.BASE]: [],
+  [ChainId.ARBITRUM]: [ProtocolId.AAVE3],
+  [ChainId.OPTIMISM]: [ProtocolId.AAVE3],
+  [ChainId.BASE]: [ProtocolId.AAVE3],
   [ChainId.SEPOLIA]: [],
 }


### PR DESCRIPTION
The migration configuration has been updated to include the AAVE3 protocol in the Arbitrum, Optimism, and Base chains.