### PR TITLE
feat: [sc-14540] [BE] Add (Partial) Take Profit to get-triggers response

### DIFF
--- a/apps/summerfi-api/lib/get-triggers-function/package.json
+++ b/apps/summerfi-api/lib/get-triggers-function/package.json
@@ -13,7 +13,6 @@
     "@aws-lambda-powertools/logger": "^1.17.0",
     "@aws-lambda-powertools/metrics": "^1.17.0",
     "@aws-lambda-powertools/tracer": "^1.17.0",
-    "graphql-request": "^6.1.0",
     "@summerfi/serverless-shared": "workspace:*",
     "@summerfi/automation-subgraph": "workspace:*",
     "@summerfi/prices-subgraph": "workspace:*",

--- a/apps/summerfi-api/lib/get-triggers-function/src/helpers/mappers.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/helpers/mappers.ts
@@ -16,6 +16,7 @@ export const mapStopLossParams = ({
   debtToken: decodedData[decodedDataNames.indexOf('debtToken')],
   collateralToken: decodedData[decodedDataNames.indexOf('collateralToken')],
   ltv: decodedData[decodedDataNames.indexOf('ltv')],
+  operationName: decodedData[decodedDataNames.indexOf('operationName')],
 })
 
 export const mapBuySellCommonParams = ({

--- a/apps/summerfi-api/lib/get-triggers-function/src/index.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/index.ts
@@ -28,9 +28,9 @@ import {
   DmaAaveStopLossToCollateralV2ID,
   DmaAaveStopLossToDebtV2ID,
   DmaSparkBasicBuy,
-  DmaSparkBasicBuyV2,
+  DmaSparkBasicBuyV2ID,
   DmaSparkBasicSell,
-  DmaSparkBasicSellV2,
+  DmaSparkBasicSellV2ID,
   DmaSparkStopLossToCollateralV2ID,
   DmaSparkStopLossToDebtV2ID,
   GetTriggersResponse,
@@ -53,8 +53,12 @@ import {
   getCurrentTrigger,
 } from './helpers'
 import { getPricesSubgraphClient } from '@summerfi/prices-subgraph'
-import { getDmaAaveTrailingStopLoss } from './trigger-parsers/dma-aave-trailing-stop-loss'
-import { getDmaSparkTrailingStopLoss } from './trigger-parsers/dma-spark-trailing-stop-loss'
+import {
+  getDmaAavePartialTakeProfit,
+  getDmaSparkPartialTakeProfit,
+  getDmaAaveTrailingStopLoss,
+  getDmaSparkTrailingStopLoss,
+} from './trigger-parsers'
 
 const logger = new Logger({ serviceName: 'getTriggersFunction' })
 
@@ -248,11 +252,11 @@ export const handler = async (
     })[0]
 
   const sparkBasicBuy: DmaSparkBasicBuy | undefined = triggers.triggers
-    .filter((trigger) => trigger.triggerType == DmaSparkBasicBuyV2)
+    .filter((trigger) => trigger.triggerType == DmaSparkBasicBuyV2ID)
     .map((trigger) => {
       return {
         triggerTypeName: 'DmaSparkBasicBuyV2' as const,
-        triggerType: DmaSparkBasicBuyV2,
+        triggerType: DmaSparkBasicBuyV2ID,
         ...mapTriggerCommonParams(trigger),
         decodedParams: {
           maxBuyPrice: trigger.decodedData[trigger.decodedDataNames.indexOf('maxBuyPrice')],
@@ -262,11 +266,11 @@ export const handler = async (
     })[0]
 
   const sparkBasicSell: DmaSparkBasicSell | undefined = triggers.triggers
-    .filter((trigger) => trigger.triggerType == DmaSparkBasicSellV2)
+    .filter((trigger) => trigger.triggerType == DmaSparkBasicSellV2ID)
     .map((trigger) => {
       return {
         triggerTypeName: 'DmaSparkBasicSellV2' as const,
-        triggerType: DmaSparkBasicSellV2,
+        triggerType: DmaSparkBasicSellV2ID,
         ...mapTriggerCommonParams(trigger),
         decodedParams: {
           minSellPrice: trigger.decodedData[trigger.decodedDataNames.indexOf('minSellPrice')],
@@ -287,6 +291,9 @@ export const handler = async (
     logger,
   })
 
+  const aavePartialTakeProfit = await getDmaAavePartialTakeProfit({ triggers, logger })
+  const sparkPartialTakeProfit = await getDmaSparkPartialTakeProfit({ triggers, logger })
+
   const response: GetTriggersResponse = {
     triggers: {
       aaveStopLossToCollateral,
@@ -303,6 +310,8 @@ export const handler = async (
       sparkBasicSell,
       sparkBasicBuy,
       sparkTrailingStopLossDMA,
+      aavePartialTakeProfit,
+      sparkPartialTakeProfit,
     },
     flags: {
       isAaveStopLossEnabled: hasAnyDefined(
@@ -323,6 +332,8 @@ export const handler = async (
       isAaveBasicSellEnabled: hasAnyDefined(aaveBasicSell),
       isSparkBasicBuyEnabled: hasAnyDefined(sparkBasicBuy),
       isSparkBasicSellEnabled: hasAnyDefined(sparkBasicSell),
+      isAavePartialTakeProfitEnabled: hasAnyDefined(aavePartialTakeProfit),
+      isSparkPartialTakeProfitEnabled: hasAnyDefined(sparkPartialTakeProfit),
     },
     triggersCount: triggers.triggers.length,
     triggerGroup: {
@@ -344,6 +355,8 @@ export const handler = async (
       aaveBasicSell: getCurrentTrigger(aaveBasicSell),
       sparkBasicBuy: getCurrentTrigger(sparkBasicBuy),
       sparkBasicSell: getCurrentTrigger(sparkBasicSell),
+      aavePartialTakeProfit: getCurrentTrigger(aavePartialTakeProfit),
+      sparkPartialTakeProfit: getCurrentTrigger(sparkPartialTakeProfit),
     },
     additionalData: {
       params: {

--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-partial-take-profit.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-partial-take-profit.ts
@@ -1,0 +1,43 @@
+import {
+  DmaAavePartialTakeProfit,
+  DmaAavePartialTakeProfitID,
+} from '@summerfi/serverless-contracts/get-triggers-response'
+import { TriggersQuery } from '@summerfi/automation-subgraph'
+import { Logger } from '@aws-lambda-powertools/logger'
+import { mapTriggerCommonParams } from '../helpers'
+
+export const getDmaAavePartialTakeProfit = async ({
+  triggers,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  logger,
+}: {
+  triggers: TriggersQuery
+  logger: Logger
+}): Promise<DmaAavePartialTakeProfit | undefined> => {
+  const trigger = triggers.triggers.find(
+    (trigger) => trigger.triggerType == DmaAavePartialTakeProfitID,
+  )
+
+  if (!trigger) {
+    return undefined
+  }
+
+  return {
+    triggerTypeName: 'DmaAavePartialTakeProfit' as const,
+    triggerType: DmaAavePartialTakeProfitID,
+    ...mapTriggerCommonParams(trigger),
+    decodedParams: {
+      triggerType: trigger.decodedData[trigger.decodedDataNames.indexOf('triggerType')],
+      positionAddress: trigger.decodedData[trigger.decodedDataNames.indexOf('positionAddress')],
+      maxCoverage: trigger.decodedData[trigger.decodedDataNames.indexOf('maxCoverage')],
+      debtToken: trigger.decodedData[trigger.decodedDataNames.indexOf('debtToken')],
+      collateralToken: trigger.decodedData[trigger.decodedDataNames.indexOf('collateralToken')],
+      operationName: trigger.decodedData[trigger.decodedDataNames.indexOf('operationName')],
+      closeToCollateral: trigger.decodedData[trigger.decodedDataNames.indexOf('closeToCollateral')],
+      executionLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('executionLtv')],
+      targetLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('targetLtv')],
+      deviation: trigger.decodedData[trigger.decodedDataNames.indexOf('deviation')],
+      executionPrice: trigger.decodedData[trigger.decodedDataNames.indexOf('executionPrice')],
+    },
+  }
+}

--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-trailing-stop-loss.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-trailing-stop-loss.ts
@@ -1,4 +1,7 @@
-import { DmaAaveTrailingStopLoss } from '@summerfi/serverless-contracts/get-triggers-response'
+import {
+  DmaAaveTrailingStopLossID,
+  DmaAaveTrailingStopLoss,
+} from '@summerfi/serverless-contracts/get-triggers-response'
 import { PricesSubgraphClient } from '@summerfi/prices-subgraph'
 import { TriggersQuery } from '@summerfi/automation-subgraph'
 import { safeParseBigInt } from '@summerfi/serverless-shared'
@@ -15,7 +18,7 @@ export const getDmaAaveTrailingStopLoss = async ({
   logger: Logger
 }): Promise<DmaAaveTrailingStopLoss | undefined> => {
   const trigger = triggers.triggers.find(
-    (trigger) => trigger.triggerType == DmaAaveTrailingStopLoss,
+    (trigger) => trigger.triggerType == DmaAaveTrailingStopLossID,
   )
   if (!trigger) {
     return undefined
@@ -84,7 +87,7 @@ export const getDmaAaveTrailingStopLoss = async ({
 
   return {
     triggerTypeName: 'DmaAaveTrailingStopLoss' as const,
-    triggerType: DmaAaveTrailingStopLoss,
+    triggerType: DmaAaveTrailingStopLossID,
     ...mapTriggerCommonParams(trigger),
     decodedParams: {
       triggerType: trigger.decodedData[trigger.decodedDataNames.indexOf('triggerType')],

--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-spark-partial-take-profit.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-spark-partial-take-profit.ts
@@ -1,0 +1,43 @@
+import {
+  DmaSparkPartialTakeProfit,
+  DmaSparkPartialTakeProfitID,
+} from '@summerfi/serverless-contracts/get-triggers-response'
+import { TriggersQuery } from '@summerfi/automation-subgraph'
+import { Logger } from '@aws-lambda-powertools/logger'
+import { mapTriggerCommonParams } from '../helpers'
+
+export const getDmaSparkPartialTakeProfit = async ({
+  triggers,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  logger,
+}: {
+  triggers: TriggersQuery
+  logger: Logger
+}): Promise<DmaSparkPartialTakeProfit | undefined> => {
+  const trigger = triggers.triggers.find(
+    (trigger) => trigger.triggerType == DmaSparkPartialTakeProfitID,
+  )
+
+  if (!trigger) {
+    return undefined
+  }
+
+  return {
+    triggerTypeName: 'DmaAavePartialTakeProfit' as const,
+    triggerType: DmaSparkPartialTakeProfitID,
+    ...mapTriggerCommonParams(trigger),
+    decodedParams: {
+      triggerType: trigger.decodedData[trigger.decodedDataNames.indexOf('triggerType')],
+      positionAddress: trigger.decodedData[trigger.decodedDataNames.indexOf('positionAddress')],
+      maxCoverage: trigger.decodedData[trigger.decodedDataNames.indexOf('maxCoverage')],
+      debtToken: trigger.decodedData[trigger.decodedDataNames.indexOf('debtToken')],
+      collateralToken: trigger.decodedData[trigger.decodedDataNames.indexOf('collateralToken')],
+      operationName: trigger.decodedData[trigger.decodedDataNames.indexOf('operationName')],
+      closeToCollateral: trigger.decodedData[trigger.decodedDataNames.indexOf('closeToCollateral')],
+      executionLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('executionLtv')],
+      targetLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('targetLtv')],
+      deviation: trigger.decodedData[trigger.decodedDataNames.indexOf('deviation')],
+      executionPrice: trigger.decodedData[trigger.decodedDataNames.indexOf('executionPrice')],
+    },
+  }
+}

--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-spark-trailing-stop-loss.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-spark-trailing-stop-loss.ts
@@ -1,4 +1,7 @@
-import { DmaSparkTrailingStopLoss } from '@summerfi/serverless-contracts/get-triggers-response'
+import {
+  DmaSparkTrailingStopLossID,
+  DmaSparkTrailingStopLoss,
+} from '@summerfi/serverless-contracts/get-triggers-response'
 import { PricesSubgraphClient } from '@summerfi/prices-subgraph'
 import { TriggersQuery } from '@summerfi/automation-subgraph'
 import { safeParseBigInt } from '@summerfi/serverless-shared'
@@ -15,7 +18,7 @@ export const getDmaSparkTrailingStopLoss = async ({
   logger: Logger
 }): Promise<DmaSparkTrailingStopLoss | undefined> => {
   const trigger = triggers.triggers.find(
-    (trigger) => trigger.triggerType == DmaSparkTrailingStopLoss,
+    (trigger) => trigger.triggerType == DmaSparkTrailingStopLossID,
   )
   if (!trigger) {
     return undefined
@@ -84,7 +87,7 @@ export const getDmaSparkTrailingStopLoss = async ({
 
   return {
     triggerTypeName: 'DmaSparkTrailingStopLoss' as const,
-    triggerType: DmaSparkTrailingStopLoss,
+    triggerType: DmaSparkTrailingStopLossID,
     ...mapTriggerCommonParams(trigger),
     decodedParams: {
       triggerType: trigger.decodedData[trigger.decodedDataNames.indexOf('triggerType')],

--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/index.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/index.ts
@@ -1,0 +1,4 @@
+export * from './dma-aave-trailing-stop-loss'
+export * from './dma-aave-partial-take-profit'
+export * from './dma-spark-partial-take-profit'
+export * from './dma-spark-trailing-stop-loss'

--- a/packages/serverless-contracts/src/get-triggers-response.ts
+++ b/packages/serverless-contracts/src/get-triggers-response.ts
@@ -16,11 +16,14 @@ export const DmaSparkStopLossToDebtV2ID = 130n as const
 export const DmaAaveBasicBuyV2ID = 121n as const
 export const DmaAaveBasicSellV2ID = 122n as const
 
-export const DmaSparkBasicBuyV2 = 131n as const
-export const DmaSparkBasicSellV2 = 132n as const
+export const DmaSparkBasicBuyV2ID = 131n as const
+export const DmaSparkBasicSellV2ID = 132n as const
 
-export const DmaAaveTrailingStopLoss = 10006n as const
-export const DmaSparkTrailingStopLoss = 10007n as const
+export const DmaAavePartialTakeProfitID = 133n as const
+export const DmaSparkPartialTakeProfitID = 134n as const
+
+export const DmaAaveTrailingStopLossID = 10006n as const
+export const DmaSparkTrailingStopLossID = 10007n as const
 
 export type Trigger = {
   triggerId: string
@@ -92,6 +95,7 @@ export type AaveStopLossToCollateralDMA = Trigger & {
     debtToken: string
     collateralToken: string
     executionLtv: string
+    operationName: string
   }
 }
 
@@ -105,6 +109,7 @@ export type AaveStopLossToDebtDMA = Trigger & {
     debtToken: string
     collateralToken: string
     executionLtv: string
+    operationName: string
   }
 }
 export type SparkStopLossToCollateralDMA = Trigger & {
@@ -117,6 +122,7 @@ export type SparkStopLossToCollateralDMA = Trigger & {
     debtToken: string
     collateralToken: string
     executionLtv: string
+    operationName: string
   }
 }
 export type SparkStopLossToDebtDMA = Trigger & {
@@ -129,6 +135,7 @@ export type SparkStopLossToDebtDMA = Trigger & {
     debtToken: string
     collateralToken: string
     executionLtv: string
+    operationName: string
   }
 }
 
@@ -169,7 +176,7 @@ export type DmaAaveBasicSell = Trigger & {
 
 export type DmaSparkBasicBuy = Trigger & {
   triggerTypeName: 'DmaSparkBasicBuyV2'
-  triggerType: typeof DmaSparkBasicBuyV2
+  triggerType: typeof DmaSparkBasicBuyV2ID
   decodedParams: {
     positionAddress: string
     triggerType: string
@@ -186,7 +193,7 @@ export type DmaSparkBasicBuy = Trigger & {
 }
 export type DmaSparkBasicSell = Trigger & {
   triggerTypeName: 'DmaSparkBasicSellV2'
-  triggerType: typeof DmaSparkBasicSellV2
+  triggerType: typeof DmaSparkBasicSellV2ID
   decodedParams: {
     positionAddress: string
     triggerType: string
@@ -204,7 +211,7 @@ export type DmaSparkBasicSell = Trigger & {
 
 export type DmaAaveTrailingStopLoss = Trigger & {
   triggerTypeName: 'DmaAaveTrailingStopLoss'
-  triggerType: typeof DmaAaveTrailingStopLoss
+  triggerType: typeof DmaAaveTrailingStopLossID
   decodedParams: {
     positionAddress: string
     triggerType: string
@@ -227,7 +234,7 @@ export type DmaAaveTrailingStopLoss = Trigger & {
 
 export type DmaSparkTrailingStopLoss = Trigger & {
   triggerTypeName: 'DmaSparkTrailingStopLoss'
-  triggerType: typeof DmaSparkTrailingStopLoss
+  triggerType: typeof DmaSparkTrailingStopLossID
   decodedParams: {
     positionAddress: string
     triggerType: string
@@ -248,6 +255,42 @@ export type DmaSparkTrailingStopLoss = Trigger & {
   }
 }
 
+export type DmaAavePartialTakeProfit = Trigger & {
+  triggerTypeName: 'DmaAavePartialTakeProfit'
+  triggerType: typeof DmaAavePartialTakeProfitID
+  decodedParams: {
+    positionAddress: string
+    triggerType: string
+    maxCoverage: string
+    debtToken: string
+    collateralToken: string
+    operationName: string
+    executionLtv: string
+    targetLtv: string
+    executionPrice: string
+    deviation: string
+    closeToCollateral: string
+  }
+}
+
+export type DmaSparkPartialTakeProfit = Trigger & {
+  triggerTypeName: 'DmaAavePartialTakeProfit'
+  triggerType: typeof DmaSparkPartialTakeProfitID
+  decodedParams: {
+    positionAddress: string
+    triggerType: string
+    maxCoverage: string
+    debtToken: string
+    collateralToken: string
+    operationName: string
+    executionLtv: string
+    targetLtv: string
+    executionPrice: string
+    deviation: string
+    closeToCollateral: string
+  }
+}
+
 export type GetTriggersResponse = {
   triggers: {
     aaveStopLossToCollateral?: AaveStopLossToCollateral
@@ -264,6 +307,8 @@ export type GetTriggersResponse = {
     sparkBasicSell?: DmaSparkBasicSell
     aaveTrailingStopLossDMA?: DmaAaveTrailingStopLoss
     sparkTrailingStopLossDMA?: DmaSparkTrailingStopLoss
+    aavePartialTakeProfit?: DmaAavePartialTakeProfit
+    sparkPartialTakeProfit?: DmaSparkPartialTakeProfit
   }
   flags: {
     isAaveStopLossEnabled: boolean
@@ -272,6 +317,8 @@ export type GetTriggersResponse = {
     isAaveBasicSellEnabled: boolean
     isSparkBasicBuyEnabled: boolean
     isSparkBasicSellEnabled: boolean
+    isAavePartialTakeProfitEnabled: boolean
+    isSparkPartialTakeProfitEnabled: boolean
   }
   triggerGroup: {
     aaveStopLoss?: Trigger
@@ -280,6 +327,8 @@ export type GetTriggersResponse = {
     aaveBasicSell?: Trigger
     sparkBasicBuy?: Trigger
     sparkBasicSell?: Trigger
+    aavePartialTakeProfit?: Trigger
+    sparkPartialTakeProfit?: Trigger
   }
   triggersCount: number
   additionalData?: Record<string, unknown>
@@ -294,6 +343,14 @@ export type AllDecodedParamsKeys =
   | keyof DmaAaveBasicSell['decodedParams']
   | keyof DmaAaveTrailingStopLoss['decodedParams']
   | keyof DmaAaveTrailingStopLoss['dynamicParams']
+  | keyof DmaAavePartialTakeProfit['decodedParams']
+  | keyof DmaAavePartialTakeProfit['dynamicParams']
+  | keyof DmaSparkBasicBuy['decodedParams']
+  | keyof DmaSparkBasicSell['decodedParams']
+  | keyof DmaSparkTrailingStopLoss['decodedParams']
+  | keyof DmaSparkTrailingStopLoss['dynamicParams']
+  | keyof DmaSparkPartialTakeProfit['decodedParams']
+  | keyof DmaSparkPartialTakeProfit['dynamicParams']
 
 export const getPropertyFromTriggerParams = ({
   trigger,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,9 +157,6 @@ importers:
       '@summerfi/serverless-shared':
         specifier: workspace:*
         version: link:../../../../packages/serverless-shared
-      graphql-request:
-        specifier: ^6.1.0
-        version: 6.1.0(graphql@16.8.1)
       zod:
         specifier: ^3.22.4
         version: 3.22.4


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14540


Add Partial Take Profit functionality to Summerfi API

This commit adds 'Partial Take Profit' functionality to both Aave and Spark alongside existing trailing stop loss. It involves modifications in various trigger parsers and helpers to incorporate ID changes and the addition of new trigger parsers for partial take profit. Additionally, the 'operationName' field is included in decoded parameters for triggers for better operation understanding.