### PR TITLE
feat: [sc-14578] [BE] Add validations in the function

### DIFF
--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-partial-take-profit.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-aave-partial-take-profit.ts
@@ -33,7 +33,7 @@ export const getDmaAavePartialTakeProfit = async ({
       debtToken: trigger.decodedData[trigger.decodedDataNames.indexOf('debtToken')],
       collateralToken: trigger.decodedData[trigger.decodedDataNames.indexOf('collateralToken')],
       operationName: trigger.decodedData[trigger.decodedDataNames.indexOf('operationName')],
-      closeToCollateral: trigger.decodedData[trigger.decodedDataNames.indexOf('closeToCollateral')],
+      withdrawToDebt: trigger.decodedData[trigger.decodedDataNames.indexOf('withdrawToDebt')],
       executionLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('executionLtv')],
       targetLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('targetLtv')],
       deviation: trigger.decodedData[trigger.decodedDataNames.indexOf('deviation')],

--- a/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-spark-partial-take-profit.ts
+++ b/apps/summerfi-api/lib/get-triggers-function/src/trigger-parsers/dma-spark-partial-take-profit.ts
@@ -33,7 +33,7 @@ export const getDmaSparkPartialTakeProfit = async ({
       debtToken: trigger.decodedData[trigger.decodedDataNames.indexOf('debtToken')],
       collateralToken: trigger.decodedData[trigger.decodedDataNames.indexOf('collateralToken')],
       operationName: trigger.decodedData[trigger.decodedDataNames.indexOf('operationName')],
-      closeToCollateral: trigger.decodedData[trigger.decodedDataNames.indexOf('closeToCollateral')],
+      withdrawToDebt: trigger.decodedData[trigger.decodedDataNames.indexOf('withdrawToDebt')],
       executionLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('executionLtv')],
       targetLtv: trigger.decodedData[trigger.decodedDataNames.indexOf('targetLtv')],
       deviation: trigger.decodedData[trigger.decodedDataNames.indexOf('deviation')],

--- a/apps/summerfi-api/lib/setup-trigger-function/src/helpers/calculate-collateral-price-in-debt-based-on-ltv.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/helpers/calculate-collateral-price-in-debt-based-on-ltv.ts
@@ -1,5 +1,5 @@
 import { PERCENT_DECIMALS, PositionLike, Price, PRICE_DECIMALS } from '~types'
-import { getTheLeastCommonMultiple, normalizeBalance } from '../helpers/normalize-balance'
+import { getTheLeastCommonMultiple, normalizeBalance } from './normalize-balance'
 
 export function calculateCollateralPriceInDebtBasedOnLtv(
   params: Pick<PositionLike, 'debt' | 'collateral' | 'ltv'>,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-buy-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-buy-validator.ts
@@ -146,6 +146,28 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const partialTakeProfit = triggers.triggers.aavePartialTakeProfit
+      if (!partialTakeProfit) {
+        return true
+      }
+      if (!triggerData.useMaxBuyPrice) {
+        return true
+      }
+
+      const partialTakeProfitMinExecutionPrice =
+        safeParseBigInt(partialTakeProfit.decodedParams.executionPrice) ?? 0n
+
+      return triggerData.maxBuyPrice > partialTakeProfitMinExecutionPrice
+    },
+    {
+      message: 'Max buy price is lower than partial take profit execution price',
+      params: {
+        code: AutoBuyTriggerCustomErrorCodes.PartialTakeProfitMinPriceLowerThanAutoBuyMaxPrice,
+      },
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-sell-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-auto-sell-validator.ts
@@ -118,6 +118,44 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const partialTakeProfit = triggers.triggers.aavePartialTakeProfit
+      if (!partialTakeProfit) {
+        return true
+      }
+      const partialTakeProfitExecutionLtv =
+        safeParseBigInt(partialTakeProfit.decodedParams.executionLtv) ?? 0n
+
+      return triggerData.targetLTV > partialTakeProfitExecutionLtv
+    },
+    {
+      message: 'Auto sell target cannot be lower than partial take profit trigger',
+      params: {
+        code: AutoSellTriggerCustomErrorCodes.PartialTakeProfitTriggerHigherThanAutoSellTarget,
+      },
+      path: ['triggerData', 'targetLTV'],
+    },
+  )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const partialTakeProfit = triggers.triggers.aavePartialTakeProfit
+      if (!partialTakeProfit) {
+        return true
+      }
+      const partialTakeProfitTargetLtv =
+        safeParseBigInt(partialTakeProfit.decodedParams.targetLtv) ?? 0n
+
+      return triggerData.executionLTV > partialTakeProfitTargetLtv
+    },
+    {
+      message: 'Auto sell trigger LTV cannot be lower than partial take profit target',
+      params: {
+        code: AutoSellTriggerCustomErrorCodes.PartialTakeProfitTargetHigherThanAutoSellTrigger,
+      },
+      path: ['triggerData', 'executionLTV'],
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-partial-take-profit-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/aave-partial-take-profit-validator.ts
@@ -6,10 +6,14 @@ import {
   ValidationResults,
   aavePartialTakeProfitTriggerDataSchema,
   CommonErrorCodes,
+  PartialTakeProfitErrorCodes,
 } from '~types'
-import { GetTriggersResponse } from '@summerfi/serverless-contracts/get-triggers-response'
+import {
+  getPropertyFromTriggerParams,
+  GetTriggersResponse,
+} from '@summerfi/serverless-contracts/get-triggers-response'
 import { z } from 'zod'
-import { chainIdSchema } from '@summerfi/serverless-shared'
+import { chainIdSchema, safeParseBigInt } from '@summerfi/serverless-shared'
 
 const paramsSchema = z.object({
   position: positionSchema,
@@ -44,6 +48,76 @@ const upsertErrorsValidation = paramsSchema
       message: 'Trigger does not exist',
       params: {
         code: CommonErrorCodes.TriggerDoesNotExist,
+      },
+    },
+  )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const autoSell = triggers.triggers.aaveBasicSell
+      if (!autoSell) return true
+
+      const autoSellTargetLtv = safeParseBigInt(autoSell.decodedParams.targetLtv) ?? 99n
+
+      return triggerData.executionLTV < autoSellTargetLtv
+    },
+    {
+      message: 'LTV is higher than the LTV of the auto sell trigger',
+      params: {
+        code: PartialTakeProfitErrorCodes.PartialTakeProfitTriggerHigherThanAutoSellTarget,
+      },
+    },
+  )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const autoSell = triggers.triggers.aaveBasicSell
+      if (!autoSell) return true
+
+      const autoSellExecutionLtv = safeParseBigInt(autoSell.decodedParams.executionLtv) ?? 99n
+
+      return triggerData.executionLTV < autoSellExecutionLtv
+    },
+    {
+      message: 'LTV is higher than the execution LTV of the auto sell trigger',
+      params: {
+        code: PartialTakeProfitErrorCodes.PartialTakeProfitTargetHigherThanAutoSellTrigger,
+      },
+    },
+  )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const stopLoss = triggers.triggerGroup.aaveStopLoss
+      if (!stopLoss) return true
+
+      const getStopLossLtv =
+        safeParseBigInt(
+          getPropertyFromTriggerParams({
+            trigger: stopLoss,
+            property: 'executionLtv',
+          }),
+        ) ?? 99n
+
+      return triggerData.executionLTV + triggerData.withdrawStep < getStopLossLtv
+    },
+    {
+      message: 'LTV is higher than the stop loss LTV',
+      params: {
+        code: PartialTakeProfitErrorCodes.PartialTakeProfitTargetHigherThanStopLoss,
+      },
+    },
+  )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const autoBuy = triggers.triggers.aaveBasicBuy
+      if (!autoBuy) return true
+
+      const autoBuyMaxPrice = safeParseBigInt(autoBuy.decodedParams.maxBuyPrice) ?? 0n
+
+      return triggerData.executionPrice > autoBuyMaxPrice
+    },
+    {
+      message: 'Min price is lower than the max price of the auto buy trigger',
+      params: {
+        code: PartialTakeProfitErrorCodes.PartialTakeProfitMinPriceLowerThanAutoBuyMaxPrice,
       },
     },
   )

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-stop-loss-validator.ts
@@ -79,6 +79,24 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const currentPartialTakeProfit = triggers.triggers.aavePartialTakeProfit
+      if (currentPartialTakeProfit) {
+        const currentPartialTakeProfitTarget =
+          safeParseBigInt(currentPartialTakeProfit.decodedParams.targetLtv) ?? 0n
+        return triggerData.executionLTV > currentPartialTakeProfitTarget
+      }
+      return true
+    },
+    {
+      message:
+        'Setting your an Stop-Loss trigger at this level could result in it being executed by your Partial Take Profit',
+      params: {
+        code: StopLossErrorCodes.PartialTakeProfitTargetHigherThanStopLoss,
+      },
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-trailing-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-aave-trailing-stop-loss-validator.ts
@@ -94,6 +94,24 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ dynamicExecutionLTV, triggers }) => {
+      const currentPartialTakeProfit = triggers.triggers.aavePartialTakeProfit
+      if (currentPartialTakeProfit) {
+        const currentPartialTakeProfitTarget =
+          safeParseBigInt(currentPartialTakeProfit.decodedParams.targetLtv) ?? 0n
+        return dynamicExecutionLTV > currentPartialTakeProfitTarget
+      }
+      return true
+    },
+    {
+      message:
+        'Setting your an Stop-Loss trigger at this level could result in it being executed by your Partial Take Profit',
+      params: {
+        code: StopLossErrorCodes.PartialTakeProfitTargetHigherThanStopLoss,
+      },
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-spark-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-spark-stop-loss-validator.ts
@@ -79,6 +79,24 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const currentPartialTakeProfit = triggers.triggers.sparkPartialTakeProfit
+      if (currentPartialTakeProfit) {
+        const currentPartialTakeProfitTarget =
+          safeParseBigInt(currentPartialTakeProfit.decodedParams.targetLtv) ?? 0n
+        return triggerData.executionLTV > currentPartialTakeProfitTarget
+      }
+      return true
+    },
+    {
+      message:
+        'Setting your an Stop-Loss trigger at this level could result in it being executed by your Partial Take Profit',
+      params: {
+        code: StopLossErrorCodes.PartialTakeProfitTargetHigherThanStopLoss,
+      },
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-spark-trailing-stop-loss-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/dma-spark-trailing-stop-loss-validator.ts
@@ -94,6 +94,24 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ dynamicExecutionLTV, triggers }) => {
+      const currentPartialTakeProfit = triggers.triggers.sparkPartialTakeProfit
+      if (currentPartialTakeProfit) {
+        const currentPartialTakeProfitTarget =
+          safeParseBigInt(currentPartialTakeProfit.decodedParams.targetLtv) ?? 0n
+        return dynamicExecutionLTV > currentPartialTakeProfitTarget
+      }
+      return true
+    },
+    {
+      message:
+        'Setting your an Stop-Loss trigger at this level could result in it being executed by your Partial Take Profit',
+      params: {
+        code: StopLossErrorCodes.PartialTakeProfitTargetHigherThanStopLoss,
+      },
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-buy-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-buy-validator.ts
@@ -146,6 +146,28 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const partialTakeProfit = triggers.triggers.sparkPartialTakeProfit
+      if (!partialTakeProfit) {
+        return true
+      }
+      if (!triggerData.useMaxBuyPrice) {
+        return true
+      }
+
+      const partialTakeProfitMinExecutionPrice =
+        safeParseBigInt(partialTakeProfit.decodedParams.executionPrice) ?? 0n
+
+      return triggerData.maxBuyPrice > partialTakeProfitMinExecutionPrice
+    },
+    {
+      message: 'Max buy price is lower than partial take profit execution price',
+      params: {
+        code: AutoBuyTriggerCustomErrorCodes.PartialTakeProfitMinPriceLowerThanAutoBuyMaxPrice,
+      },
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-sell-validator.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/against-position-validators/spark-auto-sell-validator.ts
@@ -118,6 +118,44 @@ const upsertErrorsValidation = paramsSchema
       },
     },
   )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const partialTakeProfit = triggers.triggers.sparkPartialTakeProfit
+      if (!partialTakeProfit) {
+        return true
+      }
+      const partialTakeProfitExecutionLtv =
+        safeParseBigInt(partialTakeProfit.decodedParams.executionLtv) ?? 0n
+
+      return triggerData.targetLTV > partialTakeProfitExecutionLtv
+    },
+    {
+      message: 'Auto sell target cannot be lower than partial take profit trigger',
+      params: {
+        code: AutoSellTriggerCustomErrorCodes.PartialTakeProfitTriggerHigherThanAutoSellTarget,
+      },
+      path: ['triggerData', 'targetLTV'],
+    },
+  )
+  .refine(
+    ({ triggerData, triggers }) => {
+      const partialTakeProfit = triggers.triggers.sparkPartialTakeProfit
+      if (!partialTakeProfit) {
+        return true
+      }
+      const partialTakeProfitTargetLtv =
+        safeParseBigInt(partialTakeProfit.decodedParams.targetLtv) ?? 0n
+
+      return triggerData.executionLTV > partialTakeProfitTargetLtv
+    },
+    {
+      message: 'Auto sell trigger LTV cannot be lower than partial take profit target',
+      params: {
+        code: AutoSellTriggerCustomErrorCodes.PartialTakeProfitTargetHigherThanAutoSellTrigger,
+      },
+      path: ['triggerData', 'executionLTV'],
+    },
+  )
 
 const deleteErrorsValidation = paramsSchema.refine(
   ({ triggers, action }) => {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
@@ -20,6 +20,7 @@ import { encodeFunctionForDpm } from './encode-function-for-dpm'
 import { getCurrentAaveStopLoss } from './get-current-aave-stop-loss'
 import { DerivedPrices } from '@summerfi/prices-subgraph'
 import { simulateAutoTakeProfit } from './simulations'
+import { MinimalStopLossInformation } from './simulations/auto-take-profit/types'
 
 export interface GetAavePartialTakeProfitServiceContainerProps {
   rpc: PublicClient
@@ -118,9 +119,14 @@ export const getAavePartialTakeProfitServiceContainer: (
       const triggers = await getTriggers(trigger.dpm)
 
       const currentStopLoss = getCurrentAaveStopLoss(triggers, position, logger)
+      const choosenStopLossExecutionLtv = trigger.triggerData.stopLoss?.triggerData.executionLTV
+      const minimalStopLossInformation: MinimalStopLossInformation | undefined =
+        choosenStopLossExecutionLtv
+          ? { executionLTV: choosenStopLossExecutionLtv }
+          : currentStopLoss
       return simulateAutoTakeProfit({
         position,
-        currentStopLoss,
+        currentStopLoss: minimalStopLossInformation,
         minimalTriggerData: trigger.triggerData,
       })
     },

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
@@ -14,6 +14,8 @@ import {
   SLIPPAGE,
 } from './types'
 
+const getMax = (a: bigint, b: bigint) => (a > b ? a : b)
+
 export const calculateNextProfit = ({
   lastProfit,
   currentPosition,
@@ -26,11 +28,14 @@ export const calculateNextProfit = ({
   currentStopLoss: CurrentStopLoss | undefined
 }): { profit: AutoTakeProfitRealized; nextPosition: MinimalPositionLike } => {
   const executionLTV = triggerData.executionLTV
-  const executionPrice = calculateCollateralPriceInDebtBasedOnLtv({
-    collateral: currentPosition.collateral,
-    debt: currentPosition.debt,
-    ltv: executionLTV,
-  })
+  const executionPrice = getMax(
+    calculateCollateralPriceInDebtBasedOnLtv({
+      collateral: currentPosition.collateral,
+      debt: currentPosition.debt,
+      ltv: executionLTV,
+    }),
+    triggerData.executionPrice,
+  )
 
   const collateralAfterWithdraw = calculateCollateral({
     position: {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
@@ -1,4 +1,3 @@
-import { CurrentStopLoss } from '../../trigger-encoders'
 import {
   calculateBalance,
   calculateCollateral,
@@ -11,6 +10,7 @@ import {
   FEE,
   MinimalAutoTakeProfitTriggerData,
   MinimalPositionLike,
+  MinimalStopLossInformation,
   SLIPPAGE,
 } from './types'
 
@@ -25,7 +25,7 @@ export const calculateNextProfit = ({
   lastProfit: AutoTakeProfitRealized
   currentPosition: MinimalPositionLike
   triggerData: MinimalAutoTakeProfitTriggerData
-  currentStopLoss: CurrentStopLoss | undefined
+  currentStopLoss: MinimalStopLossInformation | undefined
 }): { profit: AutoTakeProfitRealized; nextPosition: MinimalPositionLike } => {
   const executionLTV = triggerData.executionLTV
   const executionPrice = getMax(

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/types.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/types.ts
@@ -27,9 +27,11 @@ export type MinimalAutoTakeProfitTriggerData = Pick<
   'executionPrice' | 'executionLTV' | 'withdrawStep' | 'withdrawToken'
 >
 
+export type MinimalStopLossInformation = Pick<CurrentStopLoss, 'executionLTV'>
+
 export interface SimulateAutoTakeProfitParams {
   position: PositionLike
-  currentStopLoss: CurrentStopLoss | undefined
+  currentStopLoss: MinimalStopLossInformation | undefined
   minimalTriggerData: MinimalAutoTakeProfitTriggerData
   iterations?: number
 }

--- a/apps/summerfi-api/lib/setup-trigger-function/src/types/types.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/types/types.ts
@@ -155,7 +155,16 @@ export enum StopLossWarningCodes {
   StopLossMakesAutoSellNotTrigger = 'stop-loss-makes-auto-sell-not-trigger',
 }
 
-export enum PartialTakeProfitErrorCodes {}
+export enum PartialTakeProfitErrorCodes {
+  // Error: Your Partial Take Profit trigger LTV is higher than the target LTV of your Auto-Sell. Reduce your Partial Take Profit trigger, or update your Auto-Sell.
+  PartialTakeProfitTriggerHigherThanAutoSellTarget = 'partial-take-profit-trigger-higher-than-auto-sell-target',
+  // Error: Your Partial Take Profit target LTV is higher than the trigger LTV of your Auto-Sell. Reduce your Partial Take Profit target, or update your Auto-Sell.
+  PartialTakeProfitTargetHigherThanAutoSellTrigger = 'partial-take-profit-target-higher-than-auto-sell-trigger',
+  // Error: Your Partial Take Profit target LTV is higher than your Stop-Loss. Reduce your Partial Take Profit target, or update your Stop-Loss.
+  PartialTakeProfitTargetHigherThanStopLoss = 'partial-take-profit-target-higher-than-stop-loss',
+  // Error: Your Partial Take Profit min price is lower than the max price of your Auto-Buy. Increase your Partial Take Profit min price, or update your Auto-Buy
+  PartialTakeProfitMinPriceLowerThanAutoBuyMaxPrice = 'partial-take-profit-min-price-lower-than-auto-buy-max-price',
+}
 
 export enum PartialTakeProfitWarningCodes {}
 

--- a/apps/summerfi-api/lib/setup-trigger-function/src/types/types.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/types/types.ts
@@ -108,6 +108,9 @@ export enum AutoBuyTriggerCustomErrorCodes {
   AutoBuyTriggerDoesNotExist = 'auto-buy-trigger-does-not-exist',
   NetValueTooLowToSetupAutoBuy = 'net-value-too-low-to-setup-auto-buy',
   StopLossTriggerLowerThanAutoBuy = 'stop-loss-trigger-ltv-lower-than-auto-buy',
+
+  // Error: Your Partial Take Profit min price is lower than the max price of your Auto-Buy. Increase your Partial Take Profit min price, or update your Auto-Buy
+  PartialTakeProfitMinPriceLowerThanAutoBuyMaxPrice = 'partial-take-profit-min-price-lower-than-auto-buy-max-price',
 }
 
 export enum AutoBuyTriggerCustomWarningCodes {
@@ -130,6 +133,12 @@ export enum AutoSellTriggerCustomErrorCodes {
   NetValueTooLowToSetupAutoSell = 'net-value-too-low-to-setup-auto-sell',
   StopLossNeverTriggeredWithNoAutoSellMinSellPrice = 'stop-loss-never-triggered-with-no-auto-sell-min-sell-price',
   StopLossNeverTriggeredWithLowerAutoSellMinSellPrice = 'stop-loss-never-triggered-with-lower-auto-sell-min-sell-price',
+
+  // Error: Your Partial Take Profit trigger LTV is higher than the target LTV of your Auto-Sell. Reduce your Partial Take Profit trigger, or update your Auto-Sell.
+  PartialTakeProfitTriggerHigherThanAutoSellTarget = 'partial-take-profit-trigger-higher-than-auto-sell-target',
+
+  // Error: Your Partial Take Profit target LTV is higher than the trigger LTV of your Auto-Sell. Reduce your Partial Take Profit target, or update your Auto-Sell.
+  PartialTakeProfitTargetHigherThanAutoSellTrigger = 'partial-take-profit-target-higher-than-auto-sell-trigger',
 }
 
 export enum AutoSellTriggerCustomWarningCodes {
@@ -148,6 +157,9 @@ export enum StopLossErrorCodes {
   StopLossTriggeredByAutoBuy = 'stop-loss-triggered-by-auto-buy',
   StopLossNeverTriggeredWithNoAutoSellMinSellPrice = 'stop-loss-never-triggered-with-no-auto-sell-min-sell-price',
   StopLossNeverTriggeredWithLowerAutoSellMinSellPrice = 'stop-loss-never-triggered-with-lower-auto-sell-min-sell-price',
+
+  // Error: Your Partial Take Profit target LTV is higher than your Stop-Loss. Reduce your Partial Take Profit target, or update your Stop-Loss.
+  PartialTakeProfitTargetHigherThanStopLoss = 'partial-take-profit-target-higher-than-stop-loss',
 }
 
 export enum StopLossWarningCodes {

--- a/packages/serverless-contracts/src/get-triggers-response.ts
+++ b/packages/serverless-contracts/src/get-triggers-response.ts
@@ -269,7 +269,7 @@ export type DmaAavePartialTakeProfit = Trigger & {
     targetLtv: string
     executionPrice: string
     deviation: string
-    closeToCollateral: string
+    withdrawToDebt: string
   }
 }
 
@@ -287,7 +287,7 @@ export type DmaSparkPartialTakeProfit = Trigger & {
     targetLtv: string
     executionPrice: string
     deviation: string
-    closeToCollateral: string
+    withdrawToDebt: string
   }
 }
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14578

Added more specific error messages to the trigger validation code in the API. These include errors related to 'partial-take-profit-trigger' LTV (Loan to Value) ratio being higher than other trigger parameters. The changes enhance validation by providing distinct error codes for various conceivably problematic scenarios in the trading process.


Updated several validator functions to include checks for conditions related to partial take profit and stop loss triggers. The new checks help to prevent scenarios where stop loss triggers could be executed due to partial take profit logic, or auto sell and buy triggers may have undesirable repercussions with prevailing take profit settings. New error codes are introduced for better error tracking and debugging.
