### PR TITLE
Update auto-take-profit service and related tests

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/jest.config.js
+++ b/apps/summerfi-api/lib/setup-trigger-function/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   testTimeout: 10000,
   testEnvironment: 'node',
   testPathIgnorePatterns: ['dist', 'node_modules'],
+  setupFilesAfterEnv: ['jest-expect-message'],
   modulePaths: ['src'],
   moduleNameMapper: pathsToModuleNameMapper({
     '@summerfi/serverless-shared': [

--- a/apps/summerfi-api/lib/setup-trigger-function/package.json
+++ b/apps/summerfi-api/lib/setup-trigger-function/package.json
@@ -31,6 +31,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.5",
     "eslint": "^8.56.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "jest-expect-message": "^1.0.4"
   }
 }

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.spec.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.spec.ts
@@ -1,0 +1,139 @@
+import { getEmptyProfit } from './get-empty-profit'
+import { MinimalAutoTakeProfitTriggerData, MinimalPositionLike } from './types'
+import { PRICE_DECIMALS } from '~types'
+import { CurrentStopLoss } from '../../trigger-encoders'
+import { calculateNextProfit } from './calculate-next-profit'
+
+const ETH_ASSERT_PRECISION = 10n ** 5n
+/**
+ * Test data is based on the spreadsheet.
+ */
+describe('Next profit calculation', () => {
+  it('Should create a first profit with initial data', () => {
+    const minimalPosition: MinimalPositionLike = {
+      collateral: {
+        balance: 1000n * 10n ** 18n,
+        token: {
+          address: '0x1',
+          decimals: 18,
+          symbol: 'WETH',
+        },
+      },
+      debt: {
+        balance: 1000000n * 10n ** 18n,
+        token: {
+          address: '0x2',
+          decimals: 18,
+          symbol: 'DAI',
+        },
+      },
+      ltv: 5000n,
+      collateralPriceInDebt: 2000n * 10n ** PRICE_DECIMALS,
+    }
+    const triggerData: MinimalAutoTakeProfitTriggerData = {
+      executionLTV: 4000n,
+      withdrawStep: 200n,
+      executionPrice: 2500n * 10n ** PRICE_DECIMALS,
+      withdrawToken: '0x1',
+    }
+
+    const currentStopLoss: CurrentStopLoss = {
+      id: 10n,
+      triggerData: '0x10',
+      triggersOnAccount: 1,
+      executionLTV: 6000n,
+      executionPrice: 1666n * 10n ** PRICE_DECIMALS,
+    }
+
+    const nextProfit = calculateNextProfit({
+      lastProfit: getEmptyProfit(minimalPosition),
+      currentPosition: minimalPosition,
+      triggerData,
+      currentStopLoss,
+    })
+
+    const expectedCollateralProfit = 476190476190476n
+    const expectedTriggerPrice = 2500n * 10n ** PRICE_DECIMALS
+    const expectedStopLossPrice = 1750n * 10n ** PRICE_DECIMALS
+    const collateralAfterExecution = 9523809523809523n
+    const expectedLtv = 4200n
+
+    expect(nextProfit.profit.realizedProfitInCollateral.balance / ETH_ASSERT_PRECISION).toBe(
+      expectedCollateralProfit,
+    )
+    expect(nextProfit.profit.triggerPrice).toBe(expectedTriggerPrice)
+    expect(nextProfit.profit.stopLossDynamicPrice).toBe(expectedStopLossPrice)
+    expect(nextProfit.nextPosition.collateral.balance / ETH_ASSERT_PRECISION).toBe(
+      collateralAfterExecution,
+    )
+    expect(nextProfit.nextPosition.debt.balance).toBe(minimalPosition.debt.balance)
+    expect(nextProfit.nextPosition.ltv).toBe(expectedLtv)
+  })
+  it('Shuld create a next profit with data from previous profit', () => {
+    const minimalPosition: MinimalPositionLike = {
+      collateral: {
+        balance: 1000n * 10n ** 18n,
+        token: {
+          address: '0x1',
+          decimals: 18,
+          symbol: 'WETH',
+        },
+      },
+      debt: {
+        balance: 1000000n * 10n ** 18n,
+        token: {
+          address: '0x2',
+          decimals: 18,
+          symbol: 'DAI',
+        },
+      },
+      ltv: 5000n,
+      collateralPriceInDebt: 2000n * 10n ** PRICE_DECIMALS,
+    }
+    const triggerData: MinimalAutoTakeProfitTriggerData = {
+      executionLTV: 4000n,
+      withdrawStep: 200n,
+      executionPrice: 2500n * 10n ** PRICE_DECIMALS,
+      withdrawToken: '0x1',
+    }
+
+    const currentStopLoss: CurrentStopLoss = {
+      id: 10n,
+      triggerData: '0x10',
+      triggersOnAccount: 1,
+      executionLTV: 6000n,
+      executionPrice: 1666n * 10n ** PRICE_DECIMALS,
+    }
+
+    const initialProfit = calculateNextProfit({
+      lastProfit: getEmptyProfit(minimalPosition),
+      currentPosition: minimalPosition,
+      triggerData,
+      currentStopLoss,
+    })
+
+    const nextProfit = calculateNextProfit({
+      lastProfit: initialProfit.profit,
+      currentPosition: initialProfit.nextPosition,
+      triggerData,
+      currentStopLoss,
+    })
+
+    const expectedCollateralProfit = 453514739229024n
+    const expectedTriggerPrice = 2625n * 10n ** PRICE_DECIMALS
+    const expectedStopLossPrice = 18375n * 10n ** (PRICE_DECIMALS - 1n)
+    const collateralAfterExecution = 9070294784580498n
+    const expectedLtv = 4200n
+
+    expect(nextProfit.profit.realizedProfitInCollateral.balance / ETH_ASSERT_PRECISION).toBe(
+      expectedCollateralProfit,
+    )
+    expect(nextProfit.profit.triggerPrice).toBe(expectedTriggerPrice)
+    expect(nextProfit.profit.stopLossDynamicPrice).toBe(expectedStopLossPrice)
+    expect(nextProfit.nextPosition.collateral.balance / ETH_ASSERT_PRECISION).toBe(
+      collateralAfterExecution,
+    )
+    expect(nextProfit.nextPosition.debt.balance).toBe(minimalPosition.debt.balance)
+    expect(nextProfit.nextPosition.ltv).toBe(expectedLtv)
+  })
+})

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.spec.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.spec.ts
@@ -4,47 +4,53 @@ import { PRICE_DECIMALS } from '~types'
 import { CurrentStopLoss } from '../../trigger-encoders'
 import { calculateNextProfit } from './calculate-next-profit'
 
-const ETH_ASSERT_PRECISION = 10n ** 5n
+const assertBigintToBeCloseTo = (received: bigint, expected: bigint, precision: bigint) => {
+  const abs = (a: bigint) => (a < 0n ? -a : a)
+  expect(
+    abs(received - expected),
+    `expected ${received} to be close to ${expected} with precision ${precision}`,
+  ).toBeLessThan(10n ** precision)
+}
+
 /**
  * Test data is based on the spreadsheet.
  */
 describe('Next profit calculation', () => {
+  const minimalPosition: MinimalPositionLike = {
+    collateral: {
+      balance: 1000n * 10n ** 18n,
+      token: {
+        address: '0x1',
+        decimals: 18,
+        symbol: 'WETH',
+      },
+    },
+    debt: {
+      balance: 1000000n * 10n ** 18n,
+      token: {
+        address: '0x2',
+        decimals: 18,
+        symbol: 'DAI',
+      },
+    },
+    ltv: 5000n,
+    collateralPriceInDebt: 2000n * 10n ** PRICE_DECIMALS,
+  }
+  const triggerData: MinimalAutoTakeProfitTriggerData = {
+    executionLTV: 4000n,
+    withdrawStep: 200n,
+    executionPrice: 2500n * 10n ** PRICE_DECIMALS,
+    withdrawToken: '0x1',
+  }
+
+  const currentStopLoss: CurrentStopLoss = {
+    id: 10n,
+    triggerData: '0x10',
+    triggersOnAccount: 1,
+    executionLTV: 6000n,
+    executionPrice: 1666n * 10n ** PRICE_DECIMALS,
+  }
   it('Should create a first profit with initial data', () => {
-    const minimalPosition: MinimalPositionLike = {
-      collateral: {
-        balance: 1000n * 10n ** 18n,
-        token: {
-          address: '0x1',
-          decimals: 18,
-          symbol: 'WETH',
-        },
-      },
-      debt: {
-        balance: 1000000n * 10n ** 18n,
-        token: {
-          address: '0x2',
-          decimals: 18,
-          symbol: 'DAI',
-        },
-      },
-      ltv: 5000n,
-      collateralPriceInDebt: 2000n * 10n ** PRICE_DECIMALS,
-    }
-    const triggerData: MinimalAutoTakeProfitTriggerData = {
-      executionLTV: 4000n,
-      withdrawStep: 200n,
-      executionPrice: 2500n * 10n ** PRICE_DECIMALS,
-      withdrawToken: '0x1',
-    }
-
-    const currentStopLoss: CurrentStopLoss = {
-      id: 10n,
-      triggerData: '0x10',
-      triggersOnAccount: 1,
-      executionLTV: 6000n,
-      executionPrice: 1666n * 10n ** PRICE_DECIMALS,
-    }
-
     const nextProfit = calculateNextProfit({
       lastProfit: getEmptyProfit(minimalPosition),
       currentPosition: minimalPosition,
@@ -52,59 +58,28 @@ describe('Next profit calculation', () => {
       currentStopLoss,
     })
 
-    const expectedCollateralProfit = 476190476190476n
+    const expectedCollateralProfit = 47619047619047700000n
     const expectedTriggerPrice = 2500n * 10n ** PRICE_DECIMALS
     const expectedStopLossPrice = 1750n * 10n ** PRICE_DECIMALS
-    const collateralAfterExecution = 9523809523809523n
+    const collateralAfterExecution = 952380952380952000000n
     const expectedLtv = 4200n
 
-    expect(nextProfit.profit.realizedProfitInCollateral.balance / ETH_ASSERT_PRECISION).toBe(
+    assertBigintToBeCloseTo(
+      nextProfit.profit.realizedProfitInCollateral.balance,
       expectedCollateralProfit,
+      5n,
     )
     expect(nextProfit.profit.triggerPrice).toBe(expectedTriggerPrice)
     expect(nextProfit.profit.stopLossDynamicPrice).toBe(expectedStopLossPrice)
-    expect(nextProfit.nextPosition.collateral.balance / ETH_ASSERT_PRECISION).toBe(
+    assertBigintToBeCloseTo(
+      nextProfit.nextPosition.collateral.balance,
       collateralAfterExecution,
+      6n,
     )
     expect(nextProfit.nextPosition.debt.balance).toBe(minimalPosition.debt.balance)
     expect(nextProfit.nextPosition.ltv).toBe(expectedLtv)
   })
-  it('Shuld create a next profit with data from previous profit', () => {
-    const minimalPosition: MinimalPositionLike = {
-      collateral: {
-        balance: 1000n * 10n ** 18n,
-        token: {
-          address: '0x1',
-          decimals: 18,
-          symbol: 'WETH',
-        },
-      },
-      debt: {
-        balance: 1000000n * 10n ** 18n,
-        token: {
-          address: '0x2',
-          decimals: 18,
-          symbol: 'DAI',
-        },
-      },
-      ltv: 5000n,
-      collateralPriceInDebt: 2000n * 10n ** PRICE_DECIMALS,
-    }
-    const triggerData: MinimalAutoTakeProfitTriggerData = {
-      executionLTV: 4000n,
-      withdrawStep: 200n,
-      executionPrice: 2500n * 10n ** PRICE_DECIMALS,
-      withdrawToken: '0x1',
-    }
-
-    const currentStopLoss: CurrentStopLoss = {
-      id: 10n,
-      triggerData: '0x10',
-      triggersOnAccount: 1,
-      executionLTV: 6000n,
-      executionPrice: 1666n * 10n ** PRICE_DECIMALS,
-    }
-
+  it('Should create a next profit with data from previous profit', () => {
     const initialProfit = calculateNextProfit({
       lastProfit: getEmptyProfit(minimalPosition),
       currentPosition: minimalPosition,
@@ -119,21 +94,69 @@ describe('Next profit calculation', () => {
       currentStopLoss,
     })
 
-    const expectedCollateralProfit = 453514739229024n
+    const expectedCollateralProfit = 45351473922902400000n
     const expectedTriggerPrice = 2625n * 10n ** PRICE_DECIMALS
     const expectedStopLossPrice = 18375n * 10n ** (PRICE_DECIMALS - 1n)
-    const collateralAfterExecution = 9070294784580498n
+    const collateralAfterExecution = 907029478458050000000n
     const expectedLtv = 4200n
 
-    expect(nextProfit.profit.realizedProfitInCollateral.balance / ETH_ASSERT_PRECISION).toBe(
+    assertBigintToBeCloseTo(
+      nextProfit.profit.realizedProfitInCollateral.balance,
       expectedCollateralProfit,
+      5n,
     )
     expect(nextProfit.profit.triggerPrice).toBe(expectedTriggerPrice)
     expect(nextProfit.profit.stopLossDynamicPrice).toBe(expectedStopLossPrice)
-    expect(nextProfit.nextPosition.collateral.balance / ETH_ASSERT_PRECISION).toBe(
+    assertBigintToBeCloseTo(
+      nextProfit.nextPosition.collateral.balance,
       collateralAfterExecution,
+      6n,
     )
     expect(nextProfit.nextPosition.debt.balance).toBe(minimalPosition.debt.balance)
     expect(nextProfit.nextPosition.ltv).toBe(expectedLtv)
+  })
+
+  it('Should create a third profit with data from previous profit', () => {
+    const firstProfit = calculateNextProfit({
+      lastProfit: getEmptyProfit(minimalPosition),
+      currentPosition: minimalPosition,
+      triggerData,
+      currentStopLoss,
+    })
+
+    const secondProfit = calculateNextProfit({
+      lastProfit: firstProfit.profit,
+      currentPosition: firstProfit.nextPosition,
+      triggerData,
+      currentStopLoss,
+    })
+
+    const thirdProfit = calculateNextProfit({
+      lastProfit: secondProfit.profit,
+      currentPosition: secondProfit.nextPosition,
+      triggerData,
+      currentStopLoss,
+    })
+
+    const expectedCollateralProfit = 43191879926573900000n
+    const expectedTriggerPrice = 275625n * 10n ** (PRICE_DECIMALS - 2n)
+    const expectedStopLossPrice = 1929375n * 10n ** (PRICE_DECIMALS - 3n)
+    const collateralAfterExecution = 863837598531476000000n
+    const expectedLtv = 4200n
+
+    assertBigintToBeCloseTo(
+      thirdProfit.profit.realizedProfitInCollateral.balance,
+      expectedCollateralProfit,
+      5n,
+    )
+    expect(thirdProfit.profit.triggerPrice).toBe(expectedTriggerPrice)
+    expect(thirdProfit.profit.stopLossDynamicPrice).toBe(expectedStopLossPrice)
+    assertBigintToBeCloseTo(
+      thirdProfit.nextPosition.collateral.balance,
+      collateralAfterExecution,
+      6n,
+    )
+    expect(thirdProfit.nextPosition.debt.balance).toBe(minimalPosition.debt.balance)
+    expect(thirdProfit.nextPosition.ltv).toBe(expectedLtv)
   })
 })

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
@@ -67,7 +67,7 @@ export const calculateNextProfit = ({
 
     const stopLossExecutionPrice = currentStopLoss?.executionLTV
       ? calculateCollateralPriceInDebtBasedOnLtv({
-          ltv: executionLTV,
+          ltv: currentStopLoss?.executionLTV,
           collateral: collateralAfterWithdraw,
           debt: currentPosition.debt,
         })

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/get-empty-profit.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/get-empty-profit.ts
@@ -1,7 +1,9 @@
 import { PositionLike } from '~types'
 import { AutoTakeProfitRealized } from './types'
 
-export const getEmptyProfit = (position: PositionLike): AutoTakeProfitRealized => {
+export const getEmptyProfit = (
+  position: Pick<PositionLike, 'collateral' | 'debt'>,
+): AutoTakeProfitRealized => {
   return {
     triggerPrice: 0n,
     realizedProfitInCollateral: { balance: 0n, token: position.collateral.token },

--- a/apps/summerfi-api/lib/setup-trigger-function/tsconfig.test.json
+++ b/apps/summerfi-api/lib/setup-trigger-function/tsconfig.test.json
@@ -6,7 +6,8 @@
     "baseUrl": "src",
     "paths": {
       "~types": ["./types"],
-      "~abi": ["./abi"]
+      "~abi": ["./abi"],
+      "~helpers": ["./helpers"],
     }
   },
   "include": ["src/**/*.ts"],

--- a/apps/summerfi-api/lib/setup-trigger-function/tsconfig.test.json
+++ b/apps/summerfi-api/lib/setup-trigger-function/tsconfig.test.json
@@ -10,6 +10,7 @@
       "~helpers": ["./helpers"],
     }
   },
+  "files": ["node_modules/jest-expect-message/types/index.d.ts"],
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/apps/summerfi-api/lib/setup-trigger-function/tsconfig.test.json
+++ b/apps/summerfi-api/lib/setup-trigger-function/tsconfig.test.json
@@ -7,7 +7,7 @@
     "paths": {
       "~types": ["./types"],
       "~abi": ["./abi"],
-      "~helpers": ["./helpers"],
+      "~helpers": ["./helpers"]
     }
   },
   "files": ["node_modules/jest-expect-message/types/index.d.ts"],

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
+    "jest-expect-message": "^1.1.3",
     "prettier": "^3.2.2",
     "sst": "^2.39.7",
     "ts-jest": "^29.1.1",

--- a/packages/automation-subgraph/src/index.ts
+++ b/packages/automation-subgraph/src/index.ts
@@ -1,4 +1,4 @@
-import request from 'graphql-request'
+import { request } from 'graphql-request'
 import {
   TriggersDocument,
   TriggersQuery,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
+      jest-expect-message:
+        specifier: ^1.1.3
+        version: 1.1.3
       jest-extended:
         specifier: ^4.0.2
         version: 4.0.2(jest@29.7.0)
@@ -360,6 +363,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
+      jest-expect-message:
+        specifier: ^1.0.4
+        version: 1.1.3
 
   packages/automation-subgraph:
     dependencies:
@@ -12159,6 +12165,10 @@ packages:
       '@types/node': 20.11.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
+    dev: true
+
+  /jest-expect-message@1.1.3:
+    resolution: {integrity: sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==}
     dev: true
 
   /jest-extended@4.0.2(jest@29.7.0):


### PR DESCRIPTION
This commit includes modification of `tsconfig.test.json` to add a new path alias for helpers. Refinement of `getEmptyProfit` function's argument type related to PositionLike has been applied. The correct LTV value is used in calculating the stop loss execution price in `calculate-next-profit` service. Also, a new test suite for `calculateNextProfit` function is added to ensure its proper functionality.