### PR TITLE
Update trigger result and continuous status

### DIFF
--- a/summerfi-api/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
+++ b/summerfi-api/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
@@ -63,7 +63,7 @@ const getIfThereIsAStopLossToChange = async ({
     const isTheSameTriggerData = addableStopLoss.encodedTriggerData === currentStopLoss?.triggerData
 
     return {
-      result: isTheSameTriggerData,
+      result: !isTheSameTriggerData,
       addableStopLoss,
     }
   }

--- a/summerfi-api/setup-trigger-function/src/services/get-spark-partial-take-profit-service-container.ts
+++ b/summerfi-api/setup-trigger-function/src/services/get-spark-partial-take-profit-service-container.ts
@@ -61,7 +61,7 @@ const getIfThereIsAStopLossToChange = async ({
     const isTheSameTriggerData = addableStopLoss.encodedTriggerData === currentStopLoss?.triggerData
 
     return {
-      result: isTheSameTriggerData,
+      result: !isTheSameTriggerData,
       addableStopLoss,
     }
   }

--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-aave-stop-loss.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-aave-stop-loss.ts
@@ -79,7 +79,7 @@ export const encodeAaveStopLoss = (
     : undefined
 
   const addableTrigger: AddableTrigger = {
-    continuous: true,
+    continuous: false,
     currentId: currentTrigger?.id ?? 0n,
     encodedTriggerData: encodedTriggerData,
     currentTriggerData: currentTrigger?.triggerData ?? '0x0',

--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-spark-stop-loss.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-spark-stop-loss.ts
@@ -79,7 +79,7 @@ export const encodeSparkStopLoss = (
     : undefined
 
   const addableTrigger: AddableTrigger = {
-    continuous: true,
+    continuous: false,
     currentId: currentTrigger?.id ?? 0n,
     encodedTriggerData: encodedTriggerData,
     currentTriggerData: currentTrigger?.triggerData ?? '0x0',


### PR DESCRIPTION
Changes have been made to the trigger functionality where the 'isTheSameTriggerData' condition's result has been negated. Also, the 'continuous' property status of addableTrigger in the trigger encoder's service was switched from true to false. This shift in logic suggests changes in the system's handling of triggers.