### PR TITLE
Update trigger action reference in services

### DIFF
--- a/summerfi-api/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
+++ b/summerfi-api/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
@@ -128,7 +128,7 @@ export const getAavePartialTakeProfitServiceContainer: (
             position,
             executionPrice,
             triggerData: trigger.triggerData.stopLoss.triggerData,
-            action: trigger.action,
+            action: trigger.triggerData.stopLoss.action,
             triggers,
           }),
         )

--- a/summerfi-api/setup-trigger-function/src/services/get-spark-partial-take-profit-service-container.ts
+++ b/summerfi-api/setup-trigger-function/src/services/get-spark-partial-take-profit-service-container.ts
@@ -121,7 +121,7 @@ export const getSparkPartialTakeProfitServiceContainer: (
             position,
             executionPrice,
             triggerData: trigger.triggerData.stopLoss.triggerData,
-            action: trigger.action,
+            action: trigger.triggerData.stopLoss.action,
             triggers,
           }),
         )


### PR DESCRIPTION
Changed the reference of the action property in both get-aave-partial-take-profit-service-container.ts and get-spark-partial-take-profit-service-container.ts files. This update now draws the action from trigger.triggerData.stopLoss, ensuring the correct action is accurately referenced and used within these services.