### PR TITLE
chore: [sc-14565] fix trigger removal

### DIFF
--- a/apps/summerfi-api/lib/get-triggers-function/src/index.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/index.ts
@@ -324,6 +324,7 @@ export const handler = async (
       isSparkBasicBuyEnabled: hasAnyDefined(sparkBasicBuy),
       isSparkBasicSellEnabled: hasAnyDefined(sparkBasicSell),
     },
+    triggersCount: triggers.triggers.length,
     triggerGroup: {
       aaveStopLoss: getCurrentTrigger(
         aaveStopLossToCollateral,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-buy-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-buy-validator.ts
@@ -14,7 +14,7 @@ import {
 import { GetTriggersResponse } from '@summerfi/serverless-contracts/get-triggers-response'
 import { z } from 'zod'
 import { chainIdSchema, safeParseBigInt } from '@summerfi/serverless-shared'
-import { CurrentStopLoss } from '../types/current-stop-loss'
+import { CurrentStopLoss } from '../trigger-encoders'
 
 const paramsSchema = z.object({
   position: positionSchema,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-sell-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-sell-validator.ts
@@ -13,7 +13,7 @@ import {
 import { z } from 'zod'
 import { GetTriggersResponse } from '@summerfi/serverless-contracts/get-triggers-response'
 import { chainIdSchema, safeParseBigInt } from '@summerfi/serverless-shared'
-import { CurrentStopLoss } from '../types/current-stop-loss'
+import { CurrentStopLoss } from '../trigger-encoders'
 
 const paramsSchema = z.object({
   position: positionSchema,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-buy-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-buy-validator.ts
@@ -14,7 +14,7 @@ import {
 import { GetTriggersResponse } from '@summerfi/serverless-contracts/get-triggers-response'
 import { z } from 'zod'
 import { chainIdSchema, safeParseBigInt } from '@summerfi/serverless-shared'
-import { CurrentStopLoss } from '../types/current-stop-loss'
+import { CurrentStopLoss } from '../trigger-encoders'
 
 const paramsSchema = z.object({
   position: positionSchema,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-sell-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-sell-validator.ts
@@ -13,7 +13,7 @@ import {
 import { z } from 'zod'
 import { GetTriggersResponse } from '@summerfi/serverless-contracts/get-triggers-response'
 import { chainIdSchema, safeParseBigInt } from '@summerfi/serverless-shared'
-import { CurrentStopLoss } from '../types/current-stop-loss'
+import { CurrentStopLoss } from '../trigger-encoders'
 
 const paramsSchema = z.object({
   position: positionSchema,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-buy-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-buy-service-container.ts
@@ -94,6 +94,7 @@ export const getAaveAutoBuyServiceContainer: (
         ? {
             triggerData: currentAutoBuy.triggerData as `0x${string}`,
             id: safeParseBigInt(currentAutoBuy.triggerId) ?? 0n,
+            triggersOnAccount: triggers.triggersCount,
           }
         : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-sell-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-auto-sell-service-container.ts
@@ -94,6 +94,7 @@ export const getAaveAutoSellServiceContainer: (
         ? {
             triggerData: currentAutoSell.triggerData as `0x${string}`,
             id: safeParseBigInt(currentAutoSell.triggerId) ?? 0n,
+            triggersOnAccount: triggers.triggersCount,
           }
         : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-current-aave-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-current-aave-stop-loss.ts
@@ -4,10 +4,10 @@ import {
 } from '@summerfi/serverless-contracts/get-triggers-response'
 import { safeParseBigInt } from '@summerfi/serverless-shared'
 import { PositionLike } from '~types'
-import { CurrentStopLoss } from './types/current-stop-loss'
 import { Logger } from '@aws-lambda-powertools/logger'
 import { calculateLtv } from './calculate-ltv'
 import { calculateCollateralPriceInDebtBasedOnLtv } from './calculate-collateral-price-in-debt-based-on-ltv'
+import { CurrentStopLoss } from './trigger-encoders'
 
 export function getCurrentAaveStopLoss(
   triggers: GetTriggersResponse,
@@ -66,5 +66,6 @@ export function getCurrentAaveStopLoss(
     id: safeParseBigInt(currentStopLoss.triggerId) ?? 0n,
     executionLTV: stopLossExecutionLtv,
     executionPrice: stopLossExecutionPrice,
+    triggersOnAccount: triggers.triggersCount,
   }
 }

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-current-spark-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-current-spark-stop-loss.ts
@@ -4,10 +4,10 @@ import {
 } from '@summerfi/serverless-contracts/get-triggers-response'
 import { safeParseBigInt } from '@summerfi/serverless-shared'
 import { PositionLike } from '~types'
-import { CurrentStopLoss } from './types/current-stop-loss'
 import { Logger } from '@aws-lambda-powertools/logger'
 import { calculateLtv } from './calculate-ltv'
 import { calculateCollateralPriceInDebtBasedOnLtv } from './calculate-collateral-price-in-debt-based-on-ltv'
+import { CurrentStopLoss } from './trigger-encoders'
 
 export function getCurrentSparkStopLoss(
   triggers: GetTriggersResponse,
@@ -66,5 +66,6 @@ export function getCurrentSparkStopLoss(
     id: safeParseBigInt(currentStopLoss.triggerId) ?? 0n,
     executionLTV: stopLossExecutionLtv,
     executionPrice: stopLossExecutionPrice,
+    triggersOnAccount: triggers.triggersCount,
   }
 }

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-spark-auto-buy-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-spark-auto-buy-service-container.ts
@@ -95,6 +95,7 @@ export const getSparkAutoBuyServiceContainer: (
         ? {
             triggerData: currentAutoBuy.triggerData as `0x${string}`,
             id: safeParseBigInt(currentAutoBuy.triggerId) ?? 0n,
+            triggersOnAccount: triggers.triggersCount,
           }
         : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-spark-auto-sell-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-spark-auto-sell-service-container.ts
@@ -95,6 +95,7 @@ export const getSparkAutoSellServiceContainer: (
         ? {
             triggerData: currentAutoSell.triggerData as `0x${string}`,
             id: safeParseBigInt(currentAutoSell.triggerId) ?? 0n,
+            triggersOnAccount: triggers.triggersCount,
           }
         : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-buy.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-buy.ts
@@ -59,7 +59,11 @@ export const encodeAaveAutoBuy = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, //remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-sell.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-auto-sell.ts
@@ -67,7 +67,11 @@ export const encodeAaveAutoSell = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, // remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-stop-loss.ts
@@ -69,7 +69,11 @@ export const encodeAaveStopLoss = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, // remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-trailing-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-aave-trailing-stop-loss.ts
@@ -73,7 +73,11 @@ export const encodeAaveTrailingStopLoss = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, // remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-auto-buy.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-auto-buy.ts
@@ -59,7 +59,11 @@ export const encodeSparkAutoBuy = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, // remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-auto-sell.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-auto-sell.ts
@@ -67,7 +67,11 @@ export const encodeSparkAutoSell = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, // remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-stop-loss.ts
@@ -69,7 +69,11 @@ export const encodeSparkStopLoss = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, //remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-trailing-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/encode-spark-trailing-stop-loss.ts
@@ -74,7 +74,11 @@ export const encodeSparkTrailingStopLoss = (
     ? encodeFunctionData({
         abi: automationBotAbi,
         functionName: 'removeTriggers',
-        args: [[currentTrigger.id], [currentTrigger.triggerData], true],
+        args: [
+          [currentTrigger.id],
+          [currentTrigger.triggerData],
+          currentTrigger.triggersOnAccount === 1, // remove allowance only if it's the last trigger
+        ],
       })
     : undefined
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/types.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/trigger-encoders/types.ts
@@ -1,3 +1,5 @@
+import { LTV, Price } from '~types'
+
 export type TriggerTransactions = {
   encodedTriggerData: `0x${string}`
   upsertTrigger: `0x${string}`
@@ -7,4 +9,10 @@ export type TriggerTransactions = {
 export type CurrentTriggerLike = {
   id: bigint
   triggerData: `0x${string}`
+  triggersOnAccount: number
+}
+
+export interface CurrentStopLoss extends CurrentTriggerLike {
+  executionPrice: Price
+  executionLTV: LTV
 }

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/types/current-stop-loss.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/types/current-stop-loss.ts
@@ -1,8 +1,0 @@
-import { LTV, Price } from '~types'
-
-export interface CurrentStopLoss {
-  id: bigint
-  triggerData: `0x${string}`
-  executionPrice: Price
-  executionLTV: LTV
-}

--- a/packages/serverless-contracts/src/get-triggers-response.ts
+++ b/packages/serverless-contracts/src/get-triggers-response.ts
@@ -281,6 +281,7 @@ export type GetTriggersResponse = {
     sparkBasicBuy?: Trigger
     sparkBasicSell?: Trigger
   }
+  triggersCount: number
   additionalData?: Record<string, unknown>
 }
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14565

Refactor trigger removal to only revoke allowance if last trigger

Moved `CurrentStopLoss` from types to trigger-encoders. Introduced a conditional removal of the allowance. The modification checks if the current trigger is the last one in the account before revoking the allowance. This optimizes gas usage and improves performance when multiple triggers are set for the same account.