### PR TITLE
Add newStopLoss parameter to simulateAutoTakeProfit function

### DIFF
--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
@@ -118,9 +118,11 @@ export const getAavePartialTakeProfitServiceContainer: (
       const triggers = await getTriggers(trigger.dpm)
 
       const currentStopLoss = getCurrentAaveStopLoss(triggers, position, logger)
+      const newStopLoss = trigger.triggerData.stopLoss
       return simulateAutoTakeProfit({
         position,
         currentStopLoss,
+        newStopLoss,
         minimalTriggerData: trigger.triggerData,
       })
     },

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
@@ -1,4 +1,3 @@
-import { CurrentStopLoss } from '../../trigger-encoders'
 import {
   calculateBalance,
   calculateCollateral,
@@ -18,12 +17,12 @@ export const calculateNextProfit = ({
   lastProfit,
   currentPosition,
   triggerData,
-  currentStopLoss,
+  stopLossLtv,
 }: {
   lastProfit: AutoTakeProfitRealized
   currentPosition: MinimalPositionLike
   triggerData: MinimalAutoTakeProfitTriggerData
-  currentStopLoss: CurrentStopLoss | undefined
+  stopLossLtv: bigint | undefined
 }): { profit: AutoTakeProfitRealized; nextPosition: MinimalPositionLike } => {
   const executionLTV = triggerData.executionLTV
   const executionPrice = calculateCollateralPriceInDebtBasedOnLtv({
@@ -65,9 +64,9 @@ export const calculateNextProfit = ({
       balance: lastProfit.totalProfitInDebt.balance + realizedProfitInDebt.balance,
     }
 
-    const stopLossExecutionPrice = currentStopLoss?.executionLTV
+    const stopLossExecutionPrice = stopLossLtv
       ? calculateCollateralPriceInDebtBasedOnLtv({
-          ltv: currentStopLoss?.executionLTV,
+          ltv: stopLossLtv,
           collateral: collateralAfterWithdraw,
           debt: currentPosition.debt,
         })
@@ -131,7 +130,7 @@ export const calculateNextProfit = ({
       balance: lastProfit.totalProfitInDebt.balance + realizedProfitInDebt.balance,
     }
 
-    const stopLossExecutionPrice = currentStopLoss?.executionLTV
+    const stopLossExecutionPrice = stopLossLtv
       ? calculateCollateralPriceInDebtBasedOnLtv({
           ltv: executionLTV,
           collateral: collateralAfterWithdraw,

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/simulate-auto-take-profit.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/simulate-auto-take-profit.ts
@@ -10,6 +10,7 @@ import { getEmptyProfit } from './get-empty-profit'
 export const simulateAutoTakeProfit = ({
   position,
   currentStopLoss,
+  newStopLoss,
   minimalTriggerData,
   iterations = 15,
 }: SimulateAutoTakeProfitParams): AutoTakeProfitSimulation => {
@@ -20,7 +21,7 @@ export const simulateAutoTakeProfit = ({
         lastProfit: current,
         currentPosition: _nextPosition,
         triggerData: minimalTriggerData,
-        currentStopLoss,
+        stopLossLtv: currentStopLoss?.executionLTV || newStopLoss?.triggerData.executionLTV,
       })
 
       return {

--- a/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/types.ts
+++ b/apps/summerfi-api/lib/setup-trigger-function/src/services/simulations/auto-take-profit/types.ts
@@ -30,6 +30,7 @@ export type MinimalAutoTakeProfitTriggerData = Pick<
 export interface SimulateAutoTakeProfitParams {
   position: PositionLike
   currentStopLoss: CurrentStopLoss | undefined
+  newStopLoss: (AavePartialTakeProfitTriggerData | SparkPartialTakeProfitTriggerData)['stopLoss']
   minimalTriggerData: MinimalAutoTakeProfitTriggerData
   iterations?: number
 }


### PR DESCRIPTION
This pull request adds a new `newStopLoss` parameter to the `simulateAutoTakeProfit` function. The `newStopLoss` parameter allows for specifying a stop loss value for the simulation. This parameter is used in the calculation of the next profit and is passed to the `calculateNextProfit` function.