### PR TITLE
Get Locked Collateral Function

### DIFF
--- a/external-api/get-collateral-locked-function/.eslintrc.cjs
+++ b/external-api/get-collateral-locked-function/.eslintrc.cjs
@@ -1,0 +1,6 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ['@summerfi/eslint-config/function.cjs'],
+  parser: '@typescript-eslint/parser',
+}

--- a/external-api/get-collateral-locked-function/jest.config.js
+++ b/external-api/get-collateral-locked-function/jest.config.js
@@ -1,0 +1,15 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {},
+      },
+    ],
+  },
+}

--- a/external-api/get-collateral-locked-function/package.json
+++ b/external-api/get-collateral-locked-function/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@summerfi/get-collateral-locked-function",
+  "version": "0.0.1",
+  "scripts": {
+    "tsc": "tsc",
+    "watch": "tsc -w",
+    "test": "jest --passWithNoTests",
+    "build": "tsc -b -v",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^1.17.0",
+    "@aws-lambda-powertools/metrics": "^1.17.0",
+    "@aws-lambda-powertools/tracer": "^1.17.0",
+    "@summerfi/serverless-shared": "workspace:*",
+    "@summerfi/aave-spark-subgraph": "workspace:*",
+    "@summerfi/ajna-subgraph": "workspace:*",
+    "@summerfi/morpho-blue-subgraph": "workspace:*",
+    "@summerfi/serverless-contracts": "workspace:*",
+    "zod": "^3.22.4",
+    "bignumber.js": "^9.1.2"
+  },
+  "devDependencies": {
+    "@summerfi/eslint-config": "workspace:*",
+    "@summerfi/typescript-config": "workspace:*",
+    "@types/node": "^20.11.5",
+    "eslint": "^8.56.0",
+    "jest": "^29.7.0"
+  }
+}

--- a/external-api/get-collateral-locked-function/src/index.ts
+++ b/external-api/get-collateral-locked-function/src/index.ts
@@ -1,0 +1,221 @@
+import { z } from 'zod'
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2, Context } from 'aws-lambda'
+import {
+  ResponseBadRequest,
+  ResponseInternalServerError,
+  ResponseOk,
+} from '@summerfi/serverless-shared/responses'
+import { addressSchema, chainIdSchema } from '@summerfi/serverless-shared/validators'
+
+import { Logger } from '@aws-lambda-powertools/logger'
+import {
+  CollateralLocked,
+  CollateralLockedResult,
+  getAaveSparkSubgraphClient,
+} from '@summerfi/aave-spark-subgraph'
+import { Address, ChainId } from '@summerfi/serverless-shared'
+import { getAjnaSubgraphClient } from '@summerfi/ajna-subgraph'
+import { getMorphoBlueSubgraphClient } from '@summerfi/morpho-blue-subgraph'
+import { BigNumber } from 'bignumber.js'
+
+const logger = new Logger({ serviceName: 'get-collateral-locked-function' })
+
+const paramsSchema = z.object({
+  address: z.array(addressSchema).optional().default([]),
+  blockNumber: z
+    .number()
+    .positive()
+    .or(z.string().refine((v) => !isNaN(Number(v))))
+    .transform(Number),
+  chainId: chainIdSchema,
+})
+
+const weETH_eETH_decimals = 18
+
+const weETH_eETH_map: Record<ChainId, Address[]> = {
+  [ChainId.MAINNET]: [
+    '0x35fA164735182de50811E8e2E824cFb9B6118ac2', // eETH
+    '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee', // weETH
+  ],
+  [ChainId.OPTIMISM]: ['0x346e03F8Cce9fE01dCB3d0Da3e9D00dC2c0E08f0'],
+  [ChainId.ARBITRUM]: ['0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe'],
+  [ChainId.BASE]: [],
+  [ChainId.SEPOLIA]: [],
+}
+
+export interface ResponseBodyItem {
+  address: Address
+  effective_balance: number
+}
+export interface ResponseBody {
+  Result: ResponseBodyItem[]
+}
+
+export const handler = async (
+  event: APIGatewayProxyEventV2,
+  context: Context,
+): Promise<APIGatewayProxyResultV2> => {
+  const SUBGRAPH_BASE = process.env.SUBGRAPH_BASE
+
+  logger.addContext(context)
+
+  if (!SUBGRAPH_BASE) {
+    logger.error('SUBGRAPH_BASE is not set')
+    return ResponseInternalServerError('SUBGRAPH_BASE is not set')
+  }
+
+  logger.info(`Query params`, { params: event.queryStringParameters })
+
+  const parseResult = paramsSchema.safeParse(event.queryStringParameters)
+  if (!parseResult.success) {
+    logger.warn('Incorrect query params', {
+      params: event.queryStringParameters,
+      errors: parseResult.error.errors,
+    })
+    return ResponseBadRequest({
+      message: 'Validation Errors',
+      errors: parseResult.error.errors,
+    })
+  }
+  const params = parseResult.data
+
+  const calls: (() => Promise<CollateralLockedResult>)[] = []
+
+  const aaveSparkClient = getAaveSparkSubgraphClient({
+    chainId: params.chainId,
+    urlBase: SUBGRAPH_BASE,
+    logger,
+  })
+
+  calls.push(() =>
+    aaveSparkClient
+      .getCollateralLocked({
+        collaterals: weETH_eETH_map[params.chainId].map((address) => {
+          return {
+            address,
+            decimals: weETH_eETH_decimals,
+          }
+        }),
+        blockNumber: params.blockNumber,
+      })
+      .catch((error) => {
+        logger.error('Error fetching Aave/Spark collateral locked', { error })
+        return {
+          lockedCollaterals: [],
+        }
+      }),
+  )
+
+  const ajnaClient = getAjnaSubgraphClient({
+    chainId: params.chainId,
+    logger: logger,
+    urlBase: SUBGRAPH_BASE,
+  })
+
+  calls.push(() =>
+    ajnaClient
+      .getCollateralLocked({
+        collaterals: weETH_eETH_map[params.chainId].map((address) => {
+          return {
+            address,
+            decimals: weETH_eETH_decimals,
+          }
+        }),
+        blockNumber: params.blockNumber,
+      })
+      .then((result) => {
+        return {
+          lockedCollaterals: result.lockedCollaterals.map((lc) => {
+            return {
+              ...lc,
+              amount: new BigNumber(lc.amount).shiftedBy(-weETH_eETH_decimals).toString(),
+            }
+          }),
+        }
+      })
+      .catch((error) => {
+        logger.error('Error fetching ajna collateral locked', { error })
+        return {
+          lockedCollaterals: [],
+        }
+      }),
+  )
+
+  if (params.chainId === ChainId.MAINNET) {
+    const morphoBlueClient = getMorphoBlueSubgraphClient({
+      chainId: ChainId.MAINNET,
+      urlBase: SUBGRAPH_BASE,
+      logger,
+    })
+
+    calls.push(() =>
+      morphoBlueClient
+        .getCollateralLocked({
+          collaterals: weETH_eETH_map[params.chainId].map((address) => {
+            return {
+              address,
+              decimals: weETH_eETH_decimals,
+            }
+          }),
+          blockNumber: params.blockNumber,
+        })
+        .then((result) => {
+          return {
+            lockedCollaterals: result.lockedCollaterals.map((lc) => {
+              return {
+                ...lc,
+                amount: new BigNumber(lc.amount).shiftedBy(-weETH_eETH_decimals).toString(),
+              }
+            }),
+          }
+        })
+        .catch((error) => {
+          logger.error('Error fetching morpho blue collateral locked', { error })
+          return {
+            lockedCollaterals: [],
+          }
+        }),
+    )
+  }
+
+  const collateralLocked = await Promise.all(calls.map((c) => c()))
+
+  const values: ResponseBodyItem[] = collateralLocked
+    .flatMap((c) => c.lockedCollaterals)
+    .reduce(
+      (acc, c) => {
+        const index = acc.findIndex((a) => a.owner === c.owner)
+        if (index === -1) {
+          return [...acc, { owner: c.owner, lockedCollaterals: [c] }]
+        }
+        acc[index].lockedCollaterals.push(c)
+        return acc
+      },
+      [] as { owner: Address; lockedCollaterals: CollateralLocked[] }[],
+    )
+    .map((c) => {
+      return {
+        owner: c.owner,
+        amount: c.lockedCollaterals
+          .map((c) => c.amount)
+          .reduce((acc, second) => acc.plus(new BigNumber(second)), new BigNumber(0))
+          .toNumber(),
+      }
+    })
+    .map((c) => {
+      return {
+        address: c.owner,
+        effective_balance: c.amount,
+      }
+    })
+
+  const response: ResponseBody = {
+    Result: values,
+  }
+
+  return ResponseOk({
+    body: response,
+  })
+}
+
+export default handler

--- a/external-api/get-collateral-locked-function/tsconfig.json
+++ b/external-api/get-collateral-locked-function/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@summerfi/typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/packages/aave-spark-subgraph/.eslintrc.cjs
+++ b/packages/aave-spark-subgraph/.eslintrc.cjs
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  ignorePatterns: ['src/types/graphql/**'],
+  extends: ['@summerfi/eslint-config/library.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+  },
+}

--- a/packages/aave-spark-subgraph/graphql.config.yml
+++ b/packages/aave-spark-subgraph/graphql.config.yml
@@ -1,0 +1,32 @@
+schema: schema.graphql
+documents: './queries/**/*.graphql'
+config:
+  namingConvention:
+    enumValues: keep
+generates:
+  src/types/graphql/generated.ts:
+    plugins:
+      - add:
+          content:
+            - '// @ts-nocheck'
+            - '// This file was automatically generated and should not be edited.'
+      - typescript
+      - typescript-operations:
+          strictScalars: true
+          immutableTypes: true
+          scalars:
+            BigDecimal: string
+            BigInt: bigint
+            Int8: number
+            BooleanType: boolean
+            CustomData: Record<string, unknown>
+            Date: string
+            DateTime: string
+            FloatType: number
+            IntType: number
+            ItemId: string
+            JsonField: unknown
+            Bytes: string
+            MetaTagAttributes: Record<string, string>
+            UploadId: string
+      - typed-document-node

--- a/packages/aave-spark-subgraph/package.json
+++ b/packages/aave-spark-subgraph/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@summerfi/aave-spark-subgraph",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "tsc": "tsc",
+    "watch": "tsc -w",
+    "test": "jest --passWithNoTests",
+    "build": "tsc -b -v",
+    "prebuild": "pnpm run generate-ts-types",
+    "generate-ts-types": "graphql-codegen --config graphql.config.yml",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^1.17.0",
+    "graphql-request": "^6.1.0",
+    "@summerfi/serverless-shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@summerfi/eslint-config": "workspace:*",
+    "@summerfi/typescript-config": "workspace:*",
+    "@types/node": "^20.11.5",
+    "eslint": "^8.56.0"
+  }
+}

--- a/packages/aave-spark-subgraph/queries/collateral-locked.graphql
+++ b/packages/aave-spark-subgraph/queries/collateral-locked.graphql
@@ -1,0 +1,11 @@
+query CollateralLocked($collateralAddresses: [Bytes!]!, $block: Int!) {
+  positions(where: { collateralAddress_in: $collateralAddresses, account_not: null, collateral_gt: 0 }, block: { number: $block }) {
+    collateralAddress
+    collateral
+    proxy {
+      owner
+      isDPM
+    }
+    protocol
+  }
+}

--- a/packages/aave-spark-subgraph/schema.graphql
+++ b/packages/aave-spark-subgraph/schema.graphql
@@ -1,0 +1,4386 @@
+"""
+Marks the GraphQL type as indexable entity.  Each type that should be an entity
+is required to be annotated with this directive.
+"""
+directive @entity on OBJECT
+
+"""Defined a Subgraph ID for an object type"""
+directive @subgraphId(id: String!) on OBJECT
+
+"""
+creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
+"""
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+
+  """The block number"""
+  number: Int!
+
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+
+  """The deployment ID"""
+  deployment: String!
+
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
+
+type AaveLikeBorrow {
+  id: ID!
+  reserve: Bytes!
+  user: Bytes!
+  onBehalfOf: Bytes!
+  amount: BigInt!
+  borrowRateMode: BigInt!
+  borrowRate: BigInt!
+  referral: BigInt!
+  version: String
+  protocol: String!
+  variableDebtAfter: BigDecimal
+  stableDebtAfter: BigDecimal
+  debtDelta: BigDecimal
+  tokenPriceUSD: BigDecimal
+  token: Token
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input AaveLikeBorrow_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  reserve: Bytes
+  reserve_not: Bytes
+  reserve_gt: Bytes
+  reserve_lt: Bytes
+  reserve_gte: Bytes
+  reserve_lte: Bytes
+  reserve_in: [Bytes!]
+  reserve_not_in: [Bytes!]
+  reserve_contains: Bytes
+  reserve_not_contains: Bytes
+  user: Bytes
+  user_not: Bytes
+  user_gt: Bytes
+  user_lt: Bytes
+  user_gte: Bytes
+  user_lte: Bytes
+  user_in: [Bytes!]
+  user_not_in: [Bytes!]
+  user_contains: Bytes
+  user_not_contains: Bytes
+  onBehalfOf: Bytes
+  onBehalfOf_not: Bytes
+  onBehalfOf_gt: Bytes
+  onBehalfOf_lt: Bytes
+  onBehalfOf_gte: Bytes
+  onBehalfOf_lte: Bytes
+  onBehalfOf_in: [Bytes!]
+  onBehalfOf_not_in: [Bytes!]
+  onBehalfOf_contains: Bytes
+  onBehalfOf_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  borrowRateMode: BigInt
+  borrowRateMode_not: BigInt
+  borrowRateMode_gt: BigInt
+  borrowRateMode_lt: BigInt
+  borrowRateMode_gte: BigInt
+  borrowRateMode_lte: BigInt
+  borrowRateMode_in: [BigInt!]
+  borrowRateMode_not_in: [BigInt!]
+  borrowRate: BigInt
+  borrowRate_not: BigInt
+  borrowRate_gt: BigInt
+  borrowRate_lt: BigInt
+  borrowRate_gte: BigInt
+  borrowRate_lte: BigInt
+  borrowRate_in: [BigInt!]
+  borrowRate_not_in: [BigInt!]
+  referral: BigInt
+  referral_not: BigInt
+  referral_gt: BigInt
+  referral_lt: BigInt
+  referral_gte: BigInt
+  referral_lte: BigInt
+  referral_in: [BigInt!]
+  referral_not_in: [BigInt!]
+  version: String
+  version_not: String
+  version_gt: String
+  version_lt: String
+  version_gte: String
+  version_lte: String
+  version_in: [String!]
+  version_not_in: [String!]
+  version_contains: String
+  version_contains_nocase: String
+  version_not_contains: String
+  version_not_contains_nocase: String
+  version_starts_with: String
+  version_starts_with_nocase: String
+  version_not_starts_with: String
+  version_not_starts_with_nocase: String
+  version_ends_with: String
+  version_ends_with_nocase: String
+  version_not_ends_with: String
+  version_not_ends_with_nocase: String
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  variableDebtAfter: BigDecimal
+  variableDebtAfter_not: BigDecimal
+  variableDebtAfter_gt: BigDecimal
+  variableDebtAfter_lt: BigDecimal
+  variableDebtAfter_gte: BigDecimal
+  variableDebtAfter_lte: BigDecimal
+  variableDebtAfter_in: [BigDecimal!]
+  variableDebtAfter_not_in: [BigDecimal!]
+  stableDebtAfter: BigDecimal
+  stableDebtAfter_not: BigDecimal
+  stableDebtAfter_gt: BigDecimal
+  stableDebtAfter_lt: BigDecimal
+  stableDebtAfter_gte: BigDecimal
+  stableDebtAfter_lte: BigDecimal
+  stableDebtAfter_in: [BigDecimal!]
+  stableDebtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  tokenPriceUSD: BigDecimal
+  tokenPriceUSD_not: BigDecimal
+  tokenPriceUSD_gt: BigDecimal
+  tokenPriceUSD_lt: BigDecimal
+  tokenPriceUSD_gte: BigDecimal
+  tokenPriceUSD_lte: BigDecimal
+  tokenPriceUSD_in: [BigDecimal!]
+  tokenPriceUSD_not_in: [BigDecimal!]
+  token: String
+  token_not: String
+  token_gt: String
+  token_lt: String
+  token_gte: String
+  token_lte: String
+  token_in: [String!]
+  token_not_in: [String!]
+  token_contains: String
+  token_contains_nocase: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  token_: Token_filter
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AaveLikeBorrow_filter]
+  or: [AaveLikeBorrow_filter]
+}
+
+enum AaveLikeBorrow_orderBy {
+  id
+  reserve
+  user
+  onBehalfOf
+  amount
+  borrowRateMode
+  borrowRate
+  referral
+  version
+  protocol
+  variableDebtAfter
+  stableDebtAfter
+  debtDelta
+  tokenPriceUSD
+  token
+  token__id
+  token__address
+  token__symbol
+  token__decimals
+  token__precision
+  txHash
+  blockNumber
+  timestamp
+}
+
+type AaveLikeDeposit {
+  id: ID!
+  reserve: Bytes!
+  user: Bytes!
+  onBehalfOf: Bytes!
+  amount: BigInt!
+  referral: BigInt!
+  version: String
+  protocol: String!
+  collateralAfter: BigDecimal
+  collateralDelta: BigDecimal
+  tokenPriceUSD: BigDecimal
+  token: Token
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input AaveLikeDeposit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  reserve: Bytes
+  reserve_not: Bytes
+  reserve_gt: Bytes
+  reserve_lt: Bytes
+  reserve_gte: Bytes
+  reserve_lte: Bytes
+  reserve_in: [Bytes!]
+  reserve_not_in: [Bytes!]
+  reserve_contains: Bytes
+  reserve_not_contains: Bytes
+  user: Bytes
+  user_not: Bytes
+  user_gt: Bytes
+  user_lt: Bytes
+  user_gte: Bytes
+  user_lte: Bytes
+  user_in: [Bytes!]
+  user_not_in: [Bytes!]
+  user_contains: Bytes
+  user_not_contains: Bytes
+  onBehalfOf: Bytes
+  onBehalfOf_not: Bytes
+  onBehalfOf_gt: Bytes
+  onBehalfOf_lt: Bytes
+  onBehalfOf_gte: Bytes
+  onBehalfOf_lte: Bytes
+  onBehalfOf_in: [Bytes!]
+  onBehalfOf_not_in: [Bytes!]
+  onBehalfOf_contains: Bytes
+  onBehalfOf_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  referral: BigInt
+  referral_not: BigInt
+  referral_gt: BigInt
+  referral_lt: BigInt
+  referral_gte: BigInt
+  referral_lte: BigInt
+  referral_in: [BigInt!]
+  referral_not_in: [BigInt!]
+  version: String
+  version_not: String
+  version_gt: String
+  version_lt: String
+  version_gte: String
+  version_lte: String
+  version_in: [String!]
+  version_not_in: [String!]
+  version_contains: String
+  version_contains_nocase: String
+  version_not_contains: String
+  version_not_contains_nocase: String
+  version_starts_with: String
+  version_starts_with_nocase: String
+  version_not_starts_with: String
+  version_not_starts_with_nocase: String
+  version_ends_with: String
+  version_ends_with_nocase: String
+  version_not_ends_with: String
+  version_not_ends_with_nocase: String
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  tokenPriceUSD: BigDecimal
+  tokenPriceUSD_not: BigDecimal
+  tokenPriceUSD_gt: BigDecimal
+  tokenPriceUSD_lt: BigDecimal
+  tokenPriceUSD_gte: BigDecimal
+  tokenPriceUSD_lte: BigDecimal
+  tokenPriceUSD_in: [BigDecimal!]
+  tokenPriceUSD_not_in: [BigDecimal!]
+  token: String
+  token_not: String
+  token_gt: String
+  token_lt: String
+  token_gte: String
+  token_lte: String
+  token_in: [String!]
+  token_not_in: [String!]
+  token_contains: String
+  token_contains_nocase: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  token_: Token_filter
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AaveLikeDeposit_filter]
+  or: [AaveLikeDeposit_filter]
+}
+
+enum AaveLikeDeposit_orderBy {
+  id
+  reserve
+  user
+  onBehalfOf
+  amount
+  referral
+  version
+  protocol
+  collateralAfter
+  collateralDelta
+  tokenPriceUSD
+  token
+  token__id
+  token__address
+  token__symbol
+  token__decimals
+  token__precision
+  txHash
+  blockNumber
+  timestamp
+}
+
+type AaveLikeLiquidation {
+  id: ID!
+  collateralAsset: Bytes!
+  debtAsset: Bytes!
+  user: Bytes!
+  debtToCover: BigInt!
+  liquidatedCollateralAmount: BigInt!
+  liquidator: Bytes!
+  receiveAToken: Boolean!
+  version: String
+  protocol: String!
+  collateralAfter: BigDecimal
+  stableDebtAfter: BigDecimal
+  variableDebtAfter: BigDecimal
+  debtTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD: BigDecimal
+  debtDelta: BigDecimal!
+  collateralDelta: BigDecimal!
+  debtToken: Token!
+  collateralToken: Token!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input AaveLikeLiquidation_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  collateralAsset: Bytes
+  collateralAsset_not: Bytes
+  collateralAsset_gt: Bytes
+  collateralAsset_lt: Bytes
+  collateralAsset_gte: Bytes
+  collateralAsset_lte: Bytes
+  collateralAsset_in: [Bytes!]
+  collateralAsset_not_in: [Bytes!]
+  collateralAsset_contains: Bytes
+  collateralAsset_not_contains: Bytes
+  debtAsset: Bytes
+  debtAsset_not: Bytes
+  debtAsset_gt: Bytes
+  debtAsset_lt: Bytes
+  debtAsset_gte: Bytes
+  debtAsset_lte: Bytes
+  debtAsset_in: [Bytes!]
+  debtAsset_not_in: [Bytes!]
+  debtAsset_contains: Bytes
+  debtAsset_not_contains: Bytes
+  user: Bytes
+  user_not: Bytes
+  user_gt: Bytes
+  user_lt: Bytes
+  user_gte: Bytes
+  user_lte: Bytes
+  user_in: [Bytes!]
+  user_not_in: [Bytes!]
+  user_contains: Bytes
+  user_not_contains: Bytes
+  debtToCover: BigInt
+  debtToCover_not: BigInt
+  debtToCover_gt: BigInt
+  debtToCover_lt: BigInt
+  debtToCover_gte: BigInt
+  debtToCover_lte: BigInt
+  debtToCover_in: [BigInt!]
+  debtToCover_not_in: [BigInt!]
+  liquidatedCollateralAmount: BigInt
+  liquidatedCollateralAmount_not: BigInt
+  liquidatedCollateralAmount_gt: BigInt
+  liquidatedCollateralAmount_lt: BigInt
+  liquidatedCollateralAmount_gte: BigInt
+  liquidatedCollateralAmount_lte: BigInt
+  liquidatedCollateralAmount_in: [BigInt!]
+  liquidatedCollateralAmount_not_in: [BigInt!]
+  liquidator: Bytes
+  liquidator_not: Bytes
+  liquidator_gt: Bytes
+  liquidator_lt: Bytes
+  liquidator_gte: Bytes
+  liquidator_lte: Bytes
+  liquidator_in: [Bytes!]
+  liquidator_not_in: [Bytes!]
+  liquidator_contains: Bytes
+  liquidator_not_contains: Bytes
+  receiveAToken: Boolean
+  receiveAToken_not: Boolean
+  receiveAToken_in: [Boolean!]
+  receiveAToken_not_in: [Boolean!]
+  version: String
+  version_not: String
+  version_gt: String
+  version_lt: String
+  version_gte: String
+  version_lte: String
+  version_in: [String!]
+  version_not_in: [String!]
+  version_contains: String
+  version_contains_nocase: String
+  version_not_contains: String
+  version_not_contains_nocase: String
+  version_starts_with: String
+  version_starts_with_nocase: String
+  version_not_starts_with: String
+  version_not_starts_with_nocase: String
+  version_ends_with: String
+  version_ends_with_nocase: String
+  version_not_ends_with: String
+  version_not_ends_with_nocase: String
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  stableDebtAfter: BigDecimal
+  stableDebtAfter_not: BigDecimal
+  stableDebtAfter_gt: BigDecimal
+  stableDebtAfter_lt: BigDecimal
+  stableDebtAfter_gte: BigDecimal
+  stableDebtAfter_lte: BigDecimal
+  stableDebtAfter_in: [BigDecimal!]
+  stableDebtAfter_not_in: [BigDecimal!]
+  variableDebtAfter: BigDecimal
+  variableDebtAfter_not: BigDecimal
+  variableDebtAfter_gt: BigDecimal
+  variableDebtAfter_lt: BigDecimal
+  variableDebtAfter_gte: BigDecimal
+  variableDebtAfter_lte: BigDecimal
+  variableDebtAfter_in: [BigDecimal!]
+  variableDebtAfter_not_in: [BigDecimal!]
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AaveLikeLiquidation_filter]
+  or: [AaveLikeLiquidation_filter]
+}
+
+enum AaveLikeLiquidation_orderBy {
+  id
+  collateralAsset
+  debtAsset
+  user
+  debtToCover
+  liquidatedCollateralAmount
+  liquidator
+  receiveAToken
+  version
+  protocol
+  collateralAfter
+  stableDebtAfter
+  variableDebtAfter
+  debtTokenPriceUSD
+  collateralTokenPriceUSD
+  debtDelta
+  collateralDelta
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__symbol
+  debtToken__decimals
+  debtToken__precision
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__symbol
+  collateralToken__decimals
+  collateralToken__precision
+  txHash
+  blockNumber
+  timestamp
+}
+
+type AaveLikeRepay {
+  id: ID!
+  reserve: Bytes!
+  user: Bytes!
+  repayer: Bytes!
+  amount: BigInt!
+  version: String
+  protocol: String!
+  variableDebtAfter: BigDecimal
+  stableDebtAfter: BigDecimal
+  debtDelta: BigDecimal
+  tokenPriceUSD: BigDecimal
+  token: Token
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input AaveLikeRepay_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  reserve: Bytes
+  reserve_not: Bytes
+  reserve_gt: Bytes
+  reserve_lt: Bytes
+  reserve_gte: Bytes
+  reserve_lte: Bytes
+  reserve_in: [Bytes!]
+  reserve_not_in: [Bytes!]
+  reserve_contains: Bytes
+  reserve_not_contains: Bytes
+  user: Bytes
+  user_not: Bytes
+  user_gt: Bytes
+  user_lt: Bytes
+  user_gte: Bytes
+  user_lte: Bytes
+  user_in: [Bytes!]
+  user_not_in: [Bytes!]
+  user_contains: Bytes
+  user_not_contains: Bytes
+  repayer: Bytes
+  repayer_not: Bytes
+  repayer_gt: Bytes
+  repayer_lt: Bytes
+  repayer_gte: Bytes
+  repayer_lte: Bytes
+  repayer_in: [Bytes!]
+  repayer_not_in: [Bytes!]
+  repayer_contains: Bytes
+  repayer_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  version: String
+  version_not: String
+  version_gt: String
+  version_lt: String
+  version_gte: String
+  version_lte: String
+  version_in: [String!]
+  version_not_in: [String!]
+  version_contains: String
+  version_contains_nocase: String
+  version_not_contains: String
+  version_not_contains_nocase: String
+  version_starts_with: String
+  version_starts_with_nocase: String
+  version_not_starts_with: String
+  version_not_starts_with_nocase: String
+  version_ends_with: String
+  version_ends_with_nocase: String
+  version_not_ends_with: String
+  version_not_ends_with_nocase: String
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  variableDebtAfter: BigDecimal
+  variableDebtAfter_not: BigDecimal
+  variableDebtAfter_gt: BigDecimal
+  variableDebtAfter_lt: BigDecimal
+  variableDebtAfter_gte: BigDecimal
+  variableDebtAfter_lte: BigDecimal
+  variableDebtAfter_in: [BigDecimal!]
+  variableDebtAfter_not_in: [BigDecimal!]
+  stableDebtAfter: BigDecimal
+  stableDebtAfter_not: BigDecimal
+  stableDebtAfter_gt: BigDecimal
+  stableDebtAfter_lt: BigDecimal
+  stableDebtAfter_gte: BigDecimal
+  stableDebtAfter_lte: BigDecimal
+  stableDebtAfter_in: [BigDecimal!]
+  stableDebtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  tokenPriceUSD: BigDecimal
+  tokenPriceUSD_not: BigDecimal
+  tokenPriceUSD_gt: BigDecimal
+  tokenPriceUSD_lt: BigDecimal
+  tokenPriceUSD_gte: BigDecimal
+  tokenPriceUSD_lte: BigDecimal
+  tokenPriceUSD_in: [BigDecimal!]
+  tokenPriceUSD_not_in: [BigDecimal!]
+  token: String
+  token_not: String
+  token_gt: String
+  token_lt: String
+  token_gte: String
+  token_lte: String
+  token_in: [String!]
+  token_not_in: [String!]
+  token_contains: String
+  token_contains_nocase: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  token_: Token_filter
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AaveLikeRepay_filter]
+  or: [AaveLikeRepay_filter]
+}
+
+enum AaveLikeRepay_orderBy {
+  id
+  reserve
+  user
+  repayer
+  amount
+  version
+  protocol
+  variableDebtAfter
+  stableDebtAfter
+  debtDelta
+  tokenPriceUSD
+  token
+  token__id
+  token__address
+  token__symbol
+  token__decimals
+  token__precision
+  txHash
+  blockNumber
+  timestamp
+}
+
+type AaveLikeWithdraw {
+  id: ID!
+  reserve: Bytes!
+  user: Bytes!
+  to: Bytes!
+  amount: BigInt!
+  version: String
+  protocol: String!
+  collateralAfter: BigDecimal
+  collateralDelta: BigDecimal
+  tokenPriceUSD: BigDecimal
+  token: Token
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input AaveLikeWithdraw_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  reserve: Bytes
+  reserve_not: Bytes
+  reserve_gt: Bytes
+  reserve_lt: Bytes
+  reserve_gte: Bytes
+  reserve_lte: Bytes
+  reserve_in: [Bytes!]
+  reserve_not_in: [Bytes!]
+  reserve_contains: Bytes
+  reserve_not_contains: Bytes
+  user: Bytes
+  user_not: Bytes
+  user_gt: Bytes
+  user_lt: Bytes
+  user_gte: Bytes
+  user_lte: Bytes
+  user_in: [Bytes!]
+  user_not_in: [Bytes!]
+  user_contains: Bytes
+  user_not_contains: Bytes
+  to: Bytes
+  to_not: Bytes
+  to_gt: Bytes
+  to_lt: Bytes
+  to_gte: Bytes
+  to_lte: Bytes
+  to_in: [Bytes!]
+  to_not_in: [Bytes!]
+  to_contains: Bytes
+  to_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  version: String
+  version_not: String
+  version_gt: String
+  version_lt: String
+  version_gte: String
+  version_lte: String
+  version_in: [String!]
+  version_not_in: [String!]
+  version_contains: String
+  version_contains_nocase: String
+  version_not_contains: String
+  version_not_contains_nocase: String
+  version_starts_with: String
+  version_starts_with_nocase: String
+  version_not_starts_with: String
+  version_not_starts_with_nocase: String
+  version_ends_with: String
+  version_ends_with_nocase: String
+  version_not_ends_with: String
+  version_not_ends_with_nocase: String
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  tokenPriceUSD: BigDecimal
+  tokenPriceUSD_not: BigDecimal
+  tokenPriceUSD_gt: BigDecimal
+  tokenPriceUSD_lt: BigDecimal
+  tokenPriceUSD_gte: BigDecimal
+  tokenPriceUSD_lte: BigDecimal
+  tokenPriceUSD_in: [BigDecimal!]
+  tokenPriceUSD_not_in: [BigDecimal!]
+  token: String
+  token_not: String
+  token_gt: String
+  token_lt: String
+  token_gte: String
+  token_lte: String
+  token_in: [String!]
+  token_not_in: [String!]
+  token_contains: String
+  token_contains_nocase: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  token_: Token_filter
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AaveLikeWithdraw_filter]
+  or: [AaveLikeWithdraw_filter]
+}
+
+enum AaveLikeWithdraw_orderBy {
+  id
+  reserve
+  user
+  to
+  amount
+  version
+  protocol
+  collateralAfter
+  collateralDelta
+  tokenPriceUSD
+  token
+  token__id
+  token__address
+  token__symbol
+  token__decimals
+  token__precision
+  txHash
+  blockNumber
+  timestamp
+}
+
+type AssetSwap {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: ID!
+  assetIn: Bytes!
+  assetOut: Bytes!
+  amountIn: BigInt!
+  amountOut: BigInt!
+  proxy: Bytes
+}
+
+input AssetSwap_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  assetIn: Bytes
+  assetIn_not: Bytes
+  assetIn_gt: Bytes
+  assetIn_lt: Bytes
+  assetIn_gte: Bytes
+  assetIn_lte: Bytes
+  assetIn_in: [Bytes!]
+  assetIn_not_in: [Bytes!]
+  assetIn_contains: Bytes
+  assetIn_not_contains: Bytes
+  assetOut: Bytes
+  assetOut_not: Bytes
+  assetOut_gt: Bytes
+  assetOut_lt: Bytes
+  assetOut_gte: Bytes
+  assetOut_lte: Bytes
+  assetOut_in: [Bytes!]
+  assetOut_not_in: [Bytes!]
+  assetOut_contains: Bytes
+  assetOut_not_contains: Bytes
+  amountIn: BigInt
+  amountIn_not: BigInt
+  amountIn_gt: BigInt
+  amountIn_lt: BigInt
+  amountIn_gte: BigInt
+  amountIn_lte: BigInt
+  amountIn_in: [BigInt!]
+  amountIn_not_in: [BigInt!]
+  amountOut: BigInt
+  amountOut_not: BigInt
+  amountOut_gt: BigInt
+  amountOut_lt: BigInt
+  amountOut_gte: BigInt
+  amountOut_lte: BigInt
+  amountOut_in: [BigInt!]
+  amountOut_not_in: [BigInt!]
+  proxy: Bytes
+  proxy_not: Bytes
+  proxy_gt: Bytes
+  proxy_lt: Bytes
+  proxy_gte: Bytes
+  proxy_lte: Bytes
+  proxy_in: [Bytes!]
+  proxy_not_in: [Bytes!]
+  proxy_contains: Bytes
+  proxy_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AssetSwap_filter]
+  or: [AssetSwap_filter]
+}
+
+enum AssetSwap_orderBy {
+  id
+  assetIn
+  assetOut
+  amountIn
+  amountOut
+  proxy
+}
+
+scalar BigDecimal
+
+scalar BigInt
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+scalar Bytes
+
+type FeePaid {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: ID!
+  beneficiary: Bytes!
+  amount: BigInt!
+  token: Bytes!
+}
+
+input FeePaid_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  beneficiary: Bytes
+  beneficiary_not: Bytes
+  beneficiary_gt: Bytes
+  beneficiary_lt: Bytes
+  beneficiary_gte: Bytes
+  beneficiary_lte: Bytes
+  beneficiary_in: [Bytes!]
+  beneficiary_not_in: [Bytes!]
+  beneficiary_contains: Bytes
+  beneficiary_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  token: Bytes
+  token_not: Bytes
+  token_gt: Bytes
+  token_lt: Bytes
+  token_gte: Bytes
+  token_lte: Bytes
+  token_in: [Bytes!]
+  token_not_in: [Bytes!]
+  token_contains: Bytes
+  token_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [FeePaid_filter]
+  or: [FeePaid_filter]
+}
+
+enum FeePaid_orderBy {
+  id
+  beneficiary
+  amount
+  token
+}
+
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type Position {
+  id: ID!
+  account: Bytes!
+  collateralAddress: Bytes!
+  debtAddress: Bytes!
+  protocol: String!
+  type: String!
+  fromEvent: Boolean!
+  cumulativeDeposit: BigDecimal
+  cumulativeWithdraw: BigDecimal
+  cumulativeFees: BigDecimal
+  cumulativeDepositUSD: BigDecimal
+  cumulativeDepositInQuoteToken: BigDecimal
+  cumulativeDepositInCollateralToken: BigDecimal
+  cumulativeWithdrawUSD: BigDecimal
+  cumulativeWithdrawInQuoteToken: BigDecimal
+  cumulativeWithdrawInCollateralToken: BigDecimal
+  cumulativeFeesUSD: BigDecimal
+  cumulativeFeesInQuoteToken: BigDecimal
+  cumulativeFeesInCollateralToken: BigDecimal
+  debt: BigDecimal!
+  collateral: BigDecimal!
+  lastEvent: PositionEvent
+  events(skip: Int = 0, first: Int = 100, orderBy: PositionEvent_orderBy, orderDirection: OrderDirection, where: PositionEvent_filter): [PositionEvent!]!
+  proxy: Proxy!
+}
+
+input Position_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  account: Bytes
+  account_not: Bytes
+  account_gt: Bytes
+  account_lt: Bytes
+  account_gte: Bytes
+  account_lte: Bytes
+  account_in: [Bytes!]
+  account_not_in: [Bytes!]
+  account_contains: Bytes
+  account_not_contains: Bytes
+  collateralAddress: Bytes
+  collateralAddress_not: Bytes
+  collateralAddress_gt: Bytes
+  collateralAddress_lt: Bytes
+  collateralAddress_gte: Bytes
+  collateralAddress_lte: Bytes
+  collateralAddress_in: [Bytes!]
+  collateralAddress_not_in: [Bytes!]
+  collateralAddress_contains: Bytes
+  collateralAddress_not_contains: Bytes
+  debtAddress: Bytes
+  debtAddress_not: Bytes
+  debtAddress_gt: Bytes
+  debtAddress_lt: Bytes
+  debtAddress_gte: Bytes
+  debtAddress_lte: Bytes
+  debtAddress_in: [Bytes!]
+  debtAddress_not_in: [Bytes!]
+  debtAddress_contains: Bytes
+  debtAddress_not_contains: Bytes
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  type: String
+  type_not: String
+  type_gt: String
+  type_lt: String
+  type_gte: String
+  type_lte: String
+  type_in: [String!]
+  type_not_in: [String!]
+  type_contains: String
+  type_contains_nocase: String
+  type_not_contains: String
+  type_not_contains_nocase: String
+  type_starts_with: String
+  type_starts_with_nocase: String
+  type_not_starts_with: String
+  type_not_starts_with_nocase: String
+  type_ends_with: String
+  type_ends_with_nocase: String
+  type_not_ends_with: String
+  type_not_ends_with_nocase: String
+  fromEvent: Boolean
+  fromEvent_not: Boolean
+  fromEvent_in: [Boolean!]
+  fromEvent_not_in: [Boolean!]
+  cumulativeDeposit: BigDecimal
+  cumulativeDeposit_not: BigDecimal
+  cumulativeDeposit_gt: BigDecimal
+  cumulativeDeposit_lt: BigDecimal
+  cumulativeDeposit_gte: BigDecimal
+  cumulativeDeposit_lte: BigDecimal
+  cumulativeDeposit_in: [BigDecimal!]
+  cumulativeDeposit_not_in: [BigDecimal!]
+  cumulativeWithdraw: BigDecimal
+  cumulativeWithdraw_not: BigDecimal
+  cumulativeWithdraw_gt: BigDecimal
+  cumulativeWithdraw_lt: BigDecimal
+  cumulativeWithdraw_gte: BigDecimal
+  cumulativeWithdraw_lte: BigDecimal
+  cumulativeWithdraw_in: [BigDecimal!]
+  cumulativeWithdraw_not_in: [BigDecimal!]
+  cumulativeFees: BigDecimal
+  cumulativeFees_not: BigDecimal
+  cumulativeFees_gt: BigDecimal
+  cumulativeFees_lt: BigDecimal
+  cumulativeFees_gte: BigDecimal
+  cumulativeFees_lte: BigDecimal
+  cumulativeFees_in: [BigDecimal!]
+  cumulativeFees_not_in: [BigDecimal!]
+  cumulativeDepositUSD: BigDecimal
+  cumulativeDepositUSD_not: BigDecimal
+  cumulativeDepositUSD_gt: BigDecimal
+  cumulativeDepositUSD_lt: BigDecimal
+  cumulativeDepositUSD_gte: BigDecimal
+  cumulativeDepositUSD_lte: BigDecimal
+  cumulativeDepositUSD_in: [BigDecimal!]
+  cumulativeDepositUSD_not_in: [BigDecimal!]
+  cumulativeDepositInQuoteToken: BigDecimal
+  cumulativeDepositInQuoteToken_not: BigDecimal
+  cumulativeDepositInQuoteToken_gt: BigDecimal
+  cumulativeDepositInQuoteToken_lt: BigDecimal
+  cumulativeDepositInQuoteToken_gte: BigDecimal
+  cumulativeDepositInQuoteToken_lte: BigDecimal
+  cumulativeDepositInQuoteToken_in: [BigDecimal!]
+  cumulativeDepositInQuoteToken_not_in: [BigDecimal!]
+  cumulativeDepositInCollateralToken: BigDecimal
+  cumulativeDepositInCollateralToken_not: BigDecimal
+  cumulativeDepositInCollateralToken_gt: BigDecimal
+  cumulativeDepositInCollateralToken_lt: BigDecimal
+  cumulativeDepositInCollateralToken_gte: BigDecimal
+  cumulativeDepositInCollateralToken_lte: BigDecimal
+  cumulativeDepositInCollateralToken_in: [BigDecimal!]
+  cumulativeDepositInCollateralToken_not_in: [BigDecimal!]
+  cumulativeWithdrawUSD: BigDecimal
+  cumulativeWithdrawUSD_not: BigDecimal
+  cumulativeWithdrawUSD_gt: BigDecimal
+  cumulativeWithdrawUSD_lt: BigDecimal
+  cumulativeWithdrawUSD_gte: BigDecimal
+  cumulativeWithdrawUSD_lte: BigDecimal
+  cumulativeWithdrawUSD_in: [BigDecimal!]
+  cumulativeWithdrawUSD_not_in: [BigDecimal!]
+  cumulativeWithdrawInQuoteToken: BigDecimal
+  cumulativeWithdrawInQuoteToken_not: BigDecimal
+  cumulativeWithdrawInQuoteToken_gt: BigDecimal
+  cumulativeWithdrawInQuoteToken_lt: BigDecimal
+  cumulativeWithdrawInQuoteToken_gte: BigDecimal
+  cumulativeWithdrawInQuoteToken_lte: BigDecimal
+  cumulativeWithdrawInQuoteToken_in: [BigDecimal!]
+  cumulativeWithdrawInQuoteToken_not_in: [BigDecimal!]
+  cumulativeWithdrawInCollateralToken: BigDecimal
+  cumulativeWithdrawInCollateralToken_not: BigDecimal
+  cumulativeWithdrawInCollateralToken_gt: BigDecimal
+  cumulativeWithdrawInCollateralToken_lt: BigDecimal
+  cumulativeWithdrawInCollateralToken_gte: BigDecimal
+  cumulativeWithdrawInCollateralToken_lte: BigDecimal
+  cumulativeWithdrawInCollateralToken_in: [BigDecimal!]
+  cumulativeWithdrawInCollateralToken_not_in: [BigDecimal!]
+  cumulativeFeesUSD: BigDecimal
+  cumulativeFeesUSD_not: BigDecimal
+  cumulativeFeesUSD_gt: BigDecimal
+  cumulativeFeesUSD_lt: BigDecimal
+  cumulativeFeesUSD_gte: BigDecimal
+  cumulativeFeesUSD_lte: BigDecimal
+  cumulativeFeesUSD_in: [BigDecimal!]
+  cumulativeFeesUSD_not_in: [BigDecimal!]
+  cumulativeFeesInQuoteToken: BigDecimal
+  cumulativeFeesInQuoteToken_not: BigDecimal
+  cumulativeFeesInQuoteToken_gt: BigDecimal
+  cumulativeFeesInQuoteToken_lt: BigDecimal
+  cumulativeFeesInQuoteToken_gte: BigDecimal
+  cumulativeFeesInQuoteToken_lte: BigDecimal
+  cumulativeFeesInQuoteToken_in: [BigDecimal!]
+  cumulativeFeesInQuoteToken_not_in: [BigDecimal!]
+  cumulativeFeesInCollateralToken: BigDecimal
+  cumulativeFeesInCollateralToken_not: BigDecimal
+  cumulativeFeesInCollateralToken_gt: BigDecimal
+  cumulativeFeesInCollateralToken_lt: BigDecimal
+  cumulativeFeesInCollateralToken_gte: BigDecimal
+  cumulativeFeesInCollateralToken_lte: BigDecimal
+  cumulativeFeesInCollateralToken_in: [BigDecimal!]
+  cumulativeFeesInCollateralToken_not_in: [BigDecimal!]
+  debt: BigDecimal
+  debt_not: BigDecimal
+  debt_gt: BigDecimal
+  debt_lt: BigDecimal
+  debt_gte: BigDecimal
+  debt_lte: BigDecimal
+  debt_in: [BigDecimal!]
+  debt_not_in: [BigDecimal!]
+  collateral: BigDecimal
+  collateral_not: BigDecimal
+  collateral_gt: BigDecimal
+  collateral_lt: BigDecimal
+  collateral_gte: BigDecimal
+  collateral_lte: BigDecimal
+  collateral_in: [BigDecimal!]
+  collateral_not_in: [BigDecimal!]
+  lastEvent: String
+  lastEvent_not: String
+  lastEvent_gt: String
+  lastEvent_lt: String
+  lastEvent_gte: String
+  lastEvent_lte: String
+  lastEvent_in: [String!]
+  lastEvent_not_in: [String!]
+  lastEvent_contains: String
+  lastEvent_contains_nocase: String
+  lastEvent_not_contains: String
+  lastEvent_not_contains_nocase: String
+  lastEvent_starts_with: String
+  lastEvent_starts_with_nocase: String
+  lastEvent_not_starts_with: String
+  lastEvent_not_starts_with_nocase: String
+  lastEvent_ends_with: String
+  lastEvent_ends_with_nocase: String
+  lastEvent_not_ends_with: String
+  lastEvent_not_ends_with_nocase: String
+  lastEvent_: PositionEvent_filter
+  events_: PositionEvent_filter
+  proxy_: Proxy_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Position_filter]
+  or: [Position_filter]
+}
+
+enum Position_orderBy {
+  id
+  account
+  collateralAddress
+  debtAddress
+  protocol
+  type
+  fromEvent
+  cumulativeDeposit
+  cumulativeWithdraw
+  cumulativeFees
+  cumulativeDepositUSD
+  cumulativeDepositInQuoteToken
+  cumulativeDepositInCollateralToken
+  cumulativeWithdrawUSD
+  cumulativeWithdrawInQuoteToken
+  cumulativeWithdrawInCollateralToken
+  cumulativeFeesUSD
+  cumulativeFeesInQuoteToken
+  cumulativeFeesInCollateralToken
+  debt
+  collateral
+  lastEvent
+  lastEvent__id
+  lastEvent__kind
+  lastEvent__account
+  lastEvent__isAutomation
+  lastEvent__debtAddress
+  lastEvent__debtBefore
+  lastEvent__debtAfter
+  lastEvent__debtDelta
+  lastEvent__debtTokenPriceUSD
+  lastEvent__collateralAddress
+  lastEvent__collateralBefore
+  lastEvent__collateralAfter
+  lastEvent__collateralDelta
+  lastEvent__collateralTokenPriceUSD
+  lastEvent__debtOraclePrice
+  lastEvent__collateralOraclePrice
+  lastEvent__swapFromToken
+  lastEvent__swapToToken
+  lastEvent__swapFromAmount
+  lastEvent__swapToAmount
+  lastEvent__marketPrice
+  lastEvent__depositedUSD
+  lastEvent__withdrawnUSD
+  lastEvent__oasisFeeToken
+  lastEvent__oasisFee
+  lastEvent__oasisFeeUSD
+  lastEvent__summerFeeToken
+  lastEvent__summerFee
+  lastEvent__summerFeeUSD
+  lastEvent__gasUsed
+  lastEvent__gasPrice
+  lastEvent__gasFeeUSD
+  lastEvent__totalFee
+  lastEvent__multipleBefore
+  lastEvent__multipleAfter
+  lastEvent__netValueBefore
+  lastEvent__netValueAfter
+  lastEvent__healthFactorAfter
+  lastEvent__liquidationThreshold
+  lastEvent__ltvBefore
+  lastEvent__ltvAfter
+  lastEvent__liquidationPriceBefore
+  lastEvent__liquidationPriceAfter
+  lastEvent__ethPrice
+  lastEvent__timestamp
+  lastEvent__blockNumber
+  lastEvent__txHash
+  events
+  proxy
+  proxy__id
+  proxy__vaultId
+  proxy__isDPM
+  proxy__owner
+}
+
+type PositionEvent {
+  id: ID!
+  kind: String!
+  account: Bytes!
+  position: Position
+  isAutomation: Boolean
+  trigger: Trigger
+  debtToken: Token
+  debtAddress: Bytes!
+  debtBefore: BigDecimal!
+  debtAfter: BigDecimal!
+  debtDelta: BigDecimal!
+  debtTokenPriceUSD: BigDecimal!
+  collateralToken: Token
+  collateralAddress: Bytes!
+  collateralBefore: BigDecimal!
+  collateralAfter: BigDecimal!
+  collateralDelta: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  debtOraclePrice: BigDecimal!
+  collateralOraclePrice: BigDecimal!
+
+  """
+  First iteration assumes just one
+  swap in an operation
+  
+  """
+  swapFromToken: Bytes
+  swapToToken: Bytes
+  swapFromAmount: BigDecimal
+  swapToAmount: BigDecimal
+  marketPrice: BigDecimal
+  depositTransfers(skip: Int = 0, first: Int = 100, orderBy: Transfer_orderBy, orderDirection: OrderDirection, where: Transfer_filter): [Transfer!]!
+  depositedUSD: BigDecimal
+  withdrawTransfers(skip: Int = 0, first: Int = 100, orderBy: Transfer_orderBy, orderDirection: OrderDirection, where: Transfer_filter): [Transfer!]!
+  withdrawnUSD: BigDecimal
+
+  """
+  Depricated fields prefixed with oasis
+  
+  """
+  oasisFeeToken: Bytes
+  oasisFee: BigDecimal!
+  oasisFeeUSD: BigDecimal!
+  summerFeeToken: Bytes
+  summerFee: BigDecimal!
+  summerFeeUSD: BigDecimal!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  gasFeeUSD: BigDecimal!
+  totalFee: BigDecimal!
+  multipleBefore: BigDecimal
+  multipleAfter: BigDecimal
+  netValueBefore: BigDecimal
+  netValueAfter: BigDecimal
+  healthFactorAfter: BigDecimal!
+  liquidationThreshold: BigDecimal!
+  ltvBefore: BigDecimal
+  ltvAfter: BigDecimal!
+  liquidationPriceBefore: BigDecimal
+  liquidationPriceAfter: BigDecimal
+  ethPrice: BigDecimal!
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  txHash: Bytes!
+  proxy: Proxy!
+}
+
+input PositionEvent_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  account: Bytes
+  account_not: Bytes
+  account_gt: Bytes
+  account_lt: Bytes
+  account_gte: Bytes
+  account_lte: Bytes
+  account_in: [Bytes!]
+  account_not_in: [Bytes!]
+  account_contains: Bytes
+  account_not_contains: Bytes
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: Position_filter
+  isAutomation: Boolean
+  isAutomation_not: Boolean
+  isAutomation_in: [Boolean!]
+  isAutomation_not_in: [Boolean!]
+  trigger: String
+  trigger_not: String
+  trigger_gt: String
+  trigger_lt: String
+  trigger_gte: String
+  trigger_lte: String
+  trigger_in: [String!]
+  trigger_not_in: [String!]
+  trigger_contains: String
+  trigger_contains_nocase: String
+  trigger_not_contains: String
+  trigger_not_contains_nocase: String
+  trigger_starts_with: String
+  trigger_starts_with_nocase: String
+  trigger_not_starts_with: String
+  trigger_not_starts_with_nocase: String
+  trigger_ends_with: String
+  trigger_ends_with_nocase: String
+  trigger_not_ends_with: String
+  trigger_not_ends_with_nocase: String
+  trigger_: Trigger_filter
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  debtAddress: Bytes
+  debtAddress_not: Bytes
+  debtAddress_gt: Bytes
+  debtAddress_lt: Bytes
+  debtAddress_gte: Bytes
+  debtAddress_lte: Bytes
+  debtAddress_in: [Bytes!]
+  debtAddress_not_in: [Bytes!]
+  debtAddress_contains: Bytes
+  debtAddress_not_contains: Bytes
+  debtBefore: BigDecimal
+  debtBefore_not: BigDecimal
+  debtBefore_gt: BigDecimal
+  debtBefore_lt: BigDecimal
+  debtBefore_gte: BigDecimal
+  debtBefore_lte: BigDecimal
+  debtBefore_in: [BigDecimal!]
+  debtBefore_not_in: [BigDecimal!]
+  debtAfter: BigDecimal
+  debtAfter_not: BigDecimal
+  debtAfter_gt: BigDecimal
+  debtAfter_lt: BigDecimal
+  debtAfter_gte: BigDecimal
+  debtAfter_lte: BigDecimal
+  debtAfter_in: [BigDecimal!]
+  debtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  collateralAddress: Bytes
+  collateralAddress_not: Bytes
+  collateralAddress_gt: Bytes
+  collateralAddress_lt: Bytes
+  collateralAddress_gte: Bytes
+  collateralAddress_lte: Bytes
+  collateralAddress_in: [Bytes!]
+  collateralAddress_not_in: [Bytes!]
+  collateralAddress_contains: Bytes
+  collateralAddress_not_contains: Bytes
+  collateralBefore: BigDecimal
+  collateralBefore_not: BigDecimal
+  collateralBefore_gt: BigDecimal
+  collateralBefore_lt: BigDecimal
+  collateralBefore_gte: BigDecimal
+  collateralBefore_lte: BigDecimal
+  collateralBefore_in: [BigDecimal!]
+  collateralBefore_not_in: [BigDecimal!]
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  debtOraclePrice: BigDecimal
+  debtOraclePrice_not: BigDecimal
+  debtOraclePrice_gt: BigDecimal
+  debtOraclePrice_lt: BigDecimal
+  debtOraclePrice_gte: BigDecimal
+  debtOraclePrice_lte: BigDecimal
+  debtOraclePrice_in: [BigDecimal!]
+  debtOraclePrice_not_in: [BigDecimal!]
+  collateralOraclePrice: BigDecimal
+  collateralOraclePrice_not: BigDecimal
+  collateralOraclePrice_gt: BigDecimal
+  collateralOraclePrice_lt: BigDecimal
+  collateralOraclePrice_gte: BigDecimal
+  collateralOraclePrice_lte: BigDecimal
+  collateralOraclePrice_in: [BigDecimal!]
+  collateralOraclePrice_not_in: [BigDecimal!]
+  swapFromToken: Bytes
+  swapFromToken_not: Bytes
+  swapFromToken_gt: Bytes
+  swapFromToken_lt: Bytes
+  swapFromToken_gte: Bytes
+  swapFromToken_lte: Bytes
+  swapFromToken_in: [Bytes!]
+  swapFromToken_not_in: [Bytes!]
+  swapFromToken_contains: Bytes
+  swapFromToken_not_contains: Bytes
+  swapToToken: Bytes
+  swapToToken_not: Bytes
+  swapToToken_gt: Bytes
+  swapToToken_lt: Bytes
+  swapToToken_gte: Bytes
+  swapToToken_lte: Bytes
+  swapToToken_in: [Bytes!]
+  swapToToken_not_in: [Bytes!]
+  swapToToken_contains: Bytes
+  swapToToken_not_contains: Bytes
+  swapFromAmount: BigDecimal
+  swapFromAmount_not: BigDecimal
+  swapFromAmount_gt: BigDecimal
+  swapFromAmount_lt: BigDecimal
+  swapFromAmount_gte: BigDecimal
+  swapFromAmount_lte: BigDecimal
+  swapFromAmount_in: [BigDecimal!]
+  swapFromAmount_not_in: [BigDecimal!]
+  swapToAmount: BigDecimal
+  swapToAmount_not: BigDecimal
+  swapToAmount_gt: BigDecimal
+  swapToAmount_lt: BigDecimal
+  swapToAmount_gte: BigDecimal
+  swapToAmount_lte: BigDecimal
+  swapToAmount_in: [BigDecimal!]
+  swapToAmount_not_in: [BigDecimal!]
+  marketPrice: BigDecimal
+  marketPrice_not: BigDecimal
+  marketPrice_gt: BigDecimal
+  marketPrice_lt: BigDecimal
+  marketPrice_gte: BigDecimal
+  marketPrice_lte: BigDecimal
+  marketPrice_in: [BigDecimal!]
+  marketPrice_not_in: [BigDecimal!]
+  depositTransfers: [String!]
+  depositTransfers_not: [String!]
+  depositTransfers_contains: [String!]
+  depositTransfers_contains_nocase: [String!]
+  depositTransfers_not_contains: [String!]
+  depositTransfers_not_contains_nocase: [String!]
+  depositTransfers_: Transfer_filter
+  depositedUSD: BigDecimal
+  depositedUSD_not: BigDecimal
+  depositedUSD_gt: BigDecimal
+  depositedUSD_lt: BigDecimal
+  depositedUSD_gte: BigDecimal
+  depositedUSD_lte: BigDecimal
+  depositedUSD_in: [BigDecimal!]
+  depositedUSD_not_in: [BigDecimal!]
+  withdrawTransfers: [String!]
+  withdrawTransfers_not: [String!]
+  withdrawTransfers_contains: [String!]
+  withdrawTransfers_contains_nocase: [String!]
+  withdrawTransfers_not_contains: [String!]
+  withdrawTransfers_not_contains_nocase: [String!]
+  withdrawTransfers_: Transfer_filter
+  withdrawnUSD: BigDecimal
+  withdrawnUSD_not: BigDecimal
+  withdrawnUSD_gt: BigDecimal
+  withdrawnUSD_lt: BigDecimal
+  withdrawnUSD_gte: BigDecimal
+  withdrawnUSD_lte: BigDecimal
+  withdrawnUSD_in: [BigDecimal!]
+  withdrawnUSD_not_in: [BigDecimal!]
+  oasisFeeToken: Bytes
+  oasisFeeToken_not: Bytes
+  oasisFeeToken_gt: Bytes
+  oasisFeeToken_lt: Bytes
+  oasisFeeToken_gte: Bytes
+  oasisFeeToken_lte: Bytes
+  oasisFeeToken_in: [Bytes!]
+  oasisFeeToken_not_in: [Bytes!]
+  oasisFeeToken_contains: Bytes
+  oasisFeeToken_not_contains: Bytes
+  oasisFee: BigDecimal
+  oasisFee_not: BigDecimal
+  oasisFee_gt: BigDecimal
+  oasisFee_lt: BigDecimal
+  oasisFee_gte: BigDecimal
+  oasisFee_lte: BigDecimal
+  oasisFee_in: [BigDecimal!]
+  oasisFee_not_in: [BigDecimal!]
+  oasisFeeUSD: BigDecimal
+  oasisFeeUSD_not: BigDecimal
+  oasisFeeUSD_gt: BigDecimal
+  oasisFeeUSD_lt: BigDecimal
+  oasisFeeUSD_gte: BigDecimal
+  oasisFeeUSD_lte: BigDecimal
+  oasisFeeUSD_in: [BigDecimal!]
+  oasisFeeUSD_not_in: [BigDecimal!]
+  summerFeeToken: Bytes
+  summerFeeToken_not: Bytes
+  summerFeeToken_gt: Bytes
+  summerFeeToken_lt: Bytes
+  summerFeeToken_gte: Bytes
+  summerFeeToken_lte: Bytes
+  summerFeeToken_in: [Bytes!]
+  summerFeeToken_not_in: [Bytes!]
+  summerFeeToken_contains: Bytes
+  summerFeeToken_not_contains: Bytes
+  summerFee: BigDecimal
+  summerFee_not: BigDecimal
+  summerFee_gt: BigDecimal
+  summerFee_lt: BigDecimal
+  summerFee_gte: BigDecimal
+  summerFee_lte: BigDecimal
+  summerFee_in: [BigDecimal!]
+  summerFee_not_in: [BigDecimal!]
+  summerFeeUSD: BigDecimal
+  summerFeeUSD_not: BigDecimal
+  summerFeeUSD_gt: BigDecimal
+  summerFeeUSD_lt: BigDecimal
+  summerFeeUSD_gte: BigDecimal
+  summerFeeUSD_lte: BigDecimal
+  summerFeeUSD_in: [BigDecimal!]
+  summerFeeUSD_not_in: [BigDecimal!]
+  gasUsed: BigInt
+  gasUsed_not: BigInt
+  gasUsed_gt: BigInt
+  gasUsed_lt: BigInt
+  gasUsed_gte: BigInt
+  gasUsed_lte: BigInt
+  gasUsed_in: [BigInt!]
+  gasUsed_not_in: [BigInt!]
+  gasPrice: BigInt
+  gasPrice_not: BigInt
+  gasPrice_gt: BigInt
+  gasPrice_lt: BigInt
+  gasPrice_gte: BigInt
+  gasPrice_lte: BigInt
+  gasPrice_in: [BigInt!]
+  gasPrice_not_in: [BigInt!]
+  gasFeeUSD: BigDecimal
+  gasFeeUSD_not: BigDecimal
+  gasFeeUSD_gt: BigDecimal
+  gasFeeUSD_lt: BigDecimal
+  gasFeeUSD_gte: BigDecimal
+  gasFeeUSD_lte: BigDecimal
+  gasFeeUSD_in: [BigDecimal!]
+  gasFeeUSD_not_in: [BigDecimal!]
+  totalFee: BigDecimal
+  totalFee_not: BigDecimal
+  totalFee_gt: BigDecimal
+  totalFee_lt: BigDecimal
+  totalFee_gte: BigDecimal
+  totalFee_lte: BigDecimal
+  totalFee_in: [BigDecimal!]
+  totalFee_not_in: [BigDecimal!]
+  multipleBefore: BigDecimal
+  multipleBefore_not: BigDecimal
+  multipleBefore_gt: BigDecimal
+  multipleBefore_lt: BigDecimal
+  multipleBefore_gte: BigDecimal
+  multipleBefore_lte: BigDecimal
+  multipleBefore_in: [BigDecimal!]
+  multipleBefore_not_in: [BigDecimal!]
+  multipleAfter: BigDecimal
+  multipleAfter_not: BigDecimal
+  multipleAfter_gt: BigDecimal
+  multipleAfter_lt: BigDecimal
+  multipleAfter_gte: BigDecimal
+  multipleAfter_lte: BigDecimal
+  multipleAfter_in: [BigDecimal!]
+  multipleAfter_not_in: [BigDecimal!]
+  netValueBefore: BigDecimal
+  netValueBefore_not: BigDecimal
+  netValueBefore_gt: BigDecimal
+  netValueBefore_lt: BigDecimal
+  netValueBefore_gte: BigDecimal
+  netValueBefore_lte: BigDecimal
+  netValueBefore_in: [BigDecimal!]
+  netValueBefore_not_in: [BigDecimal!]
+  netValueAfter: BigDecimal
+  netValueAfter_not: BigDecimal
+  netValueAfter_gt: BigDecimal
+  netValueAfter_lt: BigDecimal
+  netValueAfter_gte: BigDecimal
+  netValueAfter_lte: BigDecimal
+  netValueAfter_in: [BigDecimal!]
+  netValueAfter_not_in: [BigDecimal!]
+  healthFactorAfter: BigDecimal
+  healthFactorAfter_not: BigDecimal
+  healthFactorAfter_gt: BigDecimal
+  healthFactorAfter_lt: BigDecimal
+  healthFactorAfter_gte: BigDecimal
+  healthFactorAfter_lte: BigDecimal
+  healthFactorAfter_in: [BigDecimal!]
+  healthFactorAfter_not_in: [BigDecimal!]
+  liquidationThreshold: BigDecimal
+  liquidationThreshold_not: BigDecimal
+  liquidationThreshold_gt: BigDecimal
+  liquidationThreshold_lt: BigDecimal
+  liquidationThreshold_gte: BigDecimal
+  liquidationThreshold_lte: BigDecimal
+  liquidationThreshold_in: [BigDecimal!]
+  liquidationThreshold_not_in: [BigDecimal!]
+  ltvBefore: BigDecimal
+  ltvBefore_not: BigDecimal
+  ltvBefore_gt: BigDecimal
+  ltvBefore_lt: BigDecimal
+  ltvBefore_gte: BigDecimal
+  ltvBefore_lte: BigDecimal
+  ltvBefore_in: [BigDecimal!]
+  ltvBefore_not_in: [BigDecimal!]
+  ltvAfter: BigDecimal
+  ltvAfter_not: BigDecimal
+  ltvAfter_gt: BigDecimal
+  ltvAfter_lt: BigDecimal
+  ltvAfter_gte: BigDecimal
+  ltvAfter_lte: BigDecimal
+  ltvAfter_in: [BigDecimal!]
+  ltvAfter_not_in: [BigDecimal!]
+  liquidationPriceBefore: BigDecimal
+  liquidationPriceBefore_not: BigDecimal
+  liquidationPriceBefore_gt: BigDecimal
+  liquidationPriceBefore_lt: BigDecimal
+  liquidationPriceBefore_gte: BigDecimal
+  liquidationPriceBefore_lte: BigDecimal
+  liquidationPriceBefore_in: [BigDecimal!]
+  liquidationPriceBefore_not_in: [BigDecimal!]
+  liquidationPriceAfter: BigDecimal
+  liquidationPriceAfter_not: BigDecimal
+  liquidationPriceAfter_gt: BigDecimal
+  liquidationPriceAfter_lt: BigDecimal
+  liquidationPriceAfter_gte: BigDecimal
+  liquidationPriceAfter_lte: BigDecimal
+  liquidationPriceAfter_in: [BigDecimal!]
+  liquidationPriceAfter_not_in: [BigDecimal!]
+  ethPrice: BigDecimal
+  ethPrice_not: BigDecimal
+  ethPrice_gt: BigDecimal
+  ethPrice_lt: BigDecimal
+  ethPrice_gte: BigDecimal
+  ethPrice_lte: BigDecimal
+  ethPrice_in: [BigDecimal!]
+  ethPrice_not_in: [BigDecimal!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  proxy: String
+  proxy_not: String
+  proxy_gt: String
+  proxy_lt: String
+  proxy_gte: String
+  proxy_lte: String
+  proxy_in: [String!]
+  proxy_not_in: [String!]
+  proxy_contains: String
+  proxy_contains_nocase: String
+  proxy_not_contains: String
+  proxy_not_contains_nocase: String
+  proxy_starts_with: String
+  proxy_starts_with_nocase: String
+  proxy_not_starts_with: String
+  proxy_not_starts_with_nocase: String
+  proxy_ends_with: String
+  proxy_ends_with_nocase: String
+  proxy_not_ends_with: String
+  proxy_not_ends_with_nocase: String
+  proxy_: Proxy_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [PositionEvent_filter]
+  or: [PositionEvent_filter]
+}
+
+enum PositionEvent_orderBy {
+  id
+  kind
+  account
+  position
+  position__id
+  position__account
+  position__collateralAddress
+  position__debtAddress
+  position__protocol
+  position__type
+  position__fromEvent
+  position__cumulativeDeposit
+  position__cumulativeWithdraw
+  position__cumulativeFees
+  position__cumulativeDepositUSD
+  position__cumulativeDepositInQuoteToken
+  position__cumulativeDepositInCollateralToken
+  position__cumulativeWithdrawUSD
+  position__cumulativeWithdrawInQuoteToken
+  position__cumulativeWithdrawInCollateralToken
+  position__cumulativeFeesUSD
+  position__cumulativeFeesInQuoteToken
+  position__cumulativeFeesInCollateralToken
+  position__debt
+  position__collateral
+  isAutomation
+  trigger
+  trigger__id
+  trigger__commandAddress
+  trigger__triggerType
+  trigger__kind
+  trigger__triggerData
+  trigger__addedBlock
+  trigger__addedTransaction
+  trigger__addedLogIndex
+  trigger__addedTimestamp
+  trigger__removedBlock
+  trigger__removedTransaction
+  trigger__removedLogIndex
+  trigger__removedTimestamp
+  trigger__executedBlock
+  trigger__executedTransaction
+  trigger__executedLogIndex
+  trigger__executedTimestamp
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__symbol
+  debtToken__decimals
+  debtToken__precision
+  debtAddress
+  debtBefore
+  debtAfter
+  debtDelta
+  debtTokenPriceUSD
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__symbol
+  collateralToken__decimals
+  collateralToken__precision
+  collateralAddress
+  collateralBefore
+  collateralAfter
+  collateralDelta
+  collateralTokenPriceUSD
+  debtOraclePrice
+  collateralOraclePrice
+  swapFromToken
+  swapToToken
+  swapFromAmount
+  swapToAmount
+  marketPrice
+  depositTransfers
+  depositedUSD
+  withdrawTransfers
+  withdrawnUSD
+  oasisFeeToken
+  oasisFee
+  oasisFeeUSD
+  summerFeeToken
+  summerFee
+  summerFeeUSD
+  gasUsed
+  gasPrice
+  gasFeeUSD
+  totalFee
+  multipleBefore
+  multipleAfter
+  netValueBefore
+  netValueAfter
+  healthFactorAfter
+  liquidationThreshold
+  ltvBefore
+  ltvAfter
+  liquidationPriceBefore
+  liquidationPriceAfter
+  ethPrice
+  timestamp
+  blockNumber
+  txHash
+  proxy
+  proxy__id
+  proxy__vaultId
+  proxy__isDPM
+  proxy__owner
+}
+
+type Proxy {
+  """
+  Address of DPM or DS proxy
+  
+  """
+  id: ID!
+  vaultId: BigInt
+  isDPM: Boolean!
+  owner: Bytes!
+  position: Position
+  triggers(skip: Int = 0, first: Int = 100, orderBy: Trigger_orderBy, orderDirection: OrderDirection, where: Trigger_filter): [Trigger!]!
+}
+
+input Proxy_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  vaultId: BigInt
+  vaultId_not: BigInt
+  vaultId_gt: BigInt
+  vaultId_lt: BigInt
+  vaultId_gte: BigInt
+  vaultId_lte: BigInt
+  vaultId_in: [BigInt!]
+  vaultId_not_in: [BigInt!]
+  isDPM: Boolean
+  isDPM_not: Boolean
+  isDPM_in: [Boolean!]
+  isDPM_not_in: [Boolean!]
+  owner: Bytes
+  owner_not: Bytes
+  owner_gt: Bytes
+  owner_lt: Bytes
+  owner_gte: Bytes
+  owner_lte: Bytes
+  owner_in: [Bytes!]
+  owner_not_in: [Bytes!]
+  owner_contains: Bytes
+  owner_not_contains: Bytes
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: Position_filter
+  triggers_: Trigger_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Proxy_filter]
+  or: [Proxy_filter]
+}
+
+enum Proxy_orderBy {
+  id
+  vaultId
+  isDPM
+  owner
+  position
+  position__id
+  position__account
+  position__collateralAddress
+  position__debtAddress
+  position__protocol
+  position__type
+  position__fromEvent
+  position__cumulativeDeposit
+  position__cumulativeWithdraw
+  position__cumulativeFees
+  position__cumulativeDepositUSD
+  position__cumulativeDepositInQuoteToken
+  position__cumulativeDepositInCollateralToken
+  position__cumulativeWithdrawUSD
+  position__cumulativeWithdrawInQuoteToken
+  position__cumulativeWithdrawInCollateralToken
+  position__cumulativeFeesUSD
+  position__cumulativeFeesInQuoteToken
+  position__cumulativeFeesInCollateralToken
+  position__debt
+  position__collateral
+  triggers
+}
+
+type Query {
+  assetSwap(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AssetSwap
+  assetSwaps(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AssetSwap_orderBy
+    orderDirection: OrderDirection
+    where: AssetSwap_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AssetSwap!]!
+  slippageSaved(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SlippageSaved
+  slippageSaveds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SlippageSaved_orderBy
+    orderDirection: OrderDirection
+    where: SlippageSaved_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SlippageSaved!]!
+  feePaid(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FeePaid
+  feePaids(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: FeePaid_orderBy
+    orderDirection: OrderDirection
+    where: FeePaid_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [FeePaid!]!
+  proxy(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Proxy
+  proxies(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Proxy_orderBy
+    orderDirection: OrderDirection
+    where: Proxy_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Proxy!]!
+  token(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  position(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Position
+  positions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Position_orderBy
+    orderDirection: OrderDirection
+    where: Position_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Position!]!
+  positionEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PositionEvent
+  positionEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PositionEvent_orderBy
+    orderDirection: OrderDirection
+    where: PositionEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PositionEvent!]!
+  transfer(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    where: Transfer_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Transfer!]!
+  registeredOperation(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegisteredOperation
+  registeredOperations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: RegisteredOperation_orderBy
+    orderDirection: OrderDirection
+    where: RegisteredOperation_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [RegisteredOperation!]!
+  aaveLikeDeposit(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeDeposit
+  aaveLikeDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeDeposit_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeDeposit_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeDeposit!]!
+  aaveLikeWithdraw(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeWithdraw
+  aaveLikeWithdraws(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeWithdraw_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeWithdraw_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeWithdraw!]!
+  aaveLikeBorrow(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeBorrow
+  aaveLikeBorrows(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeBorrow_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeBorrow_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeBorrow!]!
+  aaveLikeRepay(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeRepay
+  aaveLikeRepays(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeRepay_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeRepay_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeRepay!]!
+  aaveLikeLiquidation(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeLiquidation
+  aaveLikeLiquidations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeLiquidation_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeLiquidation_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeLiquidation!]!
+  trigger(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Trigger
+  triggers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Trigger_orderBy
+    orderDirection: OrderDirection
+    where: Trigger_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Trigger!]!
+
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type RegisteredOperation {
+  id: ID!
+  name: String!
+  actions: [Bytes!]!
+  skipped: [Boolean!]!
+}
+
+input RegisteredOperation_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  name: String
+  name_not: String
+  name_gt: String
+  name_lt: String
+  name_gte: String
+  name_lte: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_contains: String
+  name_contains_nocase: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  actions: [Bytes!]
+  actions_not: [Bytes!]
+  actions_contains: [Bytes!]
+  actions_contains_nocase: [Bytes!]
+  actions_not_contains: [Bytes!]
+  actions_not_contains_nocase: [Bytes!]
+  skipped: [Boolean!]
+  skipped_not: [Boolean!]
+  skipped_contains: [Boolean!]
+  skipped_contains_nocase: [Boolean!]
+  skipped_not_contains: [Boolean!]
+  skipped_not_contains_nocase: [Boolean!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [RegisteredOperation_filter]
+  or: [RegisteredOperation_filter]
+}
+
+enum RegisteredOperation_orderBy {
+  id
+  name
+  actions
+  skipped
+}
+
+type SlippageSaved {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: ID!
+  minimumPossible: BigInt!
+  actualAmount: BigInt!
+}
+
+input SlippageSaved_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  minimumPossible: BigInt
+  minimumPossible_not: BigInt
+  minimumPossible_gt: BigInt
+  minimumPossible_lt: BigInt
+  minimumPossible_gte: BigInt
+  minimumPossible_lte: BigInt
+  minimumPossible_in: [BigInt!]
+  minimumPossible_not_in: [BigInt!]
+  actualAmount: BigInt
+  actualAmount_not: BigInt
+  actualAmount_gt: BigInt
+  actualAmount_lt: BigInt
+  actualAmount_gte: BigInt
+  actualAmount_lte: BigInt
+  actualAmount_in: [BigInt!]
+  actualAmount_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [SlippageSaved_filter]
+  or: [SlippageSaved_filter]
+}
+
+enum SlippageSaved_orderBy {
+  id
+  minimumPossible
+  actualAmount
+}
+
+type Subscription {
+  assetSwap(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AssetSwap
+  assetSwaps(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AssetSwap_orderBy
+    orderDirection: OrderDirection
+    where: AssetSwap_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AssetSwap!]!
+  slippageSaved(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SlippageSaved
+  slippageSaveds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SlippageSaved_orderBy
+    orderDirection: OrderDirection
+    where: SlippageSaved_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SlippageSaved!]!
+  feePaid(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FeePaid
+  feePaids(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: FeePaid_orderBy
+    orderDirection: OrderDirection
+    where: FeePaid_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [FeePaid!]!
+  proxy(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Proxy
+  proxies(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Proxy_orderBy
+    orderDirection: OrderDirection
+    where: Proxy_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Proxy!]!
+  token(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  position(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Position
+  positions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Position_orderBy
+    orderDirection: OrderDirection
+    where: Position_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Position!]!
+  positionEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PositionEvent
+  positionEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: PositionEvent_orderBy
+    orderDirection: OrderDirection
+    where: PositionEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PositionEvent!]!
+  transfer(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    where: Transfer_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Transfer!]!
+  registeredOperation(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegisteredOperation
+  registeredOperations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: RegisteredOperation_orderBy
+    orderDirection: OrderDirection
+    where: RegisteredOperation_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [RegisteredOperation!]!
+  aaveLikeDeposit(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeDeposit
+  aaveLikeDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeDeposit_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeDeposit_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeDeposit!]!
+  aaveLikeWithdraw(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeWithdraw
+  aaveLikeWithdraws(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeWithdraw_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeWithdraw_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeWithdraw!]!
+  aaveLikeBorrow(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeBorrow
+  aaveLikeBorrows(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeBorrow_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeBorrow_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeBorrow!]!
+  aaveLikeRepay(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeRepay
+  aaveLikeRepays(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeRepay_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeRepay_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeRepay!]!
+  aaveLikeLiquidation(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AaveLikeLiquidation
+  aaveLikeLiquidations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AaveLikeLiquidation_orderBy
+    orderDirection: OrderDirection
+    where: AaveLikeLiquidation_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AaveLikeLiquidation!]!
+  trigger(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Trigger
+  triggers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Trigger_orderBy
+    orderDirection: OrderDirection
+    where: Trigger_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Trigger!]!
+
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type Token {
+  id: ID!
+  address: Bytes!
+  symbol: String!
+  decimals: BigInt!
+  precision: String!
+}
+
+input Token_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  symbol: String
+  symbol_not: String
+  symbol_gt: String
+  symbol_lt: String
+  symbol_gte: String
+  symbol_lte: String
+  symbol_in: [String!]
+  symbol_not_in: [String!]
+  symbol_contains: String
+  symbol_contains_nocase: String
+  symbol_not_contains: String
+  symbol_not_contains_nocase: String
+  symbol_starts_with: String
+  symbol_starts_with_nocase: String
+  symbol_not_starts_with: String
+  symbol_not_starts_with_nocase: String
+  symbol_ends_with: String
+  symbol_ends_with_nocase: String
+  symbol_not_ends_with: String
+  symbol_not_ends_with_nocase: String
+  decimals: BigInt
+  decimals_not: BigInt
+  decimals_gt: BigInt
+  decimals_lt: BigInt
+  decimals_gte: BigInt
+  decimals_lte: BigInt
+  decimals_in: [BigInt!]
+  decimals_not_in: [BigInt!]
+  precision: String
+  precision_not: String
+  precision_gt: String
+  precision_lt: String
+  precision_gte: String
+  precision_lte: String
+  precision_in: [String!]
+  precision_not_in: [String!]
+  precision_contains: String
+  precision_contains_nocase: String
+  precision_not_contains: String
+  precision_not_contains_nocase: String
+  precision_starts_with: String
+  precision_starts_with_nocase: String
+  precision_not_starts_with: String
+  precision_not_starts_with_nocase: String
+  precision_ends_with: String
+  precision_ends_with_nocase: String
+  precision_not_ends_with: String
+  precision_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Token_filter]
+  or: [Token_filter]
+}
+
+enum Token_orderBy {
+  id
+  address
+  symbol
+  decimals
+  precision
+}
+
+type Transfer {
+  id: ID!
+  event: PositionEvent!
+  from: Bytes!
+  to: Bytes!
+  token: Bytes!
+  amount: BigDecimal!
+  priceInUSD: BigDecimal!
+  amountUSD: BigDecimal!
+  txHash: String!
+}
+
+input Transfer_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  event: String
+  event_not: String
+  event_gt: String
+  event_lt: String
+  event_gte: String
+  event_lte: String
+  event_in: [String!]
+  event_not_in: [String!]
+  event_contains: String
+  event_contains_nocase: String
+  event_not_contains: String
+  event_not_contains_nocase: String
+  event_starts_with: String
+  event_starts_with_nocase: String
+  event_not_starts_with: String
+  event_not_starts_with_nocase: String
+  event_ends_with: String
+  event_ends_with_nocase: String
+  event_not_ends_with: String
+  event_not_ends_with_nocase: String
+  event_: PositionEvent_filter
+  from: Bytes
+  from_not: Bytes
+  from_gt: Bytes
+  from_lt: Bytes
+  from_gte: Bytes
+  from_lte: Bytes
+  from_in: [Bytes!]
+  from_not_in: [Bytes!]
+  from_contains: Bytes
+  from_not_contains: Bytes
+  to: Bytes
+  to_not: Bytes
+  to_gt: Bytes
+  to_lt: Bytes
+  to_gte: Bytes
+  to_lte: Bytes
+  to_in: [Bytes!]
+  to_not_in: [Bytes!]
+  to_contains: Bytes
+  to_not_contains: Bytes
+  token: Bytes
+  token_not: Bytes
+  token_gt: Bytes
+  token_lt: Bytes
+  token_gte: Bytes
+  token_lte: Bytes
+  token_in: [Bytes!]
+  token_not_in: [Bytes!]
+  token_contains: Bytes
+  token_not_contains: Bytes
+  amount: BigDecimal
+  amount_not: BigDecimal
+  amount_gt: BigDecimal
+  amount_lt: BigDecimal
+  amount_gte: BigDecimal
+  amount_lte: BigDecimal
+  amount_in: [BigDecimal!]
+  amount_not_in: [BigDecimal!]
+  priceInUSD: BigDecimal
+  priceInUSD_not: BigDecimal
+  priceInUSD_gt: BigDecimal
+  priceInUSD_lt: BigDecimal
+  priceInUSD_gte: BigDecimal
+  priceInUSD_lte: BigDecimal
+  priceInUSD_in: [BigDecimal!]
+  priceInUSD_not_in: [BigDecimal!]
+  amountUSD: BigDecimal
+  amountUSD_not: BigDecimal
+  amountUSD_gt: BigDecimal
+  amountUSD_lt: BigDecimal
+  amountUSD_gte: BigDecimal
+  amountUSD_lte: BigDecimal
+  amountUSD_in: [BigDecimal!]
+  amountUSD_not_in: [BigDecimal!]
+  txHash: String
+  txHash_not: String
+  txHash_gt: String
+  txHash_lt: String
+  txHash_gte: String
+  txHash_lte: String
+  txHash_in: [String!]
+  txHash_not_in: [String!]
+  txHash_contains: String
+  txHash_contains_nocase: String
+  txHash_not_contains: String
+  txHash_not_contains_nocase: String
+  txHash_starts_with: String
+  txHash_starts_with_nocase: String
+  txHash_not_starts_with: String
+  txHash_not_starts_with_nocase: String
+  txHash_ends_with: String
+  txHash_ends_with_nocase: String
+  txHash_not_ends_with: String
+  txHash_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Transfer_filter]
+  or: [Transfer_filter]
+}
+
+enum Transfer_orderBy {
+  id
+  event
+  event__id
+  event__kind
+  event__account
+  event__isAutomation
+  event__debtAddress
+  event__debtBefore
+  event__debtAfter
+  event__debtDelta
+  event__debtTokenPriceUSD
+  event__collateralAddress
+  event__collateralBefore
+  event__collateralAfter
+  event__collateralDelta
+  event__collateralTokenPriceUSD
+  event__debtOraclePrice
+  event__collateralOraclePrice
+  event__swapFromToken
+  event__swapToToken
+  event__swapFromAmount
+  event__swapToAmount
+  event__marketPrice
+  event__depositedUSD
+  event__withdrawnUSD
+  event__oasisFeeToken
+  event__oasisFee
+  event__oasisFeeUSD
+  event__summerFeeToken
+  event__summerFee
+  event__summerFeeUSD
+  event__gasUsed
+  event__gasPrice
+  event__gasFeeUSD
+  event__totalFee
+  event__multipleBefore
+  event__multipleAfter
+  event__netValueBefore
+  event__netValueAfter
+  event__healthFactorAfter
+  event__liquidationThreshold
+  event__ltvBefore
+  event__ltvAfter
+  event__liquidationPriceBefore
+  event__liquidationPriceAfter
+  event__ethPrice
+  event__timestamp
+  event__blockNumber
+  event__txHash
+  from
+  to
+  token
+  amount
+  priceInUSD
+  amountUSD
+  txHash
+}
+
+type Trigger {
+  id: ID!
+  account: Proxy!
+  commandAddress: Bytes!
+  triggerType: BigInt!
+  kind: String!
+  triggerData: Bytes!
+  decodedData: [String!]
+  decodedDataNames: [String!]
+  addedBlock: BigInt!
+  addedTransaction: Bytes!
+  addedLogIndex: BigInt!
+  addedTimestamp: BigInt!
+  removedBlock: BigInt
+  removedTransaction: Bytes
+  removedLogIndex: BigInt
+  removedTimestamp: BigInt
+  executedBlock: BigInt
+  executedTransaction: Bytes
+  executedLogIndex: BigInt
+  executedTimestamp: BigInt
+}
+
+input Trigger_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Proxy_filter
+  commandAddress: Bytes
+  commandAddress_not: Bytes
+  commandAddress_gt: Bytes
+  commandAddress_lt: Bytes
+  commandAddress_gte: Bytes
+  commandAddress_lte: Bytes
+  commandAddress_in: [Bytes!]
+  commandAddress_not_in: [Bytes!]
+  commandAddress_contains: Bytes
+  commandAddress_not_contains: Bytes
+  triggerType: BigInt
+  triggerType_not: BigInt
+  triggerType_gt: BigInt
+  triggerType_lt: BigInt
+  triggerType_gte: BigInt
+  triggerType_lte: BigInt
+  triggerType_in: [BigInt!]
+  triggerType_not_in: [BigInt!]
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  triggerData: Bytes
+  triggerData_not: Bytes
+  triggerData_gt: Bytes
+  triggerData_lt: Bytes
+  triggerData_gte: Bytes
+  triggerData_lte: Bytes
+  triggerData_in: [Bytes!]
+  triggerData_not_in: [Bytes!]
+  triggerData_contains: Bytes
+  triggerData_not_contains: Bytes
+  decodedData: [String!]
+  decodedData_not: [String!]
+  decodedData_contains: [String!]
+  decodedData_contains_nocase: [String!]
+  decodedData_not_contains: [String!]
+  decodedData_not_contains_nocase: [String!]
+  decodedDataNames: [String!]
+  decodedDataNames_not: [String!]
+  decodedDataNames_contains: [String!]
+  decodedDataNames_contains_nocase: [String!]
+  decodedDataNames_not_contains: [String!]
+  decodedDataNames_not_contains_nocase: [String!]
+  addedBlock: BigInt
+  addedBlock_not: BigInt
+  addedBlock_gt: BigInt
+  addedBlock_lt: BigInt
+  addedBlock_gte: BigInt
+  addedBlock_lte: BigInt
+  addedBlock_in: [BigInt!]
+  addedBlock_not_in: [BigInt!]
+  addedTransaction: Bytes
+  addedTransaction_not: Bytes
+  addedTransaction_gt: Bytes
+  addedTransaction_lt: Bytes
+  addedTransaction_gte: Bytes
+  addedTransaction_lte: Bytes
+  addedTransaction_in: [Bytes!]
+  addedTransaction_not_in: [Bytes!]
+  addedTransaction_contains: Bytes
+  addedTransaction_not_contains: Bytes
+  addedLogIndex: BigInt
+  addedLogIndex_not: BigInt
+  addedLogIndex_gt: BigInt
+  addedLogIndex_lt: BigInt
+  addedLogIndex_gte: BigInt
+  addedLogIndex_lte: BigInt
+  addedLogIndex_in: [BigInt!]
+  addedLogIndex_not_in: [BigInt!]
+  addedTimestamp: BigInt
+  addedTimestamp_not: BigInt
+  addedTimestamp_gt: BigInt
+  addedTimestamp_lt: BigInt
+  addedTimestamp_gte: BigInt
+  addedTimestamp_lte: BigInt
+  addedTimestamp_in: [BigInt!]
+  addedTimestamp_not_in: [BigInt!]
+  removedBlock: BigInt
+  removedBlock_not: BigInt
+  removedBlock_gt: BigInt
+  removedBlock_lt: BigInt
+  removedBlock_gte: BigInt
+  removedBlock_lte: BigInt
+  removedBlock_in: [BigInt!]
+  removedBlock_not_in: [BigInt!]
+  removedTransaction: Bytes
+  removedTransaction_not: Bytes
+  removedTransaction_gt: Bytes
+  removedTransaction_lt: Bytes
+  removedTransaction_gte: Bytes
+  removedTransaction_lte: Bytes
+  removedTransaction_in: [Bytes!]
+  removedTransaction_not_in: [Bytes!]
+  removedTransaction_contains: Bytes
+  removedTransaction_not_contains: Bytes
+  removedLogIndex: BigInt
+  removedLogIndex_not: BigInt
+  removedLogIndex_gt: BigInt
+  removedLogIndex_lt: BigInt
+  removedLogIndex_gte: BigInt
+  removedLogIndex_lte: BigInt
+  removedLogIndex_in: [BigInt!]
+  removedLogIndex_not_in: [BigInt!]
+  removedTimestamp: BigInt
+  removedTimestamp_not: BigInt
+  removedTimestamp_gt: BigInt
+  removedTimestamp_lt: BigInt
+  removedTimestamp_gte: BigInt
+  removedTimestamp_lte: BigInt
+  removedTimestamp_in: [BigInt!]
+  removedTimestamp_not_in: [BigInt!]
+  executedBlock: BigInt
+  executedBlock_not: BigInt
+  executedBlock_gt: BigInt
+  executedBlock_lt: BigInt
+  executedBlock_gte: BigInt
+  executedBlock_lte: BigInt
+  executedBlock_in: [BigInt!]
+  executedBlock_not_in: [BigInt!]
+  executedTransaction: Bytes
+  executedTransaction_not: Bytes
+  executedTransaction_gt: Bytes
+  executedTransaction_lt: Bytes
+  executedTransaction_gte: Bytes
+  executedTransaction_lte: Bytes
+  executedTransaction_in: [Bytes!]
+  executedTransaction_not_in: [Bytes!]
+  executedTransaction_contains: Bytes
+  executedTransaction_not_contains: Bytes
+  executedLogIndex: BigInt
+  executedLogIndex_not: BigInt
+  executedLogIndex_gt: BigInt
+  executedLogIndex_lt: BigInt
+  executedLogIndex_gte: BigInt
+  executedLogIndex_lte: BigInt
+  executedLogIndex_in: [BigInt!]
+  executedLogIndex_not_in: [BigInt!]
+  executedTimestamp: BigInt
+  executedTimestamp_not: BigInt
+  executedTimestamp_gt: BigInt
+  executedTimestamp_lt: BigInt
+  executedTimestamp_gte: BigInt
+  executedTimestamp_lte: BigInt
+  executedTimestamp_in: [BigInt!]
+  executedTimestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Trigger_filter]
+  or: [Trigger_filter]
+}
+
+enum Trigger_orderBy {
+  id
+  account
+  account__id
+  account__vaultId
+  account__isDPM
+  account__owner
+  commandAddress
+  triggerType
+  kind
+  triggerData
+  decodedData
+  decodedDataNames
+  addedBlock
+  addedTransaction
+  addedLogIndex
+  addedTimestamp
+  removedBlock
+  removedTransaction
+  removedLogIndex
+  removedTimestamp
+  executedBlock
+  executedTransaction
+  executedLogIndex
+  executedTimestamp
+}
+

--- a/packages/aave-spark-subgraph/src/index.ts
+++ b/packages/aave-spark-subgraph/src/index.ts
@@ -1,0 +1,81 @@
+import { request } from 'graphql-request'
+
+import { ChainId } from '@summerfi/serverless-shared'
+import type { Address } from '@summerfi/serverless-shared'
+import { Logger } from '@aws-lambda-powertools/logger'
+import { CollateralLockedDocument } from './types/graphql/generated'
+
+const chainIdSubgraphMap: Partial<Record<ChainId, string>> = {
+  [ChainId.MAINNET]: 'summer-oasis-history',
+  [ChainId.BASE]: 'summer-oasis-history-base',
+  [ChainId.OPTIMISM]: 'summer-oasis-history-optimism',
+  [ChainId.ARBITRUM]: 'summer-oasis-history-arbitrum',
+}
+
+const getEndpoint = (chainId: ChainId, baseUrl: string) => {
+  const subgraph = chainIdSubgraphMap[chainId]
+  if (!subgraph) {
+    throw new Error(`No subgraph for chainId ${chainId}`)
+  }
+  return `${baseUrl}/${subgraph}`
+}
+interface SubgraphClientConfig {
+  chainId: ChainId
+  urlBase: string
+  logger?: Logger
+}
+
+export interface GetCollateralLockedParams {
+  collaterals: { address: Address; decimals: number }[]
+  blockNumber: number
+}
+
+export interface CollateralLocked {
+  collateral: Address
+  amount: string
+  owner: Address
+}
+
+/**
+ * The key of the first record is the owner of the collaterals, second record is the collateral address
+ */
+export type CollateralLockedRecord = Record<Address, Record<Address, CollateralLocked>>
+
+export interface CollateralLockedResult {
+  lockedCollaterals: CollateralLocked[]
+}
+
+export type GetCollateralLocked = (
+  params: GetCollateralLockedParams,
+) => Promise<CollateralLockedResult>
+
+async function getCollateralLocked(
+  params: GetCollateralLockedParams,
+  config: SubgraphClientConfig,
+): Promise<CollateralLockedResult> {
+  const url = getEndpoint(config.chainId, config.urlBase)
+  const result = await request(url, CollateralLockedDocument, {
+    collateralAddresses: params.collaterals.map((c) => c.address),
+    block: params.blockNumber,
+  })
+
+  const mapped: CollateralLocked[] = result.positions.map((c) => ({
+    collateral: c.collateralAddress as Address,
+    amount: c.collateral,
+    owner: c.proxy.owner as Address,
+  }))
+
+  return {
+    lockedCollaterals: mapped,
+  }
+}
+
+export interface AaveSparkSubgraphClient {
+  getCollateralLocked: GetCollateralLocked
+}
+
+export function getAaveSparkSubgraphClient(config: SubgraphClientConfig): AaveSparkSubgraphClient {
+  return {
+    getCollateralLocked: (params: GetCollateralLockedParams) => getCollateralLocked(params, config),
+  }
+}

--- a/packages/aave-spark-subgraph/tsconfig.json
+++ b/packages/aave-spark-subgraph/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@summerfi/typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/packages/ajna-subgraph/.eslintrc.cjs
+++ b/packages/ajna-subgraph/.eslintrc.cjs
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  ignorePatterns: ['src/types/graphql/**'],
+  extends: ['@summerfi/eslint-config/library.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+  },
+}

--- a/packages/ajna-subgraph/graphql.config.yml
+++ b/packages/ajna-subgraph/graphql.config.yml
@@ -1,0 +1,32 @@
+schema: schema.graphql
+documents: './queries/**/*.graphql'
+config:
+  namingConvention:
+    enumValues: keep
+generates:
+  src/types/graphql/generated.ts:
+    plugins:
+      - add:
+          content:
+            - '// @ts-nocheck'
+            - '// This file was automatically generated and should not be edited.'
+      - typescript
+      - typescript-operations:
+          strictScalars: true
+          immutableTypes: true
+          scalars:
+            BigDecimal: string
+            BigInt: bigint
+            Int8: number
+            BooleanType: boolean
+            CustomData: Record<string, unknown>
+            Date: string
+            DateTime: string
+            FloatType: number
+            IntType: number
+            ItemId: string
+            JsonField: unknown
+            Bytes: string
+            MetaTagAttributes: Record<string, string>
+            UploadId: string
+      - typed-document-node

--- a/packages/ajna-subgraph/package.json
+++ b/packages/ajna-subgraph/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@summerfi/ajna-subgraph",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "tsc": "tsc",
+    "watch": "tsc -w",
+    "test": "jest --passWithNoTests",
+    "build": "tsc -b -v",
+    "prebuild": "pnpm run generate-ts-types",
+    "generate-ts-types": "graphql-codegen --config graphql.config.yml",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^1.17.0",
+    "graphql-request": "^6.1.0",
+    "@summerfi/serverless-shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@summerfi/eslint-config": "workspace:*",
+    "@summerfi/typescript-config": "workspace:*",
+    "@types/node": "^20.11.5",
+    "eslint": "^8.56.0"
+  }
+}

--- a/packages/ajna-subgraph/queries/collateral-locked.graphql
+++ b/packages/ajna-subgraph/queries/collateral-locked.graphql
@@ -1,0 +1,16 @@
+query CollateralLocked($collateralAddresses: [String!]!, $block: Int!) {
+  borrowPositions(where: { pool_: { collateralToken_in:  $collateralAddresses }, collateral_gt: 0, account_not: null}, block: { number: $block }) {
+    pool {
+      collateralToken {
+        address
+        decimals
+      }
+    }
+    collateral
+    account {
+      user {
+        address
+      }
+    }
+  }
+}

--- a/packages/ajna-subgraph/schema.graphql
+++ b/packages/ajna-subgraph/schema.graphql
@@ -1,0 +1,7975 @@
+"""
+Marks the GraphQL type as indexable entity.  Each type that should be an entity
+is required to be annotated with this directive.
+"""
+directive @entity on OBJECT
+
+"""Defined a Subgraph ID for an object type"""
+directive @subgraphId(id: String!) on OBJECT
+
+"""
+creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
+"""
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+
+  """The block number"""
+  number: Int!
+
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+
+  """The deployment ID"""
+  deployment: String!
+
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
+
+type Account {
+  id: Bytes!
+  address: Bytes!
+  user: User!
+  vaultId: BigInt!
+  isDPM: Boolean!
+  protocol: String
+  positionType: String
+  collateralToken: Bytes
+  debtToken: Bytes
+  createEvents(skip: Int = 0, first: Int = 100, orderBy: CreatePositionEvent_orderBy, orderDirection: OrderDirection, where: CreatePositionEvent_filter): [CreatePositionEvent!]
+  earnPositions(skip: Int = 0, first: Int = 100, orderBy: EarnPosition_orderBy, orderDirection: OrderDirection, where: EarnPosition_filter): [EarnPosition!]
+  borrowPositions(skip: Int = 0, first: Int = 100, orderBy: BorrowPosition_orderBy, orderDirection: OrderDirection, where: BorrowPosition_filter): [BorrowPosition!]
+  nfts(skip: Int = 0, first: Int = 100, orderBy: NFT_orderBy, orderDirection: OrderDirection, where: NFT_filter): [NFT!]
+}
+
+input Account_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  vaultId: BigInt
+  vaultId_not: BigInt
+  vaultId_gt: BigInt
+  vaultId_lt: BigInt
+  vaultId_gte: BigInt
+  vaultId_lte: BigInt
+  vaultId_in: [BigInt!]
+  vaultId_not_in: [BigInt!]
+  isDPM: Boolean
+  isDPM_not: Boolean
+  isDPM_in: [Boolean!]
+  isDPM_not_in: [Boolean!]
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  positionType: String
+  positionType_not: String
+  positionType_gt: String
+  positionType_lt: String
+  positionType_gte: String
+  positionType_lte: String
+  positionType_in: [String!]
+  positionType_not_in: [String!]
+  positionType_contains: String
+  positionType_contains_nocase: String
+  positionType_not_contains: String
+  positionType_not_contains_nocase: String
+  positionType_starts_with: String
+  positionType_starts_with_nocase: String
+  positionType_not_starts_with: String
+  positionType_not_starts_with_nocase: String
+  positionType_ends_with: String
+  positionType_ends_with_nocase: String
+  positionType_not_ends_with: String
+  positionType_not_ends_with_nocase: String
+  collateralToken: Bytes
+  collateralToken_not: Bytes
+  collateralToken_gt: Bytes
+  collateralToken_lt: Bytes
+  collateralToken_gte: Bytes
+  collateralToken_lte: Bytes
+  collateralToken_in: [Bytes!]
+  collateralToken_not_in: [Bytes!]
+  collateralToken_contains: Bytes
+  collateralToken_not_contains: Bytes
+  debtToken: Bytes
+  debtToken_not: Bytes
+  debtToken_gt: Bytes
+  debtToken_lt: Bytes
+  debtToken_gte: Bytes
+  debtToken_lte: Bytes
+  debtToken_in: [Bytes!]
+  debtToken_not_in: [Bytes!]
+  debtToken_contains: Bytes
+  debtToken_not_contains: Bytes
+  createEvents_: CreatePositionEvent_filter
+  earnPositions_: EarnPosition_filter
+  borrowPositions_: BorrowPosition_filter
+  nfts_: NFT_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Account_filter]
+  or: [Account_filter]
+}
+
+enum Account_orderBy {
+  id
+  address
+  user
+  user__id
+  user__address
+  user__vaultCount
+  vaultId
+  isDPM
+  protocol
+  positionType
+  collateralToken
+  debtToken
+  createEvents
+  earnPositions
+  borrowPositions
+  nfts
+}
+
+type AssetSwap {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: Bytes!
+  assetIn: Bytes!
+  assetOut: Bytes!
+  amountIn: BigInt!
+  amountOut: BigInt!
+  proxy: Bytes
+}
+
+input AssetSwap_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  assetIn: Bytes
+  assetIn_not: Bytes
+  assetIn_gt: Bytes
+  assetIn_lt: Bytes
+  assetIn_gte: Bytes
+  assetIn_lte: Bytes
+  assetIn_in: [Bytes!]
+  assetIn_not_in: [Bytes!]
+  assetIn_contains: Bytes
+  assetIn_not_contains: Bytes
+  assetOut: Bytes
+  assetOut_not: Bytes
+  assetOut_gt: Bytes
+  assetOut_lt: Bytes
+  assetOut_gte: Bytes
+  assetOut_lte: Bytes
+  assetOut_in: [Bytes!]
+  assetOut_not_in: [Bytes!]
+  assetOut_contains: Bytes
+  assetOut_not_contains: Bytes
+  amountIn: BigInt
+  amountIn_not: BigInt
+  amountIn_gt: BigInt
+  amountIn_lt: BigInt
+  amountIn_gte: BigInt
+  amountIn_lte: BigInt
+  amountIn_in: [BigInt!]
+  amountIn_not_in: [BigInt!]
+  amountOut: BigInt
+  amountOut_not: BigInt
+  amountOut_gt: BigInt
+  amountOut_lt: BigInt
+  amountOut_gte: BigInt
+  amountOut_lte: BigInt
+  amountOut_in: [BigInt!]
+  amountOut_not_in: [BigInt!]
+  proxy: Bytes
+  proxy_not: Bytes
+  proxy_gt: Bytes
+  proxy_lt: Bytes
+  proxy_gte: Bytes
+  proxy_lte: Bytes
+  proxy_in: [Bytes!]
+  proxy_not_in: [Bytes!]
+  proxy_contains: Bytes
+  proxy_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AssetSwap_filter]
+  or: [AssetSwap_filter]
+}
+
+enum AssetSwap_orderBy {
+  id
+  assetIn
+  assetOut
+  amountIn
+  amountOut
+  proxy
+}
+
+type Auction {
+  id: ID!
+  pool: Pool!
+  account: Account
+  user: User
+  position: BorrowPosition!
+  endOfGracePeriod: BigInt!
+  inLiquidation: Boolean!
+  kickTime: BigInt!
+  collateral: BigInt!
+  debtToCover: BigInt!
+  isCollateralized: Boolean!
+  price: BigInt!
+  neutralPrice: BigInt!
+  kicker: String
+  bondSize: BigInt!
+  referencePrice: BigInt!
+  hpbOnKick: BigInt
+}
+
+input Auction_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: BorrowPosition_filter
+  endOfGracePeriod: BigInt
+  endOfGracePeriod_not: BigInt
+  endOfGracePeriod_gt: BigInt
+  endOfGracePeriod_lt: BigInt
+  endOfGracePeriod_gte: BigInt
+  endOfGracePeriod_lte: BigInt
+  endOfGracePeriod_in: [BigInt!]
+  endOfGracePeriod_not_in: [BigInt!]
+  inLiquidation: Boolean
+  inLiquidation_not: Boolean
+  inLiquidation_in: [Boolean!]
+  inLiquidation_not_in: [Boolean!]
+  kickTime: BigInt
+  kickTime_not: BigInt
+  kickTime_gt: BigInt
+  kickTime_lt: BigInt
+  kickTime_gte: BigInt
+  kickTime_lte: BigInt
+  kickTime_in: [BigInt!]
+  kickTime_not_in: [BigInt!]
+  collateral: BigInt
+  collateral_not: BigInt
+  collateral_gt: BigInt
+  collateral_lt: BigInt
+  collateral_gte: BigInt
+  collateral_lte: BigInt
+  collateral_in: [BigInt!]
+  collateral_not_in: [BigInt!]
+  debtToCover: BigInt
+  debtToCover_not: BigInt
+  debtToCover_gt: BigInt
+  debtToCover_lt: BigInt
+  debtToCover_gte: BigInt
+  debtToCover_lte: BigInt
+  debtToCover_in: [BigInt!]
+  debtToCover_not_in: [BigInt!]
+  isCollateralized: Boolean
+  isCollateralized_not: Boolean
+  isCollateralized_in: [Boolean!]
+  isCollateralized_not_in: [Boolean!]
+  price: BigInt
+  price_not: BigInt
+  price_gt: BigInt
+  price_lt: BigInt
+  price_gte: BigInt
+  price_lte: BigInt
+  price_in: [BigInt!]
+  price_not_in: [BigInt!]
+  neutralPrice: BigInt
+  neutralPrice_not: BigInt
+  neutralPrice_gt: BigInt
+  neutralPrice_lt: BigInt
+  neutralPrice_gte: BigInt
+  neutralPrice_lte: BigInt
+  neutralPrice_in: [BigInt!]
+  neutralPrice_not_in: [BigInt!]
+  kicker: String
+  kicker_not: String
+  kicker_gt: String
+  kicker_lt: String
+  kicker_gte: String
+  kicker_lte: String
+  kicker_in: [String!]
+  kicker_not_in: [String!]
+  kicker_contains: String
+  kicker_contains_nocase: String
+  kicker_not_contains: String
+  kicker_not_contains_nocase: String
+  kicker_starts_with: String
+  kicker_starts_with_nocase: String
+  kicker_not_starts_with: String
+  kicker_not_starts_with_nocase: String
+  kicker_ends_with: String
+  kicker_ends_with_nocase: String
+  kicker_not_ends_with: String
+  kicker_not_ends_with_nocase: String
+  bondSize: BigInt
+  bondSize_not: BigInt
+  bondSize_gt: BigInt
+  bondSize_lt: BigInt
+  bondSize_gte: BigInt
+  bondSize_lte: BigInt
+  bondSize_in: [BigInt!]
+  bondSize_not_in: [BigInt!]
+  referencePrice: BigInt
+  referencePrice_not: BigInt
+  referencePrice_gt: BigInt
+  referencePrice_lt: BigInt
+  referencePrice_gte: BigInt
+  referencePrice_lte: BigInt
+  referencePrice_in: [BigInt!]
+  referencePrice_not_in: [BigInt!]
+  hpbOnKick: BigInt
+  hpbOnKick_not: BigInt
+  hpbOnKick_gt: BigInt
+  hpbOnKick_lt: BigInt
+  hpbOnKick_gte: BigInt
+  hpbOnKick_lte: BigInt
+  hpbOnKick_in: [BigInt!]
+  hpbOnKick_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Auction_filter]
+  or: [Auction_filter]
+}
+
+enum Auction_orderBy {
+  id
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  user
+  user__id
+  user__address
+  user__vaultCount
+  position
+  position__id
+  position__debt
+  position__collateral
+  position__t0Np_
+  position__t0Debt
+  position__liquidationPrice
+  position__borrowDailyTokenBlocks
+  position__borrowLastUpdateBlock
+  position__borrowCumulativeDepositUSD
+  position__borrowCumulativeDepositInQuoteToken
+  position__borrowCumulativeDepositInCollateralToken
+  position__borrowCumulativeWithdrawUSD
+  position__borrowCumulativeWithdrawInQuoteToken
+  position__borrowCumulativeWithdrawInCollateralToken
+  position__borrowCumulativeCollateralDeposit
+  position__borrowCumulativeCollateralWithdraw
+  position__borrowCumulativeDebtDeposit
+  position__borrowCumulativeDebtWithdraw
+  position__borrowCumulativeFeesUSD
+  position__borrowCumulativeFeesInQuoteToken
+  position__borrowCumulativeFeesInCollateralToken
+  endOfGracePeriod
+  inLiquidation
+  kickTime
+  collateral
+  debtToCover
+  isCollateralized
+  price
+  neutralPrice
+  kicker
+  bondSize
+  referencePrice
+  hpbOnKick
+}
+
+scalar BigDecimal
+
+scalar BigInt
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+type BorrowDailyReward {
+  id: ID!
+  day: Day!
+  week: Week!
+  pool: Pool!
+  account: Account
+  user: User
+  reward: BigDecimal!
+}
+
+input BorrowDailyReward_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  day: String
+  day_not: String
+  day_gt: String
+  day_lt: String
+  day_gte: String
+  day_lte: String
+  day_in: [String!]
+  day_not_in: [String!]
+  day_contains: String
+  day_contains_nocase: String
+  day_not_contains: String
+  day_not_contains_nocase: String
+  day_starts_with: String
+  day_starts_with_nocase: String
+  day_not_starts_with: String
+  day_not_starts_with_nocase: String
+  day_ends_with: String
+  day_ends_with_nocase: String
+  day_not_ends_with: String
+  day_not_ends_with_nocase: String
+  day_: Day_filter
+  week: String
+  week_not: String
+  week_gt: String
+  week_lt: String
+  week_gte: String
+  week_lte: String
+  week_in: [String!]
+  week_not_in: [String!]
+  week_contains: String
+  week_contains_nocase: String
+  week_not_contains: String
+  week_not_contains_nocase: String
+  week_starts_with: String
+  week_starts_with_nocase: String
+  week_not_starts_with: String
+  week_not_starts_with_nocase: String
+  week_ends_with: String
+  week_ends_with_nocase: String
+  week_not_ends_with: String
+  week_not_ends_with_nocase: String
+  week_: Week_filter
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  reward: BigDecimal
+  reward_not: BigDecimal
+  reward_gt: BigDecimal
+  reward_lt: BigDecimal
+  reward_gte: BigDecimal
+  reward_lte: BigDecimal
+  reward_in: [BigDecimal!]
+  reward_not_in: [BigDecimal!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [BorrowDailyReward_filter]
+  or: [BorrowDailyReward_filter]
+}
+
+enum BorrowDailyReward_orderBy {
+  id
+  day
+  day__id
+  day__day
+  day__dayStartTimestamp
+  day__dayDate
+  week
+  week__id
+  week__week
+  week__weekStartTimestamp
+  week__weekEndTimestamp
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  user
+  user__id
+  user__address
+  user__vaultCount
+  reward
+}
+
+type BorrowerEvent {
+  id: ID!
+  position: BorrowPosition!
+  account: Account
+  kind: String!
+  pool: Pool!
+  debtToken: Token!
+  collateralToken: Token!
+  debtTokenPriceUSD: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  originationFee: BigDecimal
+  debtBefore: BigDecimal!
+  debtAfter: BigDecimal!
+  debtDelta: BigDecimal!
+  collateralBefore: BigDecimal!
+  collateralAfter: BigDecimal!
+  collateralDelta: BigDecimal!
+  quoteRepaid: BigInt
+  collateralPulled: BigInt
+  amountBorrowed: BigInt
+  collateralPledged: BigInt
+  auction: Auction
+  debtToCover: BigInt
+  collateralForLiquidation: BigInt
+  collateralPurachased: BigInt
+  quoteUsedToPurchase: BigInt
+  settledDebt: BigInt
+  remainingCollateral: BigInt
+  bondChange: BigInt
+  isReward: Boolean
+  takeIndex: BigInt
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input BorrowerEvent_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: BorrowPosition_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  originationFee: BigDecimal
+  originationFee_not: BigDecimal
+  originationFee_gt: BigDecimal
+  originationFee_lt: BigDecimal
+  originationFee_gte: BigDecimal
+  originationFee_lte: BigDecimal
+  originationFee_in: [BigDecimal!]
+  originationFee_not_in: [BigDecimal!]
+  debtBefore: BigDecimal
+  debtBefore_not: BigDecimal
+  debtBefore_gt: BigDecimal
+  debtBefore_lt: BigDecimal
+  debtBefore_gte: BigDecimal
+  debtBefore_lte: BigDecimal
+  debtBefore_in: [BigDecimal!]
+  debtBefore_not_in: [BigDecimal!]
+  debtAfter: BigDecimal
+  debtAfter_not: BigDecimal
+  debtAfter_gt: BigDecimal
+  debtAfter_lt: BigDecimal
+  debtAfter_gte: BigDecimal
+  debtAfter_lte: BigDecimal
+  debtAfter_in: [BigDecimal!]
+  debtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  collateralBefore: BigDecimal
+  collateralBefore_not: BigDecimal
+  collateralBefore_gt: BigDecimal
+  collateralBefore_lt: BigDecimal
+  collateralBefore_gte: BigDecimal
+  collateralBefore_lte: BigDecimal
+  collateralBefore_in: [BigDecimal!]
+  collateralBefore_not_in: [BigDecimal!]
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  quoteRepaid: BigInt
+  quoteRepaid_not: BigInt
+  quoteRepaid_gt: BigInt
+  quoteRepaid_lt: BigInt
+  quoteRepaid_gte: BigInt
+  quoteRepaid_lte: BigInt
+  quoteRepaid_in: [BigInt!]
+  quoteRepaid_not_in: [BigInt!]
+  collateralPulled: BigInt
+  collateralPulled_not: BigInt
+  collateralPulled_gt: BigInt
+  collateralPulled_lt: BigInt
+  collateralPulled_gte: BigInt
+  collateralPulled_lte: BigInt
+  collateralPulled_in: [BigInt!]
+  collateralPulled_not_in: [BigInt!]
+  amountBorrowed: BigInt
+  amountBorrowed_not: BigInt
+  amountBorrowed_gt: BigInt
+  amountBorrowed_lt: BigInt
+  amountBorrowed_gte: BigInt
+  amountBorrowed_lte: BigInt
+  amountBorrowed_in: [BigInt!]
+  amountBorrowed_not_in: [BigInt!]
+  collateralPledged: BigInt
+  collateralPledged_not: BigInt
+  collateralPledged_gt: BigInt
+  collateralPledged_lt: BigInt
+  collateralPledged_gte: BigInt
+  collateralPledged_lte: BigInt
+  collateralPledged_in: [BigInt!]
+  collateralPledged_not_in: [BigInt!]
+  auction: String
+  auction_not: String
+  auction_gt: String
+  auction_lt: String
+  auction_gte: String
+  auction_lte: String
+  auction_in: [String!]
+  auction_not_in: [String!]
+  auction_contains: String
+  auction_contains_nocase: String
+  auction_not_contains: String
+  auction_not_contains_nocase: String
+  auction_starts_with: String
+  auction_starts_with_nocase: String
+  auction_not_starts_with: String
+  auction_not_starts_with_nocase: String
+  auction_ends_with: String
+  auction_ends_with_nocase: String
+  auction_not_ends_with: String
+  auction_not_ends_with_nocase: String
+  auction_: Auction_filter
+  debtToCover: BigInt
+  debtToCover_not: BigInt
+  debtToCover_gt: BigInt
+  debtToCover_lt: BigInt
+  debtToCover_gte: BigInt
+  debtToCover_lte: BigInt
+  debtToCover_in: [BigInt!]
+  debtToCover_not_in: [BigInt!]
+  collateralForLiquidation: BigInt
+  collateralForLiquidation_not: BigInt
+  collateralForLiquidation_gt: BigInt
+  collateralForLiquidation_lt: BigInt
+  collateralForLiquidation_gte: BigInt
+  collateralForLiquidation_lte: BigInt
+  collateralForLiquidation_in: [BigInt!]
+  collateralForLiquidation_not_in: [BigInt!]
+  collateralPurachased: BigInt
+  collateralPurachased_not: BigInt
+  collateralPurachased_gt: BigInt
+  collateralPurachased_lt: BigInt
+  collateralPurachased_gte: BigInt
+  collateralPurachased_lte: BigInt
+  collateralPurachased_in: [BigInt!]
+  collateralPurachased_not_in: [BigInt!]
+  quoteUsedToPurchase: BigInt
+  quoteUsedToPurchase_not: BigInt
+  quoteUsedToPurchase_gt: BigInt
+  quoteUsedToPurchase_lt: BigInt
+  quoteUsedToPurchase_gte: BigInt
+  quoteUsedToPurchase_lte: BigInt
+  quoteUsedToPurchase_in: [BigInt!]
+  quoteUsedToPurchase_not_in: [BigInt!]
+  settledDebt: BigInt
+  settledDebt_not: BigInt
+  settledDebt_gt: BigInt
+  settledDebt_lt: BigInt
+  settledDebt_gte: BigInt
+  settledDebt_lte: BigInt
+  settledDebt_in: [BigInt!]
+  settledDebt_not_in: [BigInt!]
+  remainingCollateral: BigInt
+  remainingCollateral_not: BigInt
+  remainingCollateral_gt: BigInt
+  remainingCollateral_lt: BigInt
+  remainingCollateral_gte: BigInt
+  remainingCollateral_lte: BigInt
+  remainingCollateral_in: [BigInt!]
+  remainingCollateral_not_in: [BigInt!]
+  bondChange: BigInt
+  bondChange_not: BigInt
+  bondChange_gt: BigInt
+  bondChange_lt: BigInt
+  bondChange_gte: BigInt
+  bondChange_lte: BigInt
+  bondChange_in: [BigInt!]
+  bondChange_not_in: [BigInt!]
+  isReward: Boolean
+  isReward_not: Boolean
+  isReward_in: [Boolean!]
+  isReward_not_in: [Boolean!]
+  takeIndex: BigInt
+  takeIndex_not: BigInt
+  takeIndex_gt: BigInt
+  takeIndex_lt: BigInt
+  takeIndex_gte: BigInt
+  takeIndex_lte: BigInt
+  takeIndex_in: [BigInt!]
+  takeIndex_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [BorrowerEvent_filter]
+  or: [BorrowerEvent_filter]
+}
+
+enum BorrowerEvent_orderBy {
+  id
+  position
+  position__id
+  position__debt
+  position__collateral
+  position__t0Np_
+  position__t0Debt
+  position__liquidationPrice
+  position__borrowDailyTokenBlocks
+  position__borrowLastUpdateBlock
+  position__borrowCumulativeDepositUSD
+  position__borrowCumulativeDepositInQuoteToken
+  position__borrowCumulativeDepositInCollateralToken
+  position__borrowCumulativeWithdrawUSD
+  position__borrowCumulativeWithdrawInQuoteToken
+  position__borrowCumulativeWithdrawInCollateralToken
+  position__borrowCumulativeCollateralDeposit
+  position__borrowCumulativeCollateralWithdraw
+  position__borrowCumulativeDebtDeposit
+  position__borrowCumulativeDebtWithdraw
+  position__borrowCumulativeFeesUSD
+  position__borrowCumulativeFeesInQuoteToken
+  position__borrowCumulativeFeesInCollateralToken
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  kind
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  debtTokenPriceUSD
+  collateralTokenPriceUSD
+  originationFee
+  debtBefore
+  debtAfter
+  debtDelta
+  collateralBefore
+  collateralAfter
+  collateralDelta
+  quoteRepaid
+  collateralPulled
+  amountBorrowed
+  collateralPledged
+  auction
+  auction__id
+  auction__endOfGracePeriod
+  auction__inLiquidation
+  auction__kickTime
+  auction__collateral
+  auction__debtToCover
+  auction__isCollateralized
+  auction__price
+  auction__neutralPrice
+  auction__kicker
+  auction__bondSize
+  auction__referencePrice
+  auction__hpbOnKick
+  debtToCover
+  collateralForLiquidation
+  collateralPurachased
+  quoteUsedToPurchase
+  settledDebt
+  remainingCollateral
+  bondChange
+  isReward
+  takeIndex
+  txHash
+  blockNumber
+  timestamp
+}
+
+type BorrowPosition {
+  id: ID!
+  pool: Pool!
+  account: Account
+  user: User
+  debt: BigInt!
+  collateral: BigInt!
+  t0Np_: BigInt!
+  t0Debt: BigInt!
+  liquidationPrice: BigDecimal!
+  borrowDailyTokenBlocks: BigInt!
+  borrowLastUpdateBlock: BigInt!
+  borrowCumulativeDepositUSD: BigDecimal!
+  borrowCumulativeDepositInQuoteToken: BigDecimal!
+  borrowCumulativeDepositInCollateralToken: BigDecimal!
+  borrowCumulativeWithdrawUSD: BigDecimal!
+  borrowCumulativeWithdrawInQuoteToken: BigDecimal!
+  borrowCumulativeWithdrawInCollateralToken: BigDecimal!
+  borrowCumulativeCollateralDeposit: BigDecimal!
+  borrowCumulativeCollateralWithdraw: BigDecimal!
+  borrowCumulativeDebtDeposit: BigDecimal!
+  borrowCumulativeDebtWithdraw: BigDecimal!
+  borrowCumulativeFeesUSD: BigDecimal!
+  borrowCumulativeFeesInQuoteToken: BigDecimal!
+  borrowCumulativeFeesInCollateralToken: BigDecimal!
+  protocolEvents(skip: Int = 0, first: Int = 100, orderBy: BorrowerEvent_orderBy, orderDirection: OrderDirection, where: BorrowerEvent_filter): [BorrowerEvent!]
+  oasisEvents(skip: Int = 0, first: Int = 100, orderBy: OasisEvent_orderBy, orderDirection: OrderDirection, where: OasisEvent_filter): [OasisEvent!]
+  liquidations(skip: Int = 0, first: Int = 100, orderBy: Auction_orderBy, orderDirection: OrderDirection, where: Auction_filter): [Auction!]!
+}
+
+input BorrowPosition_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  debt: BigInt
+  debt_not: BigInt
+  debt_gt: BigInt
+  debt_lt: BigInt
+  debt_gte: BigInt
+  debt_lte: BigInt
+  debt_in: [BigInt!]
+  debt_not_in: [BigInt!]
+  collateral: BigInt
+  collateral_not: BigInt
+  collateral_gt: BigInt
+  collateral_lt: BigInt
+  collateral_gte: BigInt
+  collateral_lte: BigInt
+  collateral_in: [BigInt!]
+  collateral_not_in: [BigInt!]
+  t0Np_: BigInt
+  t0Np__not: BigInt
+  t0Np__gt: BigInt
+  t0Np__lt: BigInt
+  t0Np__gte: BigInt
+  t0Np__lte: BigInt
+  t0Np__in: [BigInt!]
+  t0Np__not_in: [BigInt!]
+  t0Debt: BigInt
+  t0Debt_not: BigInt
+  t0Debt_gt: BigInt
+  t0Debt_lt: BigInt
+  t0Debt_gte: BigInt
+  t0Debt_lte: BigInt
+  t0Debt_in: [BigInt!]
+  t0Debt_not_in: [BigInt!]
+  liquidationPrice: BigDecimal
+  liquidationPrice_not: BigDecimal
+  liquidationPrice_gt: BigDecimal
+  liquidationPrice_lt: BigDecimal
+  liquidationPrice_gte: BigDecimal
+  liquidationPrice_lte: BigDecimal
+  liquidationPrice_in: [BigDecimal!]
+  liquidationPrice_not_in: [BigDecimal!]
+  borrowDailyTokenBlocks: BigInt
+  borrowDailyTokenBlocks_not: BigInt
+  borrowDailyTokenBlocks_gt: BigInt
+  borrowDailyTokenBlocks_lt: BigInt
+  borrowDailyTokenBlocks_gte: BigInt
+  borrowDailyTokenBlocks_lte: BigInt
+  borrowDailyTokenBlocks_in: [BigInt!]
+  borrowDailyTokenBlocks_not_in: [BigInt!]
+  borrowLastUpdateBlock: BigInt
+  borrowLastUpdateBlock_not: BigInt
+  borrowLastUpdateBlock_gt: BigInt
+  borrowLastUpdateBlock_lt: BigInt
+  borrowLastUpdateBlock_gte: BigInt
+  borrowLastUpdateBlock_lte: BigInt
+  borrowLastUpdateBlock_in: [BigInt!]
+  borrowLastUpdateBlock_not_in: [BigInt!]
+  borrowCumulativeDepositUSD: BigDecimal
+  borrowCumulativeDepositUSD_not: BigDecimal
+  borrowCumulativeDepositUSD_gt: BigDecimal
+  borrowCumulativeDepositUSD_lt: BigDecimal
+  borrowCumulativeDepositUSD_gte: BigDecimal
+  borrowCumulativeDepositUSD_lte: BigDecimal
+  borrowCumulativeDepositUSD_in: [BigDecimal!]
+  borrowCumulativeDepositUSD_not_in: [BigDecimal!]
+  borrowCumulativeDepositInQuoteToken: BigDecimal
+  borrowCumulativeDepositInQuoteToken_not: BigDecimal
+  borrowCumulativeDepositInQuoteToken_gt: BigDecimal
+  borrowCumulativeDepositInQuoteToken_lt: BigDecimal
+  borrowCumulativeDepositInQuoteToken_gte: BigDecimal
+  borrowCumulativeDepositInQuoteToken_lte: BigDecimal
+  borrowCumulativeDepositInQuoteToken_in: [BigDecimal!]
+  borrowCumulativeDepositInQuoteToken_not_in: [BigDecimal!]
+  borrowCumulativeDepositInCollateralToken: BigDecimal
+  borrowCumulativeDepositInCollateralToken_not: BigDecimal
+  borrowCumulativeDepositInCollateralToken_gt: BigDecimal
+  borrowCumulativeDepositInCollateralToken_lt: BigDecimal
+  borrowCumulativeDepositInCollateralToken_gte: BigDecimal
+  borrowCumulativeDepositInCollateralToken_lte: BigDecimal
+  borrowCumulativeDepositInCollateralToken_in: [BigDecimal!]
+  borrowCumulativeDepositInCollateralToken_not_in: [BigDecimal!]
+  borrowCumulativeWithdrawUSD: BigDecimal
+  borrowCumulativeWithdrawUSD_not: BigDecimal
+  borrowCumulativeWithdrawUSD_gt: BigDecimal
+  borrowCumulativeWithdrawUSD_lt: BigDecimal
+  borrowCumulativeWithdrawUSD_gte: BigDecimal
+  borrowCumulativeWithdrawUSD_lte: BigDecimal
+  borrowCumulativeWithdrawUSD_in: [BigDecimal!]
+  borrowCumulativeWithdrawUSD_not_in: [BigDecimal!]
+  borrowCumulativeWithdrawInQuoteToken: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_not: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_gt: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_lt: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_gte: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_lte: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_in: [BigDecimal!]
+  borrowCumulativeWithdrawInQuoteToken_not_in: [BigDecimal!]
+  borrowCumulativeWithdrawInCollateralToken: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_not: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_gt: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_lt: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_gte: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_lte: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_in: [BigDecimal!]
+  borrowCumulativeWithdrawInCollateralToken_not_in: [BigDecimal!]
+  borrowCumulativeCollateralDeposit: BigDecimal
+  borrowCumulativeCollateralDeposit_not: BigDecimal
+  borrowCumulativeCollateralDeposit_gt: BigDecimal
+  borrowCumulativeCollateralDeposit_lt: BigDecimal
+  borrowCumulativeCollateralDeposit_gte: BigDecimal
+  borrowCumulativeCollateralDeposit_lte: BigDecimal
+  borrowCumulativeCollateralDeposit_in: [BigDecimal!]
+  borrowCumulativeCollateralDeposit_not_in: [BigDecimal!]
+  borrowCumulativeCollateralWithdraw: BigDecimal
+  borrowCumulativeCollateralWithdraw_not: BigDecimal
+  borrowCumulativeCollateralWithdraw_gt: BigDecimal
+  borrowCumulativeCollateralWithdraw_lt: BigDecimal
+  borrowCumulativeCollateralWithdraw_gte: BigDecimal
+  borrowCumulativeCollateralWithdraw_lte: BigDecimal
+  borrowCumulativeCollateralWithdraw_in: [BigDecimal!]
+  borrowCumulativeCollateralWithdraw_not_in: [BigDecimal!]
+  borrowCumulativeDebtDeposit: BigDecimal
+  borrowCumulativeDebtDeposit_not: BigDecimal
+  borrowCumulativeDebtDeposit_gt: BigDecimal
+  borrowCumulativeDebtDeposit_lt: BigDecimal
+  borrowCumulativeDebtDeposit_gte: BigDecimal
+  borrowCumulativeDebtDeposit_lte: BigDecimal
+  borrowCumulativeDebtDeposit_in: [BigDecimal!]
+  borrowCumulativeDebtDeposit_not_in: [BigDecimal!]
+  borrowCumulativeDebtWithdraw: BigDecimal
+  borrowCumulativeDebtWithdraw_not: BigDecimal
+  borrowCumulativeDebtWithdraw_gt: BigDecimal
+  borrowCumulativeDebtWithdraw_lt: BigDecimal
+  borrowCumulativeDebtWithdraw_gte: BigDecimal
+  borrowCumulativeDebtWithdraw_lte: BigDecimal
+  borrowCumulativeDebtWithdraw_in: [BigDecimal!]
+  borrowCumulativeDebtWithdraw_not_in: [BigDecimal!]
+  borrowCumulativeFeesUSD: BigDecimal
+  borrowCumulativeFeesUSD_not: BigDecimal
+  borrowCumulativeFeesUSD_gt: BigDecimal
+  borrowCumulativeFeesUSD_lt: BigDecimal
+  borrowCumulativeFeesUSD_gte: BigDecimal
+  borrowCumulativeFeesUSD_lte: BigDecimal
+  borrowCumulativeFeesUSD_in: [BigDecimal!]
+  borrowCumulativeFeesUSD_not_in: [BigDecimal!]
+  borrowCumulativeFeesInQuoteToken: BigDecimal
+  borrowCumulativeFeesInQuoteToken_not: BigDecimal
+  borrowCumulativeFeesInQuoteToken_gt: BigDecimal
+  borrowCumulativeFeesInQuoteToken_lt: BigDecimal
+  borrowCumulativeFeesInQuoteToken_gte: BigDecimal
+  borrowCumulativeFeesInQuoteToken_lte: BigDecimal
+  borrowCumulativeFeesInQuoteToken_in: [BigDecimal!]
+  borrowCumulativeFeesInQuoteToken_not_in: [BigDecimal!]
+  borrowCumulativeFeesInCollateralToken: BigDecimal
+  borrowCumulativeFeesInCollateralToken_not: BigDecimal
+  borrowCumulativeFeesInCollateralToken_gt: BigDecimal
+  borrowCumulativeFeesInCollateralToken_lt: BigDecimal
+  borrowCumulativeFeesInCollateralToken_gte: BigDecimal
+  borrowCumulativeFeesInCollateralToken_lte: BigDecimal
+  borrowCumulativeFeesInCollateralToken_in: [BigDecimal!]
+  borrowCumulativeFeesInCollateralToken_not_in: [BigDecimal!]
+  protocolEvents_: BorrowerEvent_filter
+  oasisEvents_: OasisEvent_filter
+  liquidations: [String!]
+  liquidations_not: [String!]
+  liquidations_contains: [String!]
+  liquidations_contains_nocase: [String!]
+  liquidations_not_contains: [String!]
+  liquidations_not_contains_nocase: [String!]
+  liquidations_: Auction_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [BorrowPosition_filter]
+  or: [BorrowPosition_filter]
+}
+
+enum BorrowPosition_orderBy {
+  id
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  user
+  user__id
+  user__address
+  user__vaultCount
+  debt
+  collateral
+  t0Np_
+  t0Debt
+  liquidationPrice
+  borrowDailyTokenBlocks
+  borrowLastUpdateBlock
+  borrowCumulativeDepositUSD
+  borrowCumulativeDepositInQuoteToken
+  borrowCumulativeDepositInCollateralToken
+  borrowCumulativeWithdrawUSD
+  borrowCumulativeWithdrawInQuoteToken
+  borrowCumulativeWithdrawInCollateralToken
+  borrowCumulativeCollateralDeposit
+  borrowCumulativeCollateralWithdraw
+  borrowCumulativeDebtDeposit
+  borrowCumulativeDebtWithdraw
+  borrowCumulativeFeesUSD
+  borrowCumulativeFeesInQuoteToken
+  borrowCumulativeFeesInCollateralToken
+  protocolEvents
+  oasisEvents
+  liquidations
+}
+
+type Bucket {
+  id: ID!
+  pool: Pool!
+  price: BigInt
+  index: BigInt
+  quoteTokens: BigInt!
+  collateral: BigInt!
+  bucketLPs: BigInt!
+  scale: BigInt!
+  exchangeRate: BigInt
+}
+
+input Bucket_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  price: BigInt
+  price_not: BigInt
+  price_gt: BigInt
+  price_lt: BigInt
+  price_gte: BigInt
+  price_lte: BigInt
+  price_in: [BigInt!]
+  price_not_in: [BigInt!]
+  index: BigInt
+  index_not: BigInt
+  index_gt: BigInt
+  index_lt: BigInt
+  index_gte: BigInt
+  index_lte: BigInt
+  index_in: [BigInt!]
+  index_not_in: [BigInt!]
+  quoteTokens: BigInt
+  quoteTokens_not: BigInt
+  quoteTokens_gt: BigInt
+  quoteTokens_lt: BigInt
+  quoteTokens_gte: BigInt
+  quoteTokens_lte: BigInt
+  quoteTokens_in: [BigInt!]
+  quoteTokens_not_in: [BigInt!]
+  collateral: BigInt
+  collateral_not: BigInt
+  collateral_gt: BigInt
+  collateral_lt: BigInt
+  collateral_gte: BigInt
+  collateral_lte: BigInt
+  collateral_in: [BigInt!]
+  collateral_not_in: [BigInt!]
+  bucketLPs: BigInt
+  bucketLPs_not: BigInt
+  bucketLPs_gt: BigInt
+  bucketLPs_lt: BigInt
+  bucketLPs_gte: BigInt
+  bucketLPs_lte: BigInt
+  bucketLPs_in: [BigInt!]
+  bucketLPs_not_in: [BigInt!]
+  scale: BigInt
+  scale_not: BigInt
+  scale_gt: BigInt
+  scale_lt: BigInt
+  scale_gte: BigInt
+  scale_lte: BigInt
+  scale_in: [BigInt!]
+  scale_not_in: [BigInt!]
+  exchangeRate: BigInt
+  exchangeRate_not: BigInt
+  exchangeRate_gt: BigInt
+  exchangeRate_lt: BigInt
+  exchangeRate_gte: BigInt
+  exchangeRate_lte: BigInt
+  exchangeRate_in: [BigInt!]
+  exchangeRate_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Bucket_filter]
+  or: [Bucket_filter]
+}
+
+enum Bucket_orderBy {
+  id
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  price
+  index
+  quoteTokens
+  collateral
+  bucketLPs
+  scale
+  exchangeRate
+}
+
+scalar Bytes
+
+type Claimed {
+  id: Bytes!
+  user: User!
+  week: Week!
+  amount: BigInt
+  type: String!
+}
+
+input Claimed_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  week: String
+  week_not: String
+  week_gt: String
+  week_lt: String
+  week_gte: String
+  week_lte: String
+  week_in: [String!]
+  week_not_in: [String!]
+  week_contains: String
+  week_contains_nocase: String
+  week_not_contains: String
+  week_not_contains_nocase: String
+  week_starts_with: String
+  week_starts_with_nocase: String
+  week_not_starts_with: String
+  week_not_starts_with_nocase: String
+  week_ends_with: String
+  week_ends_with_nocase: String
+  week_not_ends_with: String
+  week_not_ends_with_nocase: String
+  week_: Week_filter
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  type: String
+  type_not: String
+  type_gt: String
+  type_lt: String
+  type_gte: String
+  type_lte: String
+  type_in: [String!]
+  type_not_in: [String!]
+  type_contains: String
+  type_contains_nocase: String
+  type_not_contains: String
+  type_not_contains_nocase: String
+  type_starts_with: String
+  type_starts_with_nocase: String
+  type_not_starts_with: String
+  type_not_starts_with_nocase: String
+  type_ends_with: String
+  type_ends_with_nocase: String
+  type_not_ends_with: String
+  type_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Claimed_filter]
+  or: [Claimed_filter]
+}
+
+enum Claimed_orderBy {
+  id
+  user
+  user__id
+  user__address
+  user__vaultCount
+  week
+  week__id
+  week__week
+  week__weekStartTimestamp
+  week__weekEndTimestamp
+  amount
+  type
+}
+
+type CreatePositionEvent {
+  id: Bytes!
+  account: Account
+  debtToken: Token!
+  collateralToken: Token!
+  positionType: String!
+  protocol: String!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input CreatePositionEvent_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  positionType: String
+  positionType_not: String
+  positionType_gt: String
+  positionType_lt: String
+  positionType_gte: String
+  positionType_lte: String
+  positionType_in: [String!]
+  positionType_not_in: [String!]
+  positionType_contains: String
+  positionType_contains_nocase: String
+  positionType_not_contains: String
+  positionType_not_contains_nocase: String
+  positionType_starts_with: String
+  positionType_starts_with_nocase: String
+  positionType_not_starts_with: String
+  positionType_not_starts_with_nocase: String
+  positionType_ends_with: String
+  positionType_ends_with_nocase: String
+  positionType_not_ends_with: String
+  positionType_not_ends_with_nocase: String
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [CreatePositionEvent_filter]
+  or: [CreatePositionEvent_filter]
+}
+
+enum CreatePositionEvent_orderBy {
+  id
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  positionType
+  protocol
+  txHash
+  blockNumber
+  timestamp
+}
+
+type Day {
+  id: ID!
+  day: BigInt!
+  dayStartTimestamp: BigInt!
+  dayDate: String
+  borrowDailyRewards(skip: Int = 0, first: Int = 100, orderBy: BorrowDailyReward_orderBy, orderDirection: OrderDirection, where: BorrowDailyReward_filter): [BorrowDailyReward!]
+  earnDailyRewards(skip: Int = 0, first: Int = 100, orderBy: EarnDailyReward_orderBy, orderDirection: OrderDirection, where: EarnDailyReward_filter): [EarnDailyReward!]
+  week: Week!
+}
+
+input Day_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  day: BigInt
+  day_not: BigInt
+  day_gt: BigInt
+  day_lt: BigInt
+  day_gte: BigInt
+  day_lte: BigInt
+  day_in: [BigInt!]
+  day_not_in: [BigInt!]
+  dayStartTimestamp: BigInt
+  dayStartTimestamp_not: BigInt
+  dayStartTimestamp_gt: BigInt
+  dayStartTimestamp_lt: BigInt
+  dayStartTimestamp_gte: BigInt
+  dayStartTimestamp_lte: BigInt
+  dayStartTimestamp_in: [BigInt!]
+  dayStartTimestamp_not_in: [BigInt!]
+  dayDate: String
+  dayDate_not: String
+  dayDate_gt: String
+  dayDate_lt: String
+  dayDate_gte: String
+  dayDate_lte: String
+  dayDate_in: [String!]
+  dayDate_not_in: [String!]
+  dayDate_contains: String
+  dayDate_contains_nocase: String
+  dayDate_not_contains: String
+  dayDate_not_contains_nocase: String
+  dayDate_starts_with: String
+  dayDate_starts_with_nocase: String
+  dayDate_not_starts_with: String
+  dayDate_not_starts_with_nocase: String
+  dayDate_ends_with: String
+  dayDate_ends_with_nocase: String
+  dayDate_not_ends_with: String
+  dayDate_not_ends_with_nocase: String
+  borrowDailyRewards_: BorrowDailyReward_filter
+  earnDailyRewards_: EarnDailyReward_filter
+  week: String
+  week_not: String
+  week_gt: String
+  week_lt: String
+  week_gte: String
+  week_lte: String
+  week_in: [String!]
+  week_not_in: [String!]
+  week_contains: String
+  week_contains_nocase: String
+  week_not_contains: String
+  week_not_contains_nocase: String
+  week_starts_with: String
+  week_starts_with_nocase: String
+  week_not_starts_with: String
+  week_not_starts_with_nocase: String
+  week_ends_with: String
+  week_ends_with_nocase: String
+  week_not_ends_with: String
+  week_not_ends_with_nocase: String
+  week_: Week_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Day_filter]
+  or: [Day_filter]
+}
+
+enum Day_orderBy {
+  id
+  day
+  dayStartTimestamp
+  dayDate
+  borrowDailyRewards
+  earnDailyRewards
+  week
+  week__id
+  week__week
+  week__weekStartTimestamp
+  week__weekEndTimestamp
+}
+
+type EarnDailyReward {
+  id: ID!
+  day: Day!
+  week: Week!
+  pool: Pool!
+  account: Account
+  user: User
+  reward: BigDecimal!
+}
+
+input EarnDailyReward_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  day: String
+  day_not: String
+  day_gt: String
+  day_lt: String
+  day_gte: String
+  day_lte: String
+  day_in: [String!]
+  day_not_in: [String!]
+  day_contains: String
+  day_contains_nocase: String
+  day_not_contains: String
+  day_not_contains_nocase: String
+  day_starts_with: String
+  day_starts_with_nocase: String
+  day_not_starts_with: String
+  day_not_starts_with_nocase: String
+  day_ends_with: String
+  day_ends_with_nocase: String
+  day_not_ends_with: String
+  day_not_ends_with_nocase: String
+  day_: Day_filter
+  week: String
+  week_not: String
+  week_gt: String
+  week_lt: String
+  week_gte: String
+  week_lte: String
+  week_in: [String!]
+  week_not_in: [String!]
+  week_contains: String
+  week_contains_nocase: String
+  week_not_contains: String
+  week_not_contains_nocase: String
+  week_starts_with: String
+  week_starts_with_nocase: String
+  week_not_starts_with: String
+  week_not_starts_with_nocase: String
+  week_ends_with: String
+  week_ends_with_nocase: String
+  week_not_ends_with: String
+  week_not_ends_with_nocase: String
+  week_: Week_filter
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  reward: BigDecimal
+  reward_not: BigDecimal
+  reward_gt: BigDecimal
+  reward_lt: BigDecimal
+  reward_gte: BigDecimal
+  reward_lte: BigDecimal
+  reward_in: [BigDecimal!]
+  reward_not_in: [BigDecimal!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EarnDailyReward_filter]
+  or: [EarnDailyReward_filter]
+}
+
+enum EarnDailyReward_orderBy {
+  id
+  day
+  day__id
+  day__day
+  day__dayStartTimestamp
+  day__dayDate
+  week
+  week__id
+  week__week
+  week__weekStartTimestamp
+  week__weekEndTimestamp
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  user
+  user__id
+  user__address
+  user__vaultCount
+  reward
+}
+
+type EarnPosition {
+  id: ID!
+  pool: Pool!
+  account: Account
+  user: User!
+  nft: NFT
+  earnPosition: EarnPositionBucket
+  earnDailyTokenBlocks: BigInt!
+  earnLastUpdateBlock: BigInt!
+  earnIsEarning: Boolean!
+  bucketPositions(skip: Int = 0, first: Int = 100, orderBy: EarnPositionBucket_orderBy, orderDirection: OrderDirection, where: EarnPositionBucket_filter): [EarnPositionBucket!]
+  earnCumulativeDepositUSD: BigDecimal!
+  earnCumulativeDepositInQuoteToken: BigDecimal!
+  earnCumulativeDepositInCollateralToken: BigDecimal!
+  earnCumulativeWithdrawUSD: BigDecimal!
+  earnCumulativeWithdrawInQuoteToken: BigDecimal!
+  earnCumulativeWithdrawInCollateralToken: BigDecimal!
+  earnCumulativeFeesUSD: BigDecimal!
+  earnCumulativeFeesInQuoteToken: BigDecimal!
+  earnCumulativeFeesInCollateralToken: BigDecimal!
+  earnCumulativeQuoteTokenDeposit: BigDecimal!
+  earnCumulativeQuoteTokenWithdraw: BigDecimal!
+  oasisEvents(skip: Int = 0, first: Int = 100, orderBy: OasisEvent_orderBy, orderDirection: OrderDirection, where: OasisEvent_filter): [OasisEvent!]
+  protocolEvents(skip: Int = 0, first: Int = 100, orderBy: LenderEvent_orderBy, orderDirection: OrderDirection, where: LenderEvent_filter): [LenderEvent!]
+}
+
+input EarnPosition_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  nft: String
+  nft_not: String
+  nft_gt: String
+  nft_lt: String
+  nft_gte: String
+  nft_lte: String
+  nft_in: [String!]
+  nft_not_in: [String!]
+  nft_contains: String
+  nft_contains_nocase: String
+  nft_not_contains: String
+  nft_not_contains_nocase: String
+  nft_starts_with: String
+  nft_starts_with_nocase: String
+  nft_not_starts_with: String
+  nft_not_starts_with_nocase: String
+  nft_ends_with: String
+  nft_ends_with_nocase: String
+  nft_not_ends_with: String
+  nft_not_ends_with_nocase: String
+  nft_: NFT_filter
+  earnPosition: String
+  earnPosition_not: String
+  earnPosition_gt: String
+  earnPosition_lt: String
+  earnPosition_gte: String
+  earnPosition_lte: String
+  earnPosition_in: [String!]
+  earnPosition_not_in: [String!]
+  earnPosition_contains: String
+  earnPosition_contains_nocase: String
+  earnPosition_not_contains: String
+  earnPosition_not_contains_nocase: String
+  earnPosition_starts_with: String
+  earnPosition_starts_with_nocase: String
+  earnPosition_not_starts_with: String
+  earnPosition_not_starts_with_nocase: String
+  earnPosition_ends_with: String
+  earnPosition_ends_with_nocase: String
+  earnPosition_not_ends_with: String
+  earnPosition_not_ends_with_nocase: String
+  earnPosition_: EarnPositionBucket_filter
+  earnDailyTokenBlocks: BigInt
+  earnDailyTokenBlocks_not: BigInt
+  earnDailyTokenBlocks_gt: BigInt
+  earnDailyTokenBlocks_lt: BigInt
+  earnDailyTokenBlocks_gte: BigInt
+  earnDailyTokenBlocks_lte: BigInt
+  earnDailyTokenBlocks_in: [BigInt!]
+  earnDailyTokenBlocks_not_in: [BigInt!]
+  earnLastUpdateBlock: BigInt
+  earnLastUpdateBlock_not: BigInt
+  earnLastUpdateBlock_gt: BigInt
+  earnLastUpdateBlock_lt: BigInt
+  earnLastUpdateBlock_gte: BigInt
+  earnLastUpdateBlock_lte: BigInt
+  earnLastUpdateBlock_in: [BigInt!]
+  earnLastUpdateBlock_not_in: [BigInt!]
+  earnIsEarning: Boolean
+  earnIsEarning_not: Boolean
+  earnIsEarning_in: [Boolean!]
+  earnIsEarning_not_in: [Boolean!]
+  bucketPositions_: EarnPositionBucket_filter
+  earnCumulativeDepositUSD: BigDecimal
+  earnCumulativeDepositUSD_not: BigDecimal
+  earnCumulativeDepositUSD_gt: BigDecimal
+  earnCumulativeDepositUSD_lt: BigDecimal
+  earnCumulativeDepositUSD_gte: BigDecimal
+  earnCumulativeDepositUSD_lte: BigDecimal
+  earnCumulativeDepositUSD_in: [BigDecimal!]
+  earnCumulativeDepositUSD_not_in: [BigDecimal!]
+  earnCumulativeDepositInQuoteToken: BigDecimal
+  earnCumulativeDepositInQuoteToken_not: BigDecimal
+  earnCumulativeDepositInQuoteToken_gt: BigDecimal
+  earnCumulativeDepositInQuoteToken_lt: BigDecimal
+  earnCumulativeDepositInQuoteToken_gte: BigDecimal
+  earnCumulativeDepositInQuoteToken_lte: BigDecimal
+  earnCumulativeDepositInQuoteToken_in: [BigDecimal!]
+  earnCumulativeDepositInQuoteToken_not_in: [BigDecimal!]
+  earnCumulativeDepositInCollateralToken: BigDecimal
+  earnCumulativeDepositInCollateralToken_not: BigDecimal
+  earnCumulativeDepositInCollateralToken_gt: BigDecimal
+  earnCumulativeDepositInCollateralToken_lt: BigDecimal
+  earnCumulativeDepositInCollateralToken_gte: BigDecimal
+  earnCumulativeDepositInCollateralToken_lte: BigDecimal
+  earnCumulativeDepositInCollateralToken_in: [BigDecimal!]
+  earnCumulativeDepositInCollateralToken_not_in: [BigDecimal!]
+  earnCumulativeWithdrawUSD: BigDecimal
+  earnCumulativeWithdrawUSD_not: BigDecimal
+  earnCumulativeWithdrawUSD_gt: BigDecimal
+  earnCumulativeWithdrawUSD_lt: BigDecimal
+  earnCumulativeWithdrawUSD_gte: BigDecimal
+  earnCumulativeWithdrawUSD_lte: BigDecimal
+  earnCumulativeWithdrawUSD_in: [BigDecimal!]
+  earnCumulativeWithdrawUSD_not_in: [BigDecimal!]
+  earnCumulativeWithdrawInQuoteToken: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_not: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_gt: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_lt: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_gte: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_lte: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_in: [BigDecimal!]
+  earnCumulativeWithdrawInQuoteToken_not_in: [BigDecimal!]
+  earnCumulativeWithdrawInCollateralToken: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_not: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_gt: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_lt: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_gte: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_lte: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_in: [BigDecimal!]
+  earnCumulativeWithdrawInCollateralToken_not_in: [BigDecimal!]
+  earnCumulativeFeesUSD: BigDecimal
+  earnCumulativeFeesUSD_not: BigDecimal
+  earnCumulativeFeesUSD_gt: BigDecimal
+  earnCumulativeFeesUSD_lt: BigDecimal
+  earnCumulativeFeesUSD_gte: BigDecimal
+  earnCumulativeFeesUSD_lte: BigDecimal
+  earnCumulativeFeesUSD_in: [BigDecimal!]
+  earnCumulativeFeesUSD_not_in: [BigDecimal!]
+  earnCumulativeFeesInQuoteToken: BigDecimal
+  earnCumulativeFeesInQuoteToken_not: BigDecimal
+  earnCumulativeFeesInQuoteToken_gt: BigDecimal
+  earnCumulativeFeesInQuoteToken_lt: BigDecimal
+  earnCumulativeFeesInQuoteToken_gte: BigDecimal
+  earnCumulativeFeesInQuoteToken_lte: BigDecimal
+  earnCumulativeFeesInQuoteToken_in: [BigDecimal!]
+  earnCumulativeFeesInQuoteToken_not_in: [BigDecimal!]
+  earnCumulativeFeesInCollateralToken: BigDecimal
+  earnCumulativeFeesInCollateralToken_not: BigDecimal
+  earnCumulativeFeesInCollateralToken_gt: BigDecimal
+  earnCumulativeFeesInCollateralToken_lt: BigDecimal
+  earnCumulativeFeesInCollateralToken_gte: BigDecimal
+  earnCumulativeFeesInCollateralToken_lte: BigDecimal
+  earnCumulativeFeesInCollateralToken_in: [BigDecimal!]
+  earnCumulativeFeesInCollateralToken_not_in: [BigDecimal!]
+  earnCumulativeQuoteTokenDeposit: BigDecimal
+  earnCumulativeQuoteTokenDeposit_not: BigDecimal
+  earnCumulativeQuoteTokenDeposit_gt: BigDecimal
+  earnCumulativeQuoteTokenDeposit_lt: BigDecimal
+  earnCumulativeQuoteTokenDeposit_gte: BigDecimal
+  earnCumulativeQuoteTokenDeposit_lte: BigDecimal
+  earnCumulativeQuoteTokenDeposit_in: [BigDecimal!]
+  earnCumulativeQuoteTokenDeposit_not_in: [BigDecimal!]
+  earnCumulativeQuoteTokenWithdraw: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_not: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_gt: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_lt: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_gte: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_lte: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_in: [BigDecimal!]
+  earnCumulativeQuoteTokenWithdraw_not_in: [BigDecimal!]
+  oasisEvents_: OasisEvent_filter
+  protocolEvents_: LenderEvent_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EarnPosition_filter]
+  or: [EarnPosition_filter]
+}
+
+enum EarnPosition_orderBy {
+  id
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  user
+  user__id
+  user__address
+  user__vaultCount
+  nft
+  nft__id
+  nft__tokenId
+  nft__staked
+  nft__currentReward
+  earnPosition
+  earnPosition__id
+  earnPosition__index
+  earnPosition__lps
+  earnPosition__depositTime
+  earnDailyTokenBlocks
+  earnLastUpdateBlock
+  earnIsEarning
+  bucketPositions
+  earnCumulativeDepositUSD
+  earnCumulativeDepositInQuoteToken
+  earnCumulativeDepositInCollateralToken
+  earnCumulativeWithdrawUSD
+  earnCumulativeWithdrawInQuoteToken
+  earnCumulativeWithdrawInCollateralToken
+  earnCumulativeFeesUSD
+  earnCumulativeFeesInQuoteToken
+  earnCumulativeFeesInCollateralToken
+  earnCumulativeQuoteTokenDeposit
+  earnCumulativeQuoteTokenWithdraw
+  oasisEvents
+  protocolEvents
+}
+
+type EarnPositionBucket {
+  id: ID!
+  pool: Pool!
+  index: BigInt!
+  account: Account
+  user: User!
+  lps: BigInt!
+  depositTime: BigInt!
+  nft: NFT
+  position: EarnPosition!
+  protocolEvents(skip: Int = 0, first: Int = 100, orderBy: LenderEvent_orderBy, orderDirection: OrderDirection, where: LenderEvent_filter): [LenderEvent!]
+}
+
+input EarnPositionBucket_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  index: BigInt
+  index_not: BigInt
+  index_gt: BigInt
+  index_lt: BigInt
+  index_gte: BigInt
+  index_lte: BigInt
+  index_in: [BigInt!]
+  index_not_in: [BigInt!]
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  lps: BigInt
+  lps_not: BigInt
+  lps_gt: BigInt
+  lps_lt: BigInt
+  lps_gte: BigInt
+  lps_lte: BigInt
+  lps_in: [BigInt!]
+  lps_not_in: [BigInt!]
+  depositTime: BigInt
+  depositTime_not: BigInt
+  depositTime_gt: BigInt
+  depositTime_lt: BigInt
+  depositTime_gte: BigInt
+  depositTime_lte: BigInt
+  depositTime_in: [BigInt!]
+  depositTime_not_in: [BigInt!]
+  nft: String
+  nft_not: String
+  nft_gt: String
+  nft_lt: String
+  nft_gte: String
+  nft_lte: String
+  nft_in: [String!]
+  nft_not_in: [String!]
+  nft_contains: String
+  nft_contains_nocase: String
+  nft_not_contains: String
+  nft_not_contains_nocase: String
+  nft_starts_with: String
+  nft_starts_with_nocase: String
+  nft_not_starts_with: String
+  nft_not_starts_with_nocase: String
+  nft_ends_with: String
+  nft_ends_with_nocase: String
+  nft_not_ends_with: String
+  nft_not_ends_with_nocase: String
+  nft_: NFT_filter
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: EarnPosition_filter
+  protocolEvents_: LenderEvent_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EarnPositionBucket_filter]
+  or: [EarnPositionBucket_filter]
+}
+
+enum EarnPositionBucket_orderBy {
+  id
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  index
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  user
+  user__id
+  user__address
+  user__vaultCount
+  lps
+  depositTime
+  nft
+  nft__id
+  nft__tokenId
+  nft__staked
+  nft__currentReward
+  position
+  position__id
+  position__earnDailyTokenBlocks
+  position__earnLastUpdateBlock
+  position__earnIsEarning
+  position__earnCumulativeDepositUSD
+  position__earnCumulativeDepositInQuoteToken
+  position__earnCumulativeDepositInCollateralToken
+  position__earnCumulativeWithdrawUSD
+  position__earnCumulativeWithdrawInQuoteToken
+  position__earnCumulativeWithdrawInCollateralToken
+  position__earnCumulativeFeesUSD
+  position__earnCumulativeFeesInQuoteToken
+  position__earnCumulativeFeesInCollateralToken
+  position__earnCumulativeQuoteTokenDeposit
+  position__earnCumulativeQuoteTokenWithdraw
+  protocolEvents
+}
+
+type FeePaid {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: Bytes!
+  beneficiary: Bytes!
+  amount: BigInt!
+  token: Bytes!
+}
+
+input FeePaid_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  beneficiary: Bytes
+  beneficiary_not: Bytes
+  beneficiary_gt: Bytes
+  beneficiary_lt: Bytes
+  beneficiary_gte: Bytes
+  beneficiary_lte: Bytes
+  beneficiary_in: [Bytes!]
+  beneficiary_not_in: [Bytes!]
+  beneficiary_contains: Bytes
+  beneficiary_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  token: Bytes
+  token_not: Bytes
+  token_gt: Bytes
+  token_lt: Bytes
+  token_gte: Bytes
+  token_lte: Bytes
+  token_in: [Bytes!]
+  token_not_in: [Bytes!]
+  token_contains: Bytes
+  token_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [FeePaid_filter]
+  or: [FeePaid_filter]
+}
+
+enum FeePaid_orderBy {
+  id
+  beneficiary
+  amount
+  token
+}
+
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
+type LenderEvent {
+  id: ID!
+  position: EarnPositionBucket!
+  earnPosition: EarnPosition!
+  account: Account
+  kind: String!
+  pool: Pool!
+  quoteToken: Token!
+  collateralToken: Token!
+  quoteTokenPriceUSD: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  quoteBefore: BigDecimal!
+  quoteAfter: BigDecimal!
+  quoteDelta: BigDecimal!
+  lender: String
+  index: BigInt
+  amount: BigInt
+  lup: BigInt
+  lpAwarded: BigInt
+  from: BigInt
+  to: BigInt
+  lpRedeemedFrom: BigInt
+  lpAwardedTo: BigInt
+  lpRedeemed: BigInt
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input LenderEvent_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: EarnPositionBucket_filter
+  earnPosition: String
+  earnPosition_not: String
+  earnPosition_gt: String
+  earnPosition_lt: String
+  earnPosition_gte: String
+  earnPosition_lte: String
+  earnPosition_in: [String!]
+  earnPosition_not_in: [String!]
+  earnPosition_contains: String
+  earnPosition_contains_nocase: String
+  earnPosition_not_contains: String
+  earnPosition_not_contains_nocase: String
+  earnPosition_starts_with: String
+  earnPosition_starts_with_nocase: String
+  earnPosition_not_starts_with: String
+  earnPosition_not_starts_with_nocase: String
+  earnPosition_ends_with: String
+  earnPosition_ends_with_nocase: String
+  earnPosition_not_ends_with: String
+  earnPosition_not_ends_with_nocase: String
+  earnPosition_: EarnPosition_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  quoteToken: String
+  quoteToken_not: String
+  quoteToken_gt: String
+  quoteToken_lt: String
+  quoteToken_gte: String
+  quoteToken_lte: String
+  quoteToken_in: [String!]
+  quoteToken_not_in: [String!]
+  quoteToken_contains: String
+  quoteToken_contains_nocase: String
+  quoteToken_not_contains: String
+  quoteToken_not_contains_nocase: String
+  quoteToken_starts_with: String
+  quoteToken_starts_with_nocase: String
+  quoteToken_not_starts_with: String
+  quoteToken_not_starts_with_nocase: String
+  quoteToken_ends_with: String
+  quoteToken_ends_with_nocase: String
+  quoteToken_not_ends_with: String
+  quoteToken_not_ends_with_nocase: String
+  quoteToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  quoteTokenPriceUSD: BigDecimal
+  quoteTokenPriceUSD_not: BigDecimal
+  quoteTokenPriceUSD_gt: BigDecimal
+  quoteTokenPriceUSD_lt: BigDecimal
+  quoteTokenPriceUSD_gte: BigDecimal
+  quoteTokenPriceUSD_lte: BigDecimal
+  quoteTokenPriceUSD_in: [BigDecimal!]
+  quoteTokenPriceUSD_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  quoteBefore: BigDecimal
+  quoteBefore_not: BigDecimal
+  quoteBefore_gt: BigDecimal
+  quoteBefore_lt: BigDecimal
+  quoteBefore_gte: BigDecimal
+  quoteBefore_lte: BigDecimal
+  quoteBefore_in: [BigDecimal!]
+  quoteBefore_not_in: [BigDecimal!]
+  quoteAfter: BigDecimal
+  quoteAfter_not: BigDecimal
+  quoteAfter_gt: BigDecimal
+  quoteAfter_lt: BigDecimal
+  quoteAfter_gte: BigDecimal
+  quoteAfter_lte: BigDecimal
+  quoteAfter_in: [BigDecimal!]
+  quoteAfter_not_in: [BigDecimal!]
+  quoteDelta: BigDecimal
+  quoteDelta_not: BigDecimal
+  quoteDelta_gt: BigDecimal
+  quoteDelta_lt: BigDecimal
+  quoteDelta_gte: BigDecimal
+  quoteDelta_lte: BigDecimal
+  quoteDelta_in: [BigDecimal!]
+  quoteDelta_not_in: [BigDecimal!]
+  lender: String
+  lender_not: String
+  lender_gt: String
+  lender_lt: String
+  lender_gte: String
+  lender_lte: String
+  lender_in: [String!]
+  lender_not_in: [String!]
+  lender_contains: String
+  lender_contains_nocase: String
+  lender_not_contains: String
+  lender_not_contains_nocase: String
+  lender_starts_with: String
+  lender_starts_with_nocase: String
+  lender_not_starts_with: String
+  lender_not_starts_with_nocase: String
+  lender_ends_with: String
+  lender_ends_with_nocase: String
+  lender_not_ends_with: String
+  lender_not_ends_with_nocase: String
+  index: BigInt
+  index_not: BigInt
+  index_gt: BigInt
+  index_lt: BigInt
+  index_gte: BigInt
+  index_lte: BigInt
+  index_in: [BigInt!]
+  index_not_in: [BigInt!]
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  lup: BigInt
+  lup_not: BigInt
+  lup_gt: BigInt
+  lup_lt: BigInt
+  lup_gte: BigInt
+  lup_lte: BigInt
+  lup_in: [BigInt!]
+  lup_not_in: [BigInt!]
+  lpAwarded: BigInt
+  lpAwarded_not: BigInt
+  lpAwarded_gt: BigInt
+  lpAwarded_lt: BigInt
+  lpAwarded_gte: BigInt
+  lpAwarded_lte: BigInt
+  lpAwarded_in: [BigInt!]
+  lpAwarded_not_in: [BigInt!]
+  from: BigInt
+  from_not: BigInt
+  from_gt: BigInt
+  from_lt: BigInt
+  from_gte: BigInt
+  from_lte: BigInt
+  from_in: [BigInt!]
+  from_not_in: [BigInt!]
+  to: BigInt
+  to_not: BigInt
+  to_gt: BigInt
+  to_lt: BigInt
+  to_gte: BigInt
+  to_lte: BigInt
+  to_in: [BigInt!]
+  to_not_in: [BigInt!]
+  lpRedeemedFrom: BigInt
+  lpRedeemedFrom_not: BigInt
+  lpRedeemedFrom_gt: BigInt
+  lpRedeemedFrom_lt: BigInt
+  lpRedeemedFrom_gte: BigInt
+  lpRedeemedFrom_lte: BigInt
+  lpRedeemedFrom_in: [BigInt!]
+  lpRedeemedFrom_not_in: [BigInt!]
+  lpAwardedTo: BigInt
+  lpAwardedTo_not: BigInt
+  lpAwardedTo_gt: BigInt
+  lpAwardedTo_lt: BigInt
+  lpAwardedTo_gte: BigInt
+  lpAwardedTo_lte: BigInt
+  lpAwardedTo_in: [BigInt!]
+  lpAwardedTo_not_in: [BigInt!]
+  lpRedeemed: BigInt
+  lpRedeemed_not: BigInt
+  lpRedeemed_gt: BigInt
+  lpRedeemed_lt: BigInt
+  lpRedeemed_gte: BigInt
+  lpRedeemed_lte: BigInt
+  lpRedeemed_in: [BigInt!]
+  lpRedeemed_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [LenderEvent_filter]
+  or: [LenderEvent_filter]
+}
+
+enum LenderEvent_orderBy {
+  id
+  position
+  position__id
+  position__index
+  position__lps
+  position__depositTime
+  earnPosition
+  earnPosition__id
+  earnPosition__earnDailyTokenBlocks
+  earnPosition__earnLastUpdateBlock
+  earnPosition__earnIsEarning
+  earnPosition__earnCumulativeDepositUSD
+  earnPosition__earnCumulativeDepositInQuoteToken
+  earnPosition__earnCumulativeDepositInCollateralToken
+  earnPosition__earnCumulativeWithdrawUSD
+  earnPosition__earnCumulativeWithdrawInQuoteToken
+  earnPosition__earnCumulativeWithdrawInCollateralToken
+  earnPosition__earnCumulativeFeesUSD
+  earnPosition__earnCumulativeFeesInQuoteToken
+  earnPosition__earnCumulativeFeesInCollateralToken
+  earnPosition__earnCumulativeQuoteTokenDeposit
+  earnPosition__earnCumulativeQuoteTokenWithdraw
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  kind
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  quoteToken
+  quoteToken__id
+  quoteToken__address
+  quoteToken__decimals
+  quoteToken__precision
+  quoteToken__symbol
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  quoteTokenPriceUSD
+  collateralTokenPriceUSD
+  quoteBefore
+  quoteAfter
+  quoteDelta
+  lender
+  index
+  amount
+  lup
+  lpAwarded
+  from
+  to
+  lpRedeemedFrom
+  lpAwardedTo
+  lpRedeemed
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ListOfPool {
+  id: ID!
+  pools(skip: Int = 0, first: Int = 100, orderBy: Pool_orderBy, orderDirection: OrderDirection, where: Pool_filter): [Pool!]!
+}
+
+input ListOfPool_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  pools: [String!]
+  pools_not: [String!]
+  pools_contains: [String!]
+  pools_contains_nocase: [String!]
+  pools_not_contains: [String!]
+  pools_not_contains_nocase: [String!]
+  pools_: Pool_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ListOfPool_filter]
+  or: [ListOfPool_filter]
+}
+
+enum ListOfPool_orderBy {
+  id
+  pools
+}
+
+type NFT {
+  id: ID!
+  tokenId: BigInt!
+  user: User
+  account: Account
+  pool: Pool!
+  buckets(skip: Int = 0, first: Int = 100, orderBy: EarnPositionBucket_orderBy, orderDirection: OrderDirection, where: EarnPositionBucket_filter): [EarnPositionBucket!]
+  staked: Boolean!
+  currentReward: BigInt!
+}
+
+input NFT_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  tokenId: BigInt
+  tokenId_not: BigInt
+  tokenId_gt: BigInt
+  tokenId_lt: BigInt
+  tokenId_gte: BigInt
+  tokenId_lte: BigInt
+  tokenId_in: [BigInt!]
+  tokenId_not_in: [BigInt!]
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  buckets_: EarnPositionBucket_filter
+  staked: Boolean
+  staked_not: Boolean
+  staked_in: [Boolean!]
+  staked_not_in: [Boolean!]
+  currentReward: BigInt
+  currentReward_not: BigInt
+  currentReward_gt: BigInt
+  currentReward_lt: BigInt
+  currentReward_gte: BigInt
+  currentReward_lte: BigInt
+  currentReward_in: [BigInt!]
+  currentReward_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NFT_filter]
+  or: [NFT_filter]
+}
+
+enum NFT_orderBy {
+  id
+  tokenId
+  user
+  user__id
+  user__address
+  user__vaultCount
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  buckets
+  staked
+  currentReward
+}
+
+type OasisEvent {
+  id: Bytes!
+  kind: String!
+  isOpen: Boolean
+  account: Account!
+  earnPosition: EarnPosition
+  borrowPosition: BorrowPosition
+  pool: Pool
+  debtToken: Token
+  debtAddress: Bytes!
+  debtBefore: BigDecimal!
+  debtAfter: BigDecimal!
+  debtDelta: BigDecimal!
+  debtTokenPriceUSD: BigDecimal!
+  collateralToken: Token
+  collateralAddress: Bytes!
+  collateralBefore: BigDecimal!
+  collateralAfter: BigDecimal!
+  collateralDelta: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  debtOraclePrice: BigDecimal!
+  collateralOraclePrice: BigDecimal!
+  swapFromToken: Bytes
+  swapToToken: Bytes
+  swapFromAmount: BigDecimal
+  swapToAmount: BigDecimal
+  marketPrice: BigDecimal
+  depositTransfers(skip: Int = 0, first: Int = 100, orderBy: Transfer_orderBy, orderDirection: OrderDirection, where: Transfer_filter): [Transfer!]!
+  depositedUSD: BigDecimal
+  depositedInQuoteToken: BigDecimal!
+  withdrawTransfers(skip: Int = 0, first: Int = 100, orderBy: Transfer_orderBy, orderDirection: OrderDirection, where: Transfer_filter): [Transfer!]!
+  withdrawnUSD: BigDecimal
+  withdrawnInQuoteToken: BigDecimal!
+  oasisFeeToken: Bytes
+  oasisFee: BigDecimal!
+  oasisFeeUSD: BigDecimal!
+  oasisFeeInQuoteToken: BigDecimal!
+  oasisFeeInCollateralToken: BigDecimal!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  gasFeeUSD: BigDecimal!
+  gasFeeInQuoteToken: BigDecimal!
+  gasFeeInCollateralToken: BigDecimal!
+  totalFee: BigDecimal!
+  totalFeeInQuoteToken: BigDecimal!
+  totalFeeInCollateralToken: BigDecimal!
+  totalFeeUSD: BigDecimal!
+  multipleBefore: BigDecimal
+  multipleAfter: BigDecimal
+  netValueBefore: BigDecimal
+  netValueAfter: BigDecimal
+  ltvBefore: BigDecimal
+  ltvAfter: BigDecimal
+  liquidationPriceBefore: BigDecimal!
+  liquidationPriceAfter: BigDecimal!
+  originationFee: BigDecimal!
+  originationFeeUSD: BigDecimal!
+  originationFeeInQuoteToken: BigDecimal!
+  originationFeeInCollateralToken: BigDecimal!
+  interestRate: BigInt
+  quoteTokensDelta: BigDecimal
+  quoteTokensBefore: BigDecimal
+  quoteTokensAfter: BigDecimal
+  quoteTokensMoved: BigDecimal
+  collateralLpsRemoved: BigDecimal
+  moveQuoteFromIndex: BigInt
+  moveQuoteToIndex: BigInt
+  addOrRemoveIndex: BigInt
+  ethPrice: BigDecimal!
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  txHash: Bytes!
+}
+
+input OasisEvent_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  isOpen: Boolean
+  isOpen_not: Boolean
+  isOpen_in: [Boolean!]
+  isOpen_not_in: [Boolean!]
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  earnPosition: String
+  earnPosition_not: String
+  earnPosition_gt: String
+  earnPosition_lt: String
+  earnPosition_gte: String
+  earnPosition_lte: String
+  earnPosition_in: [String!]
+  earnPosition_not_in: [String!]
+  earnPosition_contains: String
+  earnPosition_contains_nocase: String
+  earnPosition_not_contains: String
+  earnPosition_not_contains_nocase: String
+  earnPosition_starts_with: String
+  earnPosition_starts_with_nocase: String
+  earnPosition_not_starts_with: String
+  earnPosition_not_starts_with_nocase: String
+  earnPosition_ends_with: String
+  earnPosition_ends_with_nocase: String
+  earnPosition_not_ends_with: String
+  earnPosition_not_ends_with_nocase: String
+  earnPosition_: EarnPosition_filter
+  borrowPosition: String
+  borrowPosition_not: String
+  borrowPosition_gt: String
+  borrowPosition_lt: String
+  borrowPosition_gte: String
+  borrowPosition_lte: String
+  borrowPosition_in: [String!]
+  borrowPosition_not_in: [String!]
+  borrowPosition_contains: String
+  borrowPosition_contains_nocase: String
+  borrowPosition_not_contains: String
+  borrowPosition_not_contains_nocase: String
+  borrowPosition_starts_with: String
+  borrowPosition_starts_with_nocase: String
+  borrowPosition_not_starts_with: String
+  borrowPosition_not_starts_with_nocase: String
+  borrowPosition_ends_with: String
+  borrowPosition_ends_with_nocase: String
+  borrowPosition_not_ends_with: String
+  borrowPosition_not_ends_with_nocase: String
+  borrowPosition_: BorrowPosition_filter
+  pool: String
+  pool_not: String
+  pool_gt: String
+  pool_lt: String
+  pool_gte: String
+  pool_lte: String
+  pool_in: [String!]
+  pool_not_in: [String!]
+  pool_contains: String
+  pool_contains_nocase: String
+  pool_not_contains: String
+  pool_not_contains_nocase: String
+  pool_starts_with: String
+  pool_starts_with_nocase: String
+  pool_not_starts_with: String
+  pool_not_starts_with_nocase: String
+  pool_ends_with: String
+  pool_ends_with_nocase: String
+  pool_not_ends_with: String
+  pool_not_ends_with_nocase: String
+  pool_: Pool_filter
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  debtAddress: Bytes
+  debtAddress_not: Bytes
+  debtAddress_gt: Bytes
+  debtAddress_lt: Bytes
+  debtAddress_gte: Bytes
+  debtAddress_lte: Bytes
+  debtAddress_in: [Bytes!]
+  debtAddress_not_in: [Bytes!]
+  debtAddress_contains: Bytes
+  debtAddress_not_contains: Bytes
+  debtBefore: BigDecimal
+  debtBefore_not: BigDecimal
+  debtBefore_gt: BigDecimal
+  debtBefore_lt: BigDecimal
+  debtBefore_gte: BigDecimal
+  debtBefore_lte: BigDecimal
+  debtBefore_in: [BigDecimal!]
+  debtBefore_not_in: [BigDecimal!]
+  debtAfter: BigDecimal
+  debtAfter_not: BigDecimal
+  debtAfter_gt: BigDecimal
+  debtAfter_lt: BigDecimal
+  debtAfter_gte: BigDecimal
+  debtAfter_lte: BigDecimal
+  debtAfter_in: [BigDecimal!]
+  debtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  collateralAddress: Bytes
+  collateralAddress_not: Bytes
+  collateralAddress_gt: Bytes
+  collateralAddress_lt: Bytes
+  collateralAddress_gte: Bytes
+  collateralAddress_lte: Bytes
+  collateralAddress_in: [Bytes!]
+  collateralAddress_not_in: [Bytes!]
+  collateralAddress_contains: Bytes
+  collateralAddress_not_contains: Bytes
+  collateralBefore: BigDecimal
+  collateralBefore_not: BigDecimal
+  collateralBefore_gt: BigDecimal
+  collateralBefore_lt: BigDecimal
+  collateralBefore_gte: BigDecimal
+  collateralBefore_lte: BigDecimal
+  collateralBefore_in: [BigDecimal!]
+  collateralBefore_not_in: [BigDecimal!]
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  debtOraclePrice: BigDecimal
+  debtOraclePrice_not: BigDecimal
+  debtOraclePrice_gt: BigDecimal
+  debtOraclePrice_lt: BigDecimal
+  debtOraclePrice_gte: BigDecimal
+  debtOraclePrice_lte: BigDecimal
+  debtOraclePrice_in: [BigDecimal!]
+  debtOraclePrice_not_in: [BigDecimal!]
+  collateralOraclePrice: BigDecimal
+  collateralOraclePrice_not: BigDecimal
+  collateralOraclePrice_gt: BigDecimal
+  collateralOraclePrice_lt: BigDecimal
+  collateralOraclePrice_gte: BigDecimal
+  collateralOraclePrice_lte: BigDecimal
+  collateralOraclePrice_in: [BigDecimal!]
+  collateralOraclePrice_not_in: [BigDecimal!]
+  swapFromToken: Bytes
+  swapFromToken_not: Bytes
+  swapFromToken_gt: Bytes
+  swapFromToken_lt: Bytes
+  swapFromToken_gte: Bytes
+  swapFromToken_lte: Bytes
+  swapFromToken_in: [Bytes!]
+  swapFromToken_not_in: [Bytes!]
+  swapFromToken_contains: Bytes
+  swapFromToken_not_contains: Bytes
+  swapToToken: Bytes
+  swapToToken_not: Bytes
+  swapToToken_gt: Bytes
+  swapToToken_lt: Bytes
+  swapToToken_gte: Bytes
+  swapToToken_lte: Bytes
+  swapToToken_in: [Bytes!]
+  swapToToken_not_in: [Bytes!]
+  swapToToken_contains: Bytes
+  swapToToken_not_contains: Bytes
+  swapFromAmount: BigDecimal
+  swapFromAmount_not: BigDecimal
+  swapFromAmount_gt: BigDecimal
+  swapFromAmount_lt: BigDecimal
+  swapFromAmount_gte: BigDecimal
+  swapFromAmount_lte: BigDecimal
+  swapFromAmount_in: [BigDecimal!]
+  swapFromAmount_not_in: [BigDecimal!]
+  swapToAmount: BigDecimal
+  swapToAmount_not: BigDecimal
+  swapToAmount_gt: BigDecimal
+  swapToAmount_lt: BigDecimal
+  swapToAmount_gte: BigDecimal
+  swapToAmount_lte: BigDecimal
+  swapToAmount_in: [BigDecimal!]
+  swapToAmount_not_in: [BigDecimal!]
+  marketPrice: BigDecimal
+  marketPrice_not: BigDecimal
+  marketPrice_gt: BigDecimal
+  marketPrice_lt: BigDecimal
+  marketPrice_gte: BigDecimal
+  marketPrice_lte: BigDecimal
+  marketPrice_in: [BigDecimal!]
+  marketPrice_not_in: [BigDecimal!]
+  depositTransfers: [String!]
+  depositTransfers_not: [String!]
+  depositTransfers_contains: [String!]
+  depositTransfers_contains_nocase: [String!]
+  depositTransfers_not_contains: [String!]
+  depositTransfers_not_contains_nocase: [String!]
+  depositTransfers_: Transfer_filter
+  depositedUSD: BigDecimal
+  depositedUSD_not: BigDecimal
+  depositedUSD_gt: BigDecimal
+  depositedUSD_lt: BigDecimal
+  depositedUSD_gte: BigDecimal
+  depositedUSD_lte: BigDecimal
+  depositedUSD_in: [BigDecimal!]
+  depositedUSD_not_in: [BigDecimal!]
+  depositedInQuoteToken: BigDecimal
+  depositedInQuoteToken_not: BigDecimal
+  depositedInQuoteToken_gt: BigDecimal
+  depositedInQuoteToken_lt: BigDecimal
+  depositedInQuoteToken_gte: BigDecimal
+  depositedInQuoteToken_lte: BigDecimal
+  depositedInQuoteToken_in: [BigDecimal!]
+  depositedInQuoteToken_not_in: [BigDecimal!]
+  withdrawTransfers: [String!]
+  withdrawTransfers_not: [String!]
+  withdrawTransfers_contains: [String!]
+  withdrawTransfers_contains_nocase: [String!]
+  withdrawTransfers_not_contains: [String!]
+  withdrawTransfers_not_contains_nocase: [String!]
+  withdrawTransfers_: Transfer_filter
+  withdrawnUSD: BigDecimal
+  withdrawnUSD_not: BigDecimal
+  withdrawnUSD_gt: BigDecimal
+  withdrawnUSD_lt: BigDecimal
+  withdrawnUSD_gte: BigDecimal
+  withdrawnUSD_lte: BigDecimal
+  withdrawnUSD_in: [BigDecimal!]
+  withdrawnUSD_not_in: [BigDecimal!]
+  withdrawnInQuoteToken: BigDecimal
+  withdrawnInQuoteToken_not: BigDecimal
+  withdrawnInQuoteToken_gt: BigDecimal
+  withdrawnInQuoteToken_lt: BigDecimal
+  withdrawnInQuoteToken_gte: BigDecimal
+  withdrawnInQuoteToken_lte: BigDecimal
+  withdrawnInQuoteToken_in: [BigDecimal!]
+  withdrawnInQuoteToken_not_in: [BigDecimal!]
+  oasisFeeToken: Bytes
+  oasisFeeToken_not: Bytes
+  oasisFeeToken_gt: Bytes
+  oasisFeeToken_lt: Bytes
+  oasisFeeToken_gte: Bytes
+  oasisFeeToken_lte: Bytes
+  oasisFeeToken_in: [Bytes!]
+  oasisFeeToken_not_in: [Bytes!]
+  oasisFeeToken_contains: Bytes
+  oasisFeeToken_not_contains: Bytes
+  oasisFee: BigDecimal
+  oasisFee_not: BigDecimal
+  oasisFee_gt: BigDecimal
+  oasisFee_lt: BigDecimal
+  oasisFee_gte: BigDecimal
+  oasisFee_lte: BigDecimal
+  oasisFee_in: [BigDecimal!]
+  oasisFee_not_in: [BigDecimal!]
+  oasisFeeUSD: BigDecimal
+  oasisFeeUSD_not: BigDecimal
+  oasisFeeUSD_gt: BigDecimal
+  oasisFeeUSD_lt: BigDecimal
+  oasisFeeUSD_gte: BigDecimal
+  oasisFeeUSD_lte: BigDecimal
+  oasisFeeUSD_in: [BigDecimal!]
+  oasisFeeUSD_not_in: [BigDecimal!]
+  oasisFeeInQuoteToken: BigDecimal
+  oasisFeeInQuoteToken_not: BigDecimal
+  oasisFeeInQuoteToken_gt: BigDecimal
+  oasisFeeInQuoteToken_lt: BigDecimal
+  oasisFeeInQuoteToken_gte: BigDecimal
+  oasisFeeInQuoteToken_lte: BigDecimal
+  oasisFeeInQuoteToken_in: [BigDecimal!]
+  oasisFeeInQuoteToken_not_in: [BigDecimal!]
+  oasisFeeInCollateralToken: BigDecimal
+  oasisFeeInCollateralToken_not: BigDecimal
+  oasisFeeInCollateralToken_gt: BigDecimal
+  oasisFeeInCollateralToken_lt: BigDecimal
+  oasisFeeInCollateralToken_gte: BigDecimal
+  oasisFeeInCollateralToken_lte: BigDecimal
+  oasisFeeInCollateralToken_in: [BigDecimal!]
+  oasisFeeInCollateralToken_not_in: [BigDecimal!]
+  gasUsed: BigInt
+  gasUsed_not: BigInt
+  gasUsed_gt: BigInt
+  gasUsed_lt: BigInt
+  gasUsed_gte: BigInt
+  gasUsed_lte: BigInt
+  gasUsed_in: [BigInt!]
+  gasUsed_not_in: [BigInt!]
+  gasPrice: BigInt
+  gasPrice_not: BigInt
+  gasPrice_gt: BigInt
+  gasPrice_lt: BigInt
+  gasPrice_gte: BigInt
+  gasPrice_lte: BigInt
+  gasPrice_in: [BigInt!]
+  gasPrice_not_in: [BigInt!]
+  gasFeeUSD: BigDecimal
+  gasFeeUSD_not: BigDecimal
+  gasFeeUSD_gt: BigDecimal
+  gasFeeUSD_lt: BigDecimal
+  gasFeeUSD_gte: BigDecimal
+  gasFeeUSD_lte: BigDecimal
+  gasFeeUSD_in: [BigDecimal!]
+  gasFeeUSD_not_in: [BigDecimal!]
+  gasFeeInQuoteToken: BigDecimal
+  gasFeeInQuoteToken_not: BigDecimal
+  gasFeeInQuoteToken_gt: BigDecimal
+  gasFeeInQuoteToken_lt: BigDecimal
+  gasFeeInQuoteToken_gte: BigDecimal
+  gasFeeInQuoteToken_lte: BigDecimal
+  gasFeeInQuoteToken_in: [BigDecimal!]
+  gasFeeInQuoteToken_not_in: [BigDecimal!]
+  gasFeeInCollateralToken: BigDecimal
+  gasFeeInCollateralToken_not: BigDecimal
+  gasFeeInCollateralToken_gt: BigDecimal
+  gasFeeInCollateralToken_lt: BigDecimal
+  gasFeeInCollateralToken_gte: BigDecimal
+  gasFeeInCollateralToken_lte: BigDecimal
+  gasFeeInCollateralToken_in: [BigDecimal!]
+  gasFeeInCollateralToken_not_in: [BigDecimal!]
+  totalFee: BigDecimal
+  totalFee_not: BigDecimal
+  totalFee_gt: BigDecimal
+  totalFee_lt: BigDecimal
+  totalFee_gte: BigDecimal
+  totalFee_lte: BigDecimal
+  totalFee_in: [BigDecimal!]
+  totalFee_not_in: [BigDecimal!]
+  totalFeeInQuoteToken: BigDecimal
+  totalFeeInQuoteToken_not: BigDecimal
+  totalFeeInQuoteToken_gt: BigDecimal
+  totalFeeInQuoteToken_lt: BigDecimal
+  totalFeeInQuoteToken_gte: BigDecimal
+  totalFeeInQuoteToken_lte: BigDecimal
+  totalFeeInQuoteToken_in: [BigDecimal!]
+  totalFeeInQuoteToken_not_in: [BigDecimal!]
+  totalFeeInCollateralToken: BigDecimal
+  totalFeeInCollateralToken_not: BigDecimal
+  totalFeeInCollateralToken_gt: BigDecimal
+  totalFeeInCollateralToken_lt: BigDecimal
+  totalFeeInCollateralToken_gte: BigDecimal
+  totalFeeInCollateralToken_lte: BigDecimal
+  totalFeeInCollateralToken_in: [BigDecimal!]
+  totalFeeInCollateralToken_not_in: [BigDecimal!]
+  totalFeeUSD: BigDecimal
+  totalFeeUSD_not: BigDecimal
+  totalFeeUSD_gt: BigDecimal
+  totalFeeUSD_lt: BigDecimal
+  totalFeeUSD_gte: BigDecimal
+  totalFeeUSD_lte: BigDecimal
+  totalFeeUSD_in: [BigDecimal!]
+  totalFeeUSD_not_in: [BigDecimal!]
+  multipleBefore: BigDecimal
+  multipleBefore_not: BigDecimal
+  multipleBefore_gt: BigDecimal
+  multipleBefore_lt: BigDecimal
+  multipleBefore_gte: BigDecimal
+  multipleBefore_lte: BigDecimal
+  multipleBefore_in: [BigDecimal!]
+  multipleBefore_not_in: [BigDecimal!]
+  multipleAfter: BigDecimal
+  multipleAfter_not: BigDecimal
+  multipleAfter_gt: BigDecimal
+  multipleAfter_lt: BigDecimal
+  multipleAfter_gte: BigDecimal
+  multipleAfter_lte: BigDecimal
+  multipleAfter_in: [BigDecimal!]
+  multipleAfter_not_in: [BigDecimal!]
+  netValueBefore: BigDecimal
+  netValueBefore_not: BigDecimal
+  netValueBefore_gt: BigDecimal
+  netValueBefore_lt: BigDecimal
+  netValueBefore_gte: BigDecimal
+  netValueBefore_lte: BigDecimal
+  netValueBefore_in: [BigDecimal!]
+  netValueBefore_not_in: [BigDecimal!]
+  netValueAfter: BigDecimal
+  netValueAfter_not: BigDecimal
+  netValueAfter_gt: BigDecimal
+  netValueAfter_lt: BigDecimal
+  netValueAfter_gte: BigDecimal
+  netValueAfter_lte: BigDecimal
+  netValueAfter_in: [BigDecimal!]
+  netValueAfter_not_in: [BigDecimal!]
+  ltvBefore: BigDecimal
+  ltvBefore_not: BigDecimal
+  ltvBefore_gt: BigDecimal
+  ltvBefore_lt: BigDecimal
+  ltvBefore_gte: BigDecimal
+  ltvBefore_lte: BigDecimal
+  ltvBefore_in: [BigDecimal!]
+  ltvBefore_not_in: [BigDecimal!]
+  ltvAfter: BigDecimal
+  ltvAfter_not: BigDecimal
+  ltvAfter_gt: BigDecimal
+  ltvAfter_lt: BigDecimal
+  ltvAfter_gte: BigDecimal
+  ltvAfter_lte: BigDecimal
+  ltvAfter_in: [BigDecimal!]
+  ltvAfter_not_in: [BigDecimal!]
+  liquidationPriceBefore: BigDecimal
+  liquidationPriceBefore_not: BigDecimal
+  liquidationPriceBefore_gt: BigDecimal
+  liquidationPriceBefore_lt: BigDecimal
+  liquidationPriceBefore_gte: BigDecimal
+  liquidationPriceBefore_lte: BigDecimal
+  liquidationPriceBefore_in: [BigDecimal!]
+  liquidationPriceBefore_not_in: [BigDecimal!]
+  liquidationPriceAfter: BigDecimal
+  liquidationPriceAfter_not: BigDecimal
+  liquidationPriceAfter_gt: BigDecimal
+  liquidationPriceAfter_lt: BigDecimal
+  liquidationPriceAfter_gte: BigDecimal
+  liquidationPriceAfter_lte: BigDecimal
+  liquidationPriceAfter_in: [BigDecimal!]
+  liquidationPriceAfter_not_in: [BigDecimal!]
+  originationFee: BigDecimal
+  originationFee_not: BigDecimal
+  originationFee_gt: BigDecimal
+  originationFee_lt: BigDecimal
+  originationFee_gte: BigDecimal
+  originationFee_lte: BigDecimal
+  originationFee_in: [BigDecimal!]
+  originationFee_not_in: [BigDecimal!]
+  originationFeeUSD: BigDecimal
+  originationFeeUSD_not: BigDecimal
+  originationFeeUSD_gt: BigDecimal
+  originationFeeUSD_lt: BigDecimal
+  originationFeeUSD_gte: BigDecimal
+  originationFeeUSD_lte: BigDecimal
+  originationFeeUSD_in: [BigDecimal!]
+  originationFeeUSD_not_in: [BigDecimal!]
+  originationFeeInQuoteToken: BigDecimal
+  originationFeeInQuoteToken_not: BigDecimal
+  originationFeeInQuoteToken_gt: BigDecimal
+  originationFeeInQuoteToken_lt: BigDecimal
+  originationFeeInQuoteToken_gte: BigDecimal
+  originationFeeInQuoteToken_lte: BigDecimal
+  originationFeeInQuoteToken_in: [BigDecimal!]
+  originationFeeInQuoteToken_not_in: [BigDecimal!]
+  originationFeeInCollateralToken: BigDecimal
+  originationFeeInCollateralToken_not: BigDecimal
+  originationFeeInCollateralToken_gt: BigDecimal
+  originationFeeInCollateralToken_lt: BigDecimal
+  originationFeeInCollateralToken_gte: BigDecimal
+  originationFeeInCollateralToken_lte: BigDecimal
+  originationFeeInCollateralToken_in: [BigDecimal!]
+  originationFeeInCollateralToken_not_in: [BigDecimal!]
+  interestRate: BigInt
+  interestRate_not: BigInt
+  interestRate_gt: BigInt
+  interestRate_lt: BigInt
+  interestRate_gte: BigInt
+  interestRate_lte: BigInt
+  interestRate_in: [BigInt!]
+  interestRate_not_in: [BigInt!]
+  quoteTokensDelta: BigDecimal
+  quoteTokensDelta_not: BigDecimal
+  quoteTokensDelta_gt: BigDecimal
+  quoteTokensDelta_lt: BigDecimal
+  quoteTokensDelta_gte: BigDecimal
+  quoteTokensDelta_lte: BigDecimal
+  quoteTokensDelta_in: [BigDecimal!]
+  quoteTokensDelta_not_in: [BigDecimal!]
+  quoteTokensBefore: BigDecimal
+  quoteTokensBefore_not: BigDecimal
+  quoteTokensBefore_gt: BigDecimal
+  quoteTokensBefore_lt: BigDecimal
+  quoteTokensBefore_gte: BigDecimal
+  quoteTokensBefore_lte: BigDecimal
+  quoteTokensBefore_in: [BigDecimal!]
+  quoteTokensBefore_not_in: [BigDecimal!]
+  quoteTokensAfter: BigDecimal
+  quoteTokensAfter_not: BigDecimal
+  quoteTokensAfter_gt: BigDecimal
+  quoteTokensAfter_lt: BigDecimal
+  quoteTokensAfter_gte: BigDecimal
+  quoteTokensAfter_lte: BigDecimal
+  quoteTokensAfter_in: [BigDecimal!]
+  quoteTokensAfter_not_in: [BigDecimal!]
+  quoteTokensMoved: BigDecimal
+  quoteTokensMoved_not: BigDecimal
+  quoteTokensMoved_gt: BigDecimal
+  quoteTokensMoved_lt: BigDecimal
+  quoteTokensMoved_gte: BigDecimal
+  quoteTokensMoved_lte: BigDecimal
+  quoteTokensMoved_in: [BigDecimal!]
+  quoteTokensMoved_not_in: [BigDecimal!]
+  collateralLpsRemoved: BigDecimal
+  collateralLpsRemoved_not: BigDecimal
+  collateralLpsRemoved_gt: BigDecimal
+  collateralLpsRemoved_lt: BigDecimal
+  collateralLpsRemoved_gte: BigDecimal
+  collateralLpsRemoved_lte: BigDecimal
+  collateralLpsRemoved_in: [BigDecimal!]
+  collateralLpsRemoved_not_in: [BigDecimal!]
+  moveQuoteFromIndex: BigInt
+  moveQuoteFromIndex_not: BigInt
+  moveQuoteFromIndex_gt: BigInt
+  moveQuoteFromIndex_lt: BigInt
+  moveQuoteFromIndex_gte: BigInt
+  moveQuoteFromIndex_lte: BigInt
+  moveQuoteFromIndex_in: [BigInt!]
+  moveQuoteFromIndex_not_in: [BigInt!]
+  moveQuoteToIndex: BigInt
+  moveQuoteToIndex_not: BigInt
+  moveQuoteToIndex_gt: BigInt
+  moveQuoteToIndex_lt: BigInt
+  moveQuoteToIndex_gte: BigInt
+  moveQuoteToIndex_lte: BigInt
+  moveQuoteToIndex_in: [BigInt!]
+  moveQuoteToIndex_not_in: [BigInt!]
+  addOrRemoveIndex: BigInt
+  addOrRemoveIndex_not: BigInt
+  addOrRemoveIndex_gt: BigInt
+  addOrRemoveIndex_lt: BigInt
+  addOrRemoveIndex_gte: BigInt
+  addOrRemoveIndex_lte: BigInt
+  addOrRemoveIndex_in: [BigInt!]
+  addOrRemoveIndex_not_in: [BigInt!]
+  ethPrice: BigDecimal
+  ethPrice_not: BigDecimal
+  ethPrice_gt: BigDecimal
+  ethPrice_lt: BigDecimal
+  ethPrice_gte: BigDecimal
+  ethPrice_lte: BigDecimal
+  ethPrice_in: [BigDecimal!]
+  ethPrice_not_in: [BigDecimal!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [OasisEvent_filter]
+  or: [OasisEvent_filter]
+}
+
+enum OasisEvent_orderBy {
+  id
+  kind
+  isOpen
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  earnPosition
+  earnPosition__id
+  earnPosition__earnDailyTokenBlocks
+  earnPosition__earnLastUpdateBlock
+  earnPosition__earnIsEarning
+  earnPosition__earnCumulativeDepositUSD
+  earnPosition__earnCumulativeDepositInQuoteToken
+  earnPosition__earnCumulativeDepositInCollateralToken
+  earnPosition__earnCumulativeWithdrawUSD
+  earnPosition__earnCumulativeWithdrawInQuoteToken
+  earnPosition__earnCumulativeWithdrawInCollateralToken
+  earnPosition__earnCumulativeFeesUSD
+  earnPosition__earnCumulativeFeesInQuoteToken
+  earnPosition__earnCumulativeFeesInCollateralToken
+  earnPosition__earnCumulativeQuoteTokenDeposit
+  earnPosition__earnCumulativeQuoteTokenWithdraw
+  borrowPosition
+  borrowPosition__id
+  borrowPosition__debt
+  borrowPosition__collateral
+  borrowPosition__t0Np_
+  borrowPosition__t0Debt
+  borrowPosition__liquidationPrice
+  borrowPosition__borrowDailyTokenBlocks
+  borrowPosition__borrowLastUpdateBlock
+  borrowPosition__borrowCumulativeDepositUSD
+  borrowPosition__borrowCumulativeDepositInQuoteToken
+  borrowPosition__borrowCumulativeDepositInCollateralToken
+  borrowPosition__borrowCumulativeWithdrawUSD
+  borrowPosition__borrowCumulativeWithdrawInQuoteToken
+  borrowPosition__borrowCumulativeWithdrawInCollateralToken
+  borrowPosition__borrowCumulativeCollateralDeposit
+  borrowPosition__borrowCumulativeCollateralWithdraw
+  borrowPosition__borrowCumulativeDebtDeposit
+  borrowPosition__borrowCumulativeDebtWithdraw
+  borrowPosition__borrowCumulativeFeesUSD
+  borrowPosition__borrowCumulativeFeesInQuoteToken
+  borrowPosition__borrowCumulativeFeesInCollateralToken
+  pool
+  pool__id
+  pool__address
+  pool__name
+  pool__collateralAddress
+  pool__quoteTokenAddress
+  pool__collateralScale
+  pool__quoteTokenScale
+  pool__htp
+  pool__hpb
+  pool__lup
+  pool__htpIndex
+  pool__hpbIndex
+  pool__lupIndex
+  pool__debt
+  pool__debtInAuctions
+  pool__accuredDebt
+  pool__t0debt
+  pool__depositSize
+  pool__reserves
+  pool__claimableReserves
+  pool__claimableReservesRemaining
+  pool__auctionPrice
+  pool__timeRemaining
+  pool__loansCount
+  pool__totalAuctionsInPool
+  pool__interestRate
+  pool__borrowApr
+  pool__apr30dAverage
+  pool__dailyPercentageRate30dAverage
+  pool__monthlyPercentageRate30dAverage
+  pool__lastInterestRateUpdate
+  pool__lendApr
+  pool__lendApr30dAverage
+  pool__lendDailyPercentageRate30dAverage
+  pool__lendMonthlyPercentageRate30dAverage
+  pool__poolMinDebtAmount
+  pool__poolCollateralization
+  pool__poolActualUtilization
+  pool__poolTargetUtilization
+  pool__currentBurnEpoch
+  pool__borrowDailyTokenBlocks
+  pool__earnDailyTokenBlocks
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  debtAddress
+  debtBefore
+  debtAfter
+  debtDelta
+  debtTokenPriceUSD
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  collateralAddress
+  collateralBefore
+  collateralAfter
+  collateralDelta
+  collateralTokenPriceUSD
+  debtOraclePrice
+  collateralOraclePrice
+  swapFromToken
+  swapToToken
+  swapFromAmount
+  swapToAmount
+  marketPrice
+  depositTransfers
+  depositedUSD
+  depositedInQuoteToken
+  withdrawTransfers
+  withdrawnUSD
+  withdrawnInQuoteToken
+  oasisFeeToken
+  oasisFee
+  oasisFeeUSD
+  oasisFeeInQuoteToken
+  oasisFeeInCollateralToken
+  gasUsed
+  gasPrice
+  gasFeeUSD
+  gasFeeInQuoteToken
+  gasFeeInCollateralToken
+  totalFee
+  totalFeeInQuoteToken
+  totalFeeInCollateralToken
+  totalFeeUSD
+  multipleBefore
+  multipleAfter
+  netValueBefore
+  netValueAfter
+  ltvBefore
+  ltvAfter
+  liquidationPriceBefore
+  liquidationPriceAfter
+  originationFee
+  originationFeeUSD
+  originationFeeInQuoteToken
+  originationFeeInCollateralToken
+  interestRate
+  quoteTokensDelta
+  quoteTokensBefore
+  quoteTokensAfter
+  quoteTokensMoved
+  collateralLpsRemoved
+  moveQuoteFromIndex
+  moveQuoteToIndex
+  addOrRemoveIndex
+  ethPrice
+  timestamp
+  blockNumber
+  txHash
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type Permission {
+  id: ID!
+  user: User!
+  account: Account!
+}
+
+input Permission_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Permission_filter]
+  or: [Permission_filter]
+}
+
+enum Permission_orderBy {
+  id
+  user
+  user__id
+  user__address
+  user__vaultCount
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+}
+
+type Pool {
+  id: ID!
+  address: Bytes!
+  name: String
+  collateralAddress: Bytes!
+  quoteTokenAddress: Bytes!
+  collateralToken: Token
+  quoteToken: Token
+  collateralScale: BigInt!
+  quoteTokenScale: BigInt!
+  htp: BigInt!
+  hpb: BigInt!
+  lup: BigInt!
+  htpIndex: BigInt!
+  hpbIndex: BigInt!
+  lupIndex: BigInt!
+  debt: BigInt!
+  debtInAuctions: BigInt!
+  accuredDebt: BigInt!
+  t0debt: BigInt!
+  depositSize: BigInt!
+  reserves: BigInt!
+  claimableReserves: BigInt!
+  claimableReservesRemaining: BigInt!
+  auctionPrice: BigInt!
+  timeRemaining: BigInt!
+  loansCount: BigInt!
+  totalAuctionsInPool: BigInt!
+  interestRate: BigInt!
+  borrowApr: BigInt
+  apr30dAverage: BigInt!
+  dailyPercentageRate30dAverage: BigInt!
+  monthlyPercentageRate30dAverage: BigInt!
+  interestRatesHistory30d: [BigInt!]!
+  lastInterestRateUpdate: BigInt!
+  lendApr: BigInt
+  lendAprHistory30d: [BigInt!]!
+  lendApr30dAverage: BigInt!
+  lendDailyPercentageRate30dAverage: BigInt!
+  lendMonthlyPercentageRate30dAverage: BigInt!
+  poolMinDebtAmount: BigInt!
+  poolCollateralization: BigInt!
+  poolActualUtilization: BigInt!
+  poolTargetUtilization: BigInt!
+  currentBurnEpoch: BigInt!
+  buckets(skip: Int = 0, first: Int = 100, orderBy: Bucket_orderBy, orderDirection: OrderDirection, where: Bucket_filter): [Bucket!]
+  stakedNfts(skip: Int = 0, first: Int = 100, orderBy: NFT_orderBy, orderDirection: OrderDirection, where: NFT_filter): [NFT!]!
+  earnPositions: [String!]!
+  borrowPositions: [String!]!
+  borrowDailyTokenBlocks: BigInt!
+  earnDailyTokenBlocks: BigInt!
+}
+
+input Pool_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  name: String
+  name_not: String
+  name_gt: String
+  name_lt: String
+  name_gte: String
+  name_lte: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_contains: String
+  name_contains_nocase: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  collateralAddress: Bytes
+  collateralAddress_not: Bytes
+  collateralAddress_gt: Bytes
+  collateralAddress_lt: Bytes
+  collateralAddress_gte: Bytes
+  collateralAddress_lte: Bytes
+  collateralAddress_in: [Bytes!]
+  collateralAddress_not_in: [Bytes!]
+  collateralAddress_contains: Bytes
+  collateralAddress_not_contains: Bytes
+  quoteTokenAddress: Bytes
+  quoteTokenAddress_not: Bytes
+  quoteTokenAddress_gt: Bytes
+  quoteTokenAddress_lt: Bytes
+  quoteTokenAddress_gte: Bytes
+  quoteTokenAddress_lte: Bytes
+  quoteTokenAddress_in: [Bytes!]
+  quoteTokenAddress_not_in: [Bytes!]
+  quoteTokenAddress_contains: Bytes
+  quoteTokenAddress_not_contains: Bytes
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  quoteToken: String
+  quoteToken_not: String
+  quoteToken_gt: String
+  quoteToken_lt: String
+  quoteToken_gte: String
+  quoteToken_lte: String
+  quoteToken_in: [String!]
+  quoteToken_not_in: [String!]
+  quoteToken_contains: String
+  quoteToken_contains_nocase: String
+  quoteToken_not_contains: String
+  quoteToken_not_contains_nocase: String
+  quoteToken_starts_with: String
+  quoteToken_starts_with_nocase: String
+  quoteToken_not_starts_with: String
+  quoteToken_not_starts_with_nocase: String
+  quoteToken_ends_with: String
+  quoteToken_ends_with_nocase: String
+  quoteToken_not_ends_with: String
+  quoteToken_not_ends_with_nocase: String
+  quoteToken_: Token_filter
+  collateralScale: BigInt
+  collateralScale_not: BigInt
+  collateralScale_gt: BigInt
+  collateralScale_lt: BigInt
+  collateralScale_gte: BigInt
+  collateralScale_lte: BigInt
+  collateralScale_in: [BigInt!]
+  collateralScale_not_in: [BigInt!]
+  quoteTokenScale: BigInt
+  quoteTokenScale_not: BigInt
+  quoteTokenScale_gt: BigInt
+  quoteTokenScale_lt: BigInt
+  quoteTokenScale_gte: BigInt
+  quoteTokenScale_lte: BigInt
+  quoteTokenScale_in: [BigInt!]
+  quoteTokenScale_not_in: [BigInt!]
+  htp: BigInt
+  htp_not: BigInt
+  htp_gt: BigInt
+  htp_lt: BigInt
+  htp_gte: BigInt
+  htp_lte: BigInt
+  htp_in: [BigInt!]
+  htp_not_in: [BigInt!]
+  hpb: BigInt
+  hpb_not: BigInt
+  hpb_gt: BigInt
+  hpb_lt: BigInt
+  hpb_gte: BigInt
+  hpb_lte: BigInt
+  hpb_in: [BigInt!]
+  hpb_not_in: [BigInt!]
+  lup: BigInt
+  lup_not: BigInt
+  lup_gt: BigInt
+  lup_lt: BigInt
+  lup_gte: BigInt
+  lup_lte: BigInt
+  lup_in: [BigInt!]
+  lup_not_in: [BigInt!]
+  htpIndex: BigInt
+  htpIndex_not: BigInt
+  htpIndex_gt: BigInt
+  htpIndex_lt: BigInt
+  htpIndex_gte: BigInt
+  htpIndex_lte: BigInt
+  htpIndex_in: [BigInt!]
+  htpIndex_not_in: [BigInt!]
+  hpbIndex: BigInt
+  hpbIndex_not: BigInt
+  hpbIndex_gt: BigInt
+  hpbIndex_lt: BigInt
+  hpbIndex_gte: BigInt
+  hpbIndex_lte: BigInt
+  hpbIndex_in: [BigInt!]
+  hpbIndex_not_in: [BigInt!]
+  lupIndex: BigInt
+  lupIndex_not: BigInt
+  lupIndex_gt: BigInt
+  lupIndex_lt: BigInt
+  lupIndex_gte: BigInt
+  lupIndex_lte: BigInt
+  lupIndex_in: [BigInt!]
+  lupIndex_not_in: [BigInt!]
+  debt: BigInt
+  debt_not: BigInt
+  debt_gt: BigInt
+  debt_lt: BigInt
+  debt_gte: BigInt
+  debt_lte: BigInt
+  debt_in: [BigInt!]
+  debt_not_in: [BigInt!]
+  debtInAuctions: BigInt
+  debtInAuctions_not: BigInt
+  debtInAuctions_gt: BigInt
+  debtInAuctions_lt: BigInt
+  debtInAuctions_gte: BigInt
+  debtInAuctions_lte: BigInt
+  debtInAuctions_in: [BigInt!]
+  debtInAuctions_not_in: [BigInt!]
+  accuredDebt: BigInt
+  accuredDebt_not: BigInt
+  accuredDebt_gt: BigInt
+  accuredDebt_lt: BigInt
+  accuredDebt_gte: BigInt
+  accuredDebt_lte: BigInt
+  accuredDebt_in: [BigInt!]
+  accuredDebt_not_in: [BigInt!]
+  t0debt: BigInt
+  t0debt_not: BigInt
+  t0debt_gt: BigInt
+  t0debt_lt: BigInt
+  t0debt_gte: BigInt
+  t0debt_lte: BigInt
+  t0debt_in: [BigInt!]
+  t0debt_not_in: [BigInt!]
+  depositSize: BigInt
+  depositSize_not: BigInt
+  depositSize_gt: BigInt
+  depositSize_lt: BigInt
+  depositSize_gte: BigInt
+  depositSize_lte: BigInt
+  depositSize_in: [BigInt!]
+  depositSize_not_in: [BigInt!]
+  reserves: BigInt
+  reserves_not: BigInt
+  reserves_gt: BigInt
+  reserves_lt: BigInt
+  reserves_gte: BigInt
+  reserves_lte: BigInt
+  reserves_in: [BigInt!]
+  reserves_not_in: [BigInt!]
+  claimableReserves: BigInt
+  claimableReserves_not: BigInt
+  claimableReserves_gt: BigInt
+  claimableReserves_lt: BigInt
+  claimableReserves_gte: BigInt
+  claimableReserves_lte: BigInt
+  claimableReserves_in: [BigInt!]
+  claimableReserves_not_in: [BigInt!]
+  claimableReservesRemaining: BigInt
+  claimableReservesRemaining_not: BigInt
+  claimableReservesRemaining_gt: BigInt
+  claimableReservesRemaining_lt: BigInt
+  claimableReservesRemaining_gte: BigInt
+  claimableReservesRemaining_lte: BigInt
+  claimableReservesRemaining_in: [BigInt!]
+  claimableReservesRemaining_not_in: [BigInt!]
+  auctionPrice: BigInt
+  auctionPrice_not: BigInt
+  auctionPrice_gt: BigInt
+  auctionPrice_lt: BigInt
+  auctionPrice_gte: BigInt
+  auctionPrice_lte: BigInt
+  auctionPrice_in: [BigInt!]
+  auctionPrice_not_in: [BigInt!]
+  timeRemaining: BigInt
+  timeRemaining_not: BigInt
+  timeRemaining_gt: BigInt
+  timeRemaining_lt: BigInt
+  timeRemaining_gte: BigInt
+  timeRemaining_lte: BigInt
+  timeRemaining_in: [BigInt!]
+  timeRemaining_not_in: [BigInt!]
+  loansCount: BigInt
+  loansCount_not: BigInt
+  loansCount_gt: BigInt
+  loansCount_lt: BigInt
+  loansCount_gte: BigInt
+  loansCount_lte: BigInt
+  loansCount_in: [BigInt!]
+  loansCount_not_in: [BigInt!]
+  totalAuctionsInPool: BigInt
+  totalAuctionsInPool_not: BigInt
+  totalAuctionsInPool_gt: BigInt
+  totalAuctionsInPool_lt: BigInt
+  totalAuctionsInPool_gte: BigInt
+  totalAuctionsInPool_lte: BigInt
+  totalAuctionsInPool_in: [BigInt!]
+  totalAuctionsInPool_not_in: [BigInt!]
+  interestRate: BigInt
+  interestRate_not: BigInt
+  interestRate_gt: BigInt
+  interestRate_lt: BigInt
+  interestRate_gte: BigInt
+  interestRate_lte: BigInt
+  interestRate_in: [BigInt!]
+  interestRate_not_in: [BigInt!]
+  borrowApr: BigInt
+  borrowApr_not: BigInt
+  borrowApr_gt: BigInt
+  borrowApr_lt: BigInt
+  borrowApr_gte: BigInt
+  borrowApr_lte: BigInt
+  borrowApr_in: [BigInt!]
+  borrowApr_not_in: [BigInt!]
+  apr30dAverage: BigInt
+  apr30dAverage_not: BigInt
+  apr30dAverage_gt: BigInt
+  apr30dAverage_lt: BigInt
+  apr30dAverage_gte: BigInt
+  apr30dAverage_lte: BigInt
+  apr30dAverage_in: [BigInt!]
+  apr30dAverage_not_in: [BigInt!]
+  dailyPercentageRate30dAverage: BigInt
+  dailyPercentageRate30dAverage_not: BigInt
+  dailyPercentageRate30dAverage_gt: BigInt
+  dailyPercentageRate30dAverage_lt: BigInt
+  dailyPercentageRate30dAverage_gte: BigInt
+  dailyPercentageRate30dAverage_lte: BigInt
+  dailyPercentageRate30dAverage_in: [BigInt!]
+  dailyPercentageRate30dAverage_not_in: [BigInt!]
+  monthlyPercentageRate30dAverage: BigInt
+  monthlyPercentageRate30dAverage_not: BigInt
+  monthlyPercentageRate30dAverage_gt: BigInt
+  monthlyPercentageRate30dAverage_lt: BigInt
+  monthlyPercentageRate30dAverage_gte: BigInt
+  monthlyPercentageRate30dAverage_lte: BigInt
+  monthlyPercentageRate30dAverage_in: [BigInt!]
+  monthlyPercentageRate30dAverage_not_in: [BigInt!]
+  interestRatesHistory30d: [BigInt!]
+  interestRatesHistory30d_not: [BigInt!]
+  interestRatesHistory30d_contains: [BigInt!]
+  interestRatesHistory30d_contains_nocase: [BigInt!]
+  interestRatesHistory30d_not_contains: [BigInt!]
+  interestRatesHistory30d_not_contains_nocase: [BigInt!]
+  lastInterestRateUpdate: BigInt
+  lastInterestRateUpdate_not: BigInt
+  lastInterestRateUpdate_gt: BigInt
+  lastInterestRateUpdate_lt: BigInt
+  lastInterestRateUpdate_gte: BigInt
+  lastInterestRateUpdate_lte: BigInt
+  lastInterestRateUpdate_in: [BigInt!]
+  lastInterestRateUpdate_not_in: [BigInt!]
+  lendApr: BigInt
+  lendApr_not: BigInt
+  lendApr_gt: BigInt
+  lendApr_lt: BigInt
+  lendApr_gte: BigInt
+  lendApr_lte: BigInt
+  lendApr_in: [BigInt!]
+  lendApr_not_in: [BigInt!]
+  lendAprHistory30d: [BigInt!]
+  lendAprHistory30d_not: [BigInt!]
+  lendAprHistory30d_contains: [BigInt!]
+  lendAprHistory30d_contains_nocase: [BigInt!]
+  lendAprHistory30d_not_contains: [BigInt!]
+  lendAprHistory30d_not_contains_nocase: [BigInt!]
+  lendApr30dAverage: BigInt
+  lendApr30dAverage_not: BigInt
+  lendApr30dAverage_gt: BigInt
+  lendApr30dAverage_lt: BigInt
+  lendApr30dAverage_gte: BigInt
+  lendApr30dAverage_lte: BigInt
+  lendApr30dAverage_in: [BigInt!]
+  lendApr30dAverage_not_in: [BigInt!]
+  lendDailyPercentageRate30dAverage: BigInt
+  lendDailyPercentageRate30dAverage_not: BigInt
+  lendDailyPercentageRate30dAverage_gt: BigInt
+  lendDailyPercentageRate30dAverage_lt: BigInt
+  lendDailyPercentageRate30dAverage_gte: BigInt
+  lendDailyPercentageRate30dAverage_lte: BigInt
+  lendDailyPercentageRate30dAverage_in: [BigInt!]
+  lendDailyPercentageRate30dAverage_not_in: [BigInt!]
+  lendMonthlyPercentageRate30dAverage: BigInt
+  lendMonthlyPercentageRate30dAverage_not: BigInt
+  lendMonthlyPercentageRate30dAverage_gt: BigInt
+  lendMonthlyPercentageRate30dAverage_lt: BigInt
+  lendMonthlyPercentageRate30dAverage_gte: BigInt
+  lendMonthlyPercentageRate30dAverage_lte: BigInt
+  lendMonthlyPercentageRate30dAverage_in: [BigInt!]
+  lendMonthlyPercentageRate30dAverage_not_in: [BigInt!]
+  poolMinDebtAmount: BigInt
+  poolMinDebtAmount_not: BigInt
+  poolMinDebtAmount_gt: BigInt
+  poolMinDebtAmount_lt: BigInt
+  poolMinDebtAmount_gte: BigInt
+  poolMinDebtAmount_lte: BigInt
+  poolMinDebtAmount_in: [BigInt!]
+  poolMinDebtAmount_not_in: [BigInt!]
+  poolCollateralization: BigInt
+  poolCollateralization_not: BigInt
+  poolCollateralization_gt: BigInt
+  poolCollateralization_lt: BigInt
+  poolCollateralization_gte: BigInt
+  poolCollateralization_lte: BigInt
+  poolCollateralization_in: [BigInt!]
+  poolCollateralization_not_in: [BigInt!]
+  poolActualUtilization: BigInt
+  poolActualUtilization_not: BigInt
+  poolActualUtilization_gt: BigInt
+  poolActualUtilization_lt: BigInt
+  poolActualUtilization_gte: BigInt
+  poolActualUtilization_lte: BigInt
+  poolActualUtilization_in: [BigInt!]
+  poolActualUtilization_not_in: [BigInt!]
+  poolTargetUtilization: BigInt
+  poolTargetUtilization_not: BigInt
+  poolTargetUtilization_gt: BigInt
+  poolTargetUtilization_lt: BigInt
+  poolTargetUtilization_gte: BigInt
+  poolTargetUtilization_lte: BigInt
+  poolTargetUtilization_in: [BigInt!]
+  poolTargetUtilization_not_in: [BigInt!]
+  currentBurnEpoch: BigInt
+  currentBurnEpoch_not: BigInt
+  currentBurnEpoch_gt: BigInt
+  currentBurnEpoch_lt: BigInt
+  currentBurnEpoch_gte: BigInt
+  currentBurnEpoch_lte: BigInt
+  currentBurnEpoch_in: [BigInt!]
+  currentBurnEpoch_not_in: [BigInt!]
+  buckets_: Bucket_filter
+  stakedNfts: [String!]
+  stakedNfts_not: [String!]
+  stakedNfts_contains: [String!]
+  stakedNfts_contains_nocase: [String!]
+  stakedNfts_not_contains: [String!]
+  stakedNfts_not_contains_nocase: [String!]
+  stakedNfts_: NFT_filter
+  earnPositions: [String!]
+  earnPositions_not: [String!]
+  earnPositions_contains: [String!]
+  earnPositions_contains_nocase: [String!]
+  earnPositions_not_contains: [String!]
+  earnPositions_not_contains_nocase: [String!]
+  borrowPositions: [String!]
+  borrowPositions_not: [String!]
+  borrowPositions_contains: [String!]
+  borrowPositions_contains_nocase: [String!]
+  borrowPositions_not_contains: [String!]
+  borrowPositions_not_contains_nocase: [String!]
+  borrowDailyTokenBlocks: BigInt
+  borrowDailyTokenBlocks_not: BigInt
+  borrowDailyTokenBlocks_gt: BigInt
+  borrowDailyTokenBlocks_lt: BigInt
+  borrowDailyTokenBlocks_gte: BigInt
+  borrowDailyTokenBlocks_lte: BigInt
+  borrowDailyTokenBlocks_in: [BigInt!]
+  borrowDailyTokenBlocks_not_in: [BigInt!]
+  earnDailyTokenBlocks: BigInt
+  earnDailyTokenBlocks_not: BigInt
+  earnDailyTokenBlocks_gt: BigInt
+  earnDailyTokenBlocks_lt: BigInt
+  earnDailyTokenBlocks_gte: BigInt
+  earnDailyTokenBlocks_lte: BigInt
+  earnDailyTokenBlocks_in: [BigInt!]
+  earnDailyTokenBlocks_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Pool_filter]
+  or: [Pool_filter]
+}
+
+enum Pool_orderBy {
+  id
+  address
+  name
+  collateralAddress
+  quoteTokenAddress
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  quoteToken
+  quoteToken__id
+  quoteToken__address
+  quoteToken__decimals
+  quoteToken__precision
+  quoteToken__symbol
+  collateralScale
+  quoteTokenScale
+  htp
+  hpb
+  lup
+  htpIndex
+  hpbIndex
+  lupIndex
+  debt
+  debtInAuctions
+  accuredDebt
+  t0debt
+  depositSize
+  reserves
+  claimableReserves
+  claimableReservesRemaining
+  auctionPrice
+  timeRemaining
+  loansCount
+  totalAuctionsInPool
+  interestRate
+  borrowApr
+  apr30dAverage
+  dailyPercentageRate30dAverage
+  monthlyPercentageRate30dAverage
+  interestRatesHistory30d
+  lastInterestRateUpdate
+  lendApr
+  lendAprHistory30d
+  lendApr30dAverage
+  lendDailyPercentageRate30dAverage
+  lendMonthlyPercentageRate30dAverage
+  poolMinDebtAmount
+  poolCollateralization
+  poolActualUtilization
+  poolTargetUtilization
+  currentBurnEpoch
+  buckets
+  stakedNfts
+  earnPositions
+  borrowPositions
+  borrowDailyTokenBlocks
+  earnDailyTokenBlocks
+}
+
+type Query {
+  state(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): State
+  states(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: State_orderBy
+    orderDirection: OrderDirection
+    where: State_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [State!]!
+  createPositionEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): CreatePositionEvent
+  createPositionEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: CreatePositionEvent_orderBy
+    orderDirection: OrderDirection
+    where: CreatePositionEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [CreatePositionEvent!]!
+  user(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): User
+  users(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: User_orderBy
+    orderDirection: OrderDirection
+    where: User_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [User!]!
+  account(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Account
+  accounts(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Account_orderBy
+    orderDirection: OrderDirection
+    where: Account_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Account!]!
+  earnPositionBucket(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnPositionBucket
+  earnPositionBuckets(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnPositionBucket_orderBy
+    orderDirection: OrderDirection
+    where: EarnPositionBucket_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnPositionBucket!]!
+  earnPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnPosition
+  earnPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnPosition_orderBy
+    orderDirection: OrderDirection
+    where: EarnPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnPosition!]!
+  borrowPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowPosition
+  borrowPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowPosition_orderBy
+    orderDirection: OrderDirection
+    where: BorrowPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowPosition!]!
+  day(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Day
+  days(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Day_orderBy
+    orderDirection: OrderDirection
+    where: Day_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Day!]!
+  week(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Week
+  weeks(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Week_orderBy
+    orderDirection: OrderDirection
+    where: Week_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Week!]!
+  borrowDailyReward(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowDailyReward
+  borrowDailyRewards(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowDailyReward_orderBy
+    orderDirection: OrderDirection
+    where: BorrowDailyReward_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowDailyReward!]!
+  earnDailyReward(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnDailyReward
+  earnDailyRewards(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnDailyReward_orderBy
+    orderDirection: OrderDirection
+    where: EarnDailyReward_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnDailyReward!]!
+  auction(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Auction
+  auctions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Auction_orderBy
+    orderDirection: OrderDirection
+    where: Auction_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Auction!]!
+  permission(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Permission
+  permissions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Permission_orderBy
+    orderDirection: OrderDirection
+    where: Permission_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Permission!]!
+  pool(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Pool
+  pools(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Pool_orderBy
+    orderDirection: OrderDirection
+    where: Pool_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Pool!]!
+  bucket(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Bucket
+  buckets(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Bucket_orderBy
+    orderDirection: OrderDirection
+    where: Bucket_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Bucket!]!
+  listOfPool(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ListOfPool
+  listOfPools(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ListOfPool_orderBy
+    orderDirection: OrderDirection
+    where: ListOfPool_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ListOfPool!]!
+  nft(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NFT
+  nfts(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NFT_orderBy
+    orderDirection: OrderDirection
+    where: NFT_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NFT!]!
+  borrowerEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowerEvent
+  borrowerEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowerEvent_orderBy
+    orderDirection: OrderDirection
+    where: BorrowerEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowerEvent!]!
+  lenderEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): LenderEvent
+  lenderEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: LenderEvent_orderBy
+    orderDirection: OrderDirection
+    where: LenderEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [LenderEvent!]!
+  oasisEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): OasisEvent
+  oasisEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: OasisEvent_orderBy
+    orderDirection: OrderDirection
+    where: OasisEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [OasisEvent!]!
+  token(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  transfer(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    where: Transfer_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Transfer!]!
+  assetSwap(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AssetSwap
+  assetSwaps(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AssetSwap_orderBy
+    orderDirection: OrderDirection
+    where: AssetSwap_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AssetSwap!]!
+  slippageSaved(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SlippageSaved
+  slippageSaveds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SlippageSaved_orderBy
+    orderDirection: OrderDirection
+    where: SlippageSaved_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SlippageSaved!]!
+  feePaid(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FeePaid
+  feePaids(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: FeePaid_orderBy
+    orderDirection: OrderDirection
+    where: FeePaid_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [FeePaid!]!
+  claimed(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Claimed
+  claimeds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Claimed_orderBy
+    orderDirection: OrderDirection
+    where: Claimed_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Claimed!]!
+
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type SlippageSaved {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: Bytes!
+  minimumPossible: BigInt!
+  actualAmount: BigInt!
+}
+
+input SlippageSaved_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  minimumPossible: BigInt
+  minimumPossible_not: BigInt
+  minimumPossible_gt: BigInt
+  minimumPossible_lt: BigInt
+  minimumPossible_gte: BigInt
+  minimumPossible_lte: BigInt
+  minimumPossible_in: [BigInt!]
+  minimumPossible_not_in: [BigInt!]
+  actualAmount: BigInt
+  actualAmount_not: BigInt
+  actualAmount_gt: BigInt
+  actualAmount_lt: BigInt
+  actualAmount_gte: BigInt
+  actualAmount_lte: BigInt
+  actualAmount_in: [BigInt!]
+  actualAmount_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [SlippageSaved_filter]
+  or: [SlippageSaved_filter]
+}
+
+enum SlippageSaved_orderBy {
+  id
+  minimumPossible
+  actualAmount
+}
+
+type State {
+  id: Bytes!
+  lastDay: BigInt
+  lastWeek: BigInt
+}
+
+input State_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  lastDay: BigInt
+  lastDay_not: BigInt
+  lastDay_gt: BigInt
+  lastDay_lt: BigInt
+  lastDay_gte: BigInt
+  lastDay_lte: BigInt
+  lastDay_in: [BigInt!]
+  lastDay_not_in: [BigInt!]
+  lastWeek: BigInt
+  lastWeek_not: BigInt
+  lastWeek_gt: BigInt
+  lastWeek_lt: BigInt
+  lastWeek_gte: BigInt
+  lastWeek_lte: BigInt
+  lastWeek_in: [BigInt!]
+  lastWeek_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [State_filter]
+  or: [State_filter]
+}
+
+enum State_orderBy {
+  id
+  lastDay
+  lastWeek
+}
+
+type Subscription {
+  state(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): State
+  states(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: State_orderBy
+    orderDirection: OrderDirection
+    where: State_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [State!]!
+  createPositionEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): CreatePositionEvent
+  createPositionEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: CreatePositionEvent_orderBy
+    orderDirection: OrderDirection
+    where: CreatePositionEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [CreatePositionEvent!]!
+  user(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): User
+  users(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: User_orderBy
+    orderDirection: OrderDirection
+    where: User_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [User!]!
+  account(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Account
+  accounts(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Account_orderBy
+    orderDirection: OrderDirection
+    where: Account_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Account!]!
+  earnPositionBucket(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnPositionBucket
+  earnPositionBuckets(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnPositionBucket_orderBy
+    orderDirection: OrderDirection
+    where: EarnPositionBucket_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnPositionBucket!]!
+  earnPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnPosition
+  earnPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnPosition_orderBy
+    orderDirection: OrderDirection
+    where: EarnPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnPosition!]!
+  borrowPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowPosition
+  borrowPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowPosition_orderBy
+    orderDirection: OrderDirection
+    where: BorrowPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowPosition!]!
+  day(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Day
+  days(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Day_orderBy
+    orderDirection: OrderDirection
+    where: Day_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Day!]!
+  week(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Week
+  weeks(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Week_orderBy
+    orderDirection: OrderDirection
+    where: Week_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Week!]!
+  borrowDailyReward(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowDailyReward
+  borrowDailyRewards(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowDailyReward_orderBy
+    orderDirection: OrderDirection
+    where: BorrowDailyReward_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowDailyReward!]!
+  earnDailyReward(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnDailyReward
+  earnDailyRewards(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnDailyReward_orderBy
+    orderDirection: OrderDirection
+    where: EarnDailyReward_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnDailyReward!]!
+  auction(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Auction
+  auctions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Auction_orderBy
+    orderDirection: OrderDirection
+    where: Auction_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Auction!]!
+  permission(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Permission
+  permissions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Permission_orderBy
+    orderDirection: OrderDirection
+    where: Permission_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Permission!]!
+  pool(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Pool
+  pools(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Pool_orderBy
+    orderDirection: OrderDirection
+    where: Pool_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Pool!]!
+  bucket(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Bucket
+  buckets(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Bucket_orderBy
+    orderDirection: OrderDirection
+    where: Bucket_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Bucket!]!
+  listOfPool(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ListOfPool
+  listOfPools(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ListOfPool_orderBy
+    orderDirection: OrderDirection
+    where: ListOfPool_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ListOfPool!]!
+  nft(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NFT
+  nfts(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: NFT_orderBy
+    orderDirection: OrderDirection
+    where: NFT_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [NFT!]!
+  borrowerEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowerEvent
+  borrowerEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowerEvent_orderBy
+    orderDirection: OrderDirection
+    where: BorrowerEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowerEvent!]!
+  lenderEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): LenderEvent
+  lenderEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: LenderEvent_orderBy
+    orderDirection: OrderDirection
+    where: LenderEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [LenderEvent!]!
+  oasisEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): OasisEvent
+  oasisEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: OasisEvent_orderBy
+    orderDirection: OrderDirection
+    where: OasisEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [OasisEvent!]!
+  token(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  transfer(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    where: Transfer_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Transfer!]!
+  assetSwap(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AssetSwap
+  assetSwaps(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AssetSwap_orderBy
+    orderDirection: OrderDirection
+    where: AssetSwap_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AssetSwap!]!
+  slippageSaved(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SlippageSaved
+  slippageSaveds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SlippageSaved_orderBy
+    orderDirection: OrderDirection
+    where: SlippageSaved_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SlippageSaved!]!
+  feePaid(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FeePaid
+  feePaids(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: FeePaid_orderBy
+    orderDirection: OrderDirection
+    where: FeePaid_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [FeePaid!]!
+  claimed(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Claimed
+  claimeds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Claimed_orderBy
+    orderDirection: OrderDirection
+    where: Claimed_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Claimed!]!
+
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type Token {
+  id: Bytes!
+  address: Bytes!
+  decimals: BigInt!
+  precision: BigInt!
+  symbol: String!
+}
+
+input Token_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  decimals: BigInt
+  decimals_not: BigInt
+  decimals_gt: BigInt
+  decimals_lt: BigInt
+  decimals_gte: BigInt
+  decimals_lte: BigInt
+  decimals_in: [BigInt!]
+  decimals_not_in: [BigInt!]
+  precision: BigInt
+  precision_not: BigInt
+  precision_gt: BigInt
+  precision_lt: BigInt
+  precision_gte: BigInt
+  precision_lte: BigInt
+  precision_in: [BigInt!]
+  precision_not_in: [BigInt!]
+  symbol: String
+  symbol_not: String
+  symbol_gt: String
+  symbol_lt: String
+  symbol_gte: String
+  symbol_lte: String
+  symbol_in: [String!]
+  symbol_not_in: [String!]
+  symbol_contains: String
+  symbol_contains_nocase: String
+  symbol_not_contains: String
+  symbol_not_contains_nocase: String
+  symbol_starts_with: String
+  symbol_starts_with_nocase: String
+  symbol_not_starts_with: String
+  symbol_not_starts_with_nocase: String
+  symbol_ends_with: String
+  symbol_ends_with_nocase: String
+  symbol_not_ends_with: String
+  symbol_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Token_filter]
+  or: [Token_filter]
+}
+
+enum Token_orderBy {
+  id
+  address
+  decimals
+  precision
+  symbol
+}
+
+type Transfer {
+  id: Bytes!
+  event: OasisEvent!
+  from: Bytes!
+  to: Bytes!
+  token: Bytes!
+  amount: BigDecimal!
+  priceInUSD: BigDecimal!
+  amountUSD: BigDecimal!
+  txHash: String!
+}
+
+input Transfer_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  event: String
+  event_not: String
+  event_gt: String
+  event_lt: String
+  event_gte: String
+  event_lte: String
+  event_in: [String!]
+  event_not_in: [String!]
+  event_contains: String
+  event_contains_nocase: String
+  event_not_contains: String
+  event_not_contains_nocase: String
+  event_starts_with: String
+  event_starts_with_nocase: String
+  event_not_starts_with: String
+  event_not_starts_with_nocase: String
+  event_ends_with: String
+  event_ends_with_nocase: String
+  event_not_ends_with: String
+  event_not_ends_with_nocase: String
+  event_: OasisEvent_filter
+  from: Bytes
+  from_not: Bytes
+  from_gt: Bytes
+  from_lt: Bytes
+  from_gte: Bytes
+  from_lte: Bytes
+  from_in: [Bytes!]
+  from_not_in: [Bytes!]
+  from_contains: Bytes
+  from_not_contains: Bytes
+  to: Bytes
+  to_not: Bytes
+  to_gt: Bytes
+  to_lt: Bytes
+  to_gte: Bytes
+  to_lte: Bytes
+  to_in: [Bytes!]
+  to_not_in: [Bytes!]
+  to_contains: Bytes
+  to_not_contains: Bytes
+  token: Bytes
+  token_not: Bytes
+  token_gt: Bytes
+  token_lt: Bytes
+  token_gte: Bytes
+  token_lte: Bytes
+  token_in: [Bytes!]
+  token_not_in: [Bytes!]
+  token_contains: Bytes
+  token_not_contains: Bytes
+  amount: BigDecimal
+  amount_not: BigDecimal
+  amount_gt: BigDecimal
+  amount_lt: BigDecimal
+  amount_gte: BigDecimal
+  amount_lte: BigDecimal
+  amount_in: [BigDecimal!]
+  amount_not_in: [BigDecimal!]
+  priceInUSD: BigDecimal
+  priceInUSD_not: BigDecimal
+  priceInUSD_gt: BigDecimal
+  priceInUSD_lt: BigDecimal
+  priceInUSD_gte: BigDecimal
+  priceInUSD_lte: BigDecimal
+  priceInUSD_in: [BigDecimal!]
+  priceInUSD_not_in: [BigDecimal!]
+  amountUSD: BigDecimal
+  amountUSD_not: BigDecimal
+  amountUSD_gt: BigDecimal
+  amountUSD_lt: BigDecimal
+  amountUSD_gte: BigDecimal
+  amountUSD_lte: BigDecimal
+  amountUSD_in: [BigDecimal!]
+  amountUSD_not_in: [BigDecimal!]
+  txHash: String
+  txHash_not: String
+  txHash_gt: String
+  txHash_lt: String
+  txHash_gte: String
+  txHash_lte: String
+  txHash_in: [String!]
+  txHash_not_in: [String!]
+  txHash_contains: String
+  txHash_contains_nocase: String
+  txHash_not_contains: String
+  txHash_not_contains_nocase: String
+  txHash_starts_with: String
+  txHash_starts_with_nocase: String
+  txHash_not_starts_with: String
+  txHash_not_starts_with_nocase: String
+  txHash_ends_with: String
+  txHash_ends_with_nocase: String
+  txHash_not_ends_with: String
+  txHash_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Transfer_filter]
+  or: [Transfer_filter]
+}
+
+enum Transfer_orderBy {
+  id
+  event
+  event__id
+  event__kind
+  event__isOpen
+  event__debtAddress
+  event__debtBefore
+  event__debtAfter
+  event__debtDelta
+  event__debtTokenPriceUSD
+  event__collateralAddress
+  event__collateralBefore
+  event__collateralAfter
+  event__collateralDelta
+  event__collateralTokenPriceUSD
+  event__debtOraclePrice
+  event__collateralOraclePrice
+  event__swapFromToken
+  event__swapToToken
+  event__swapFromAmount
+  event__swapToAmount
+  event__marketPrice
+  event__depositedUSD
+  event__depositedInQuoteToken
+  event__withdrawnUSD
+  event__withdrawnInQuoteToken
+  event__oasisFeeToken
+  event__oasisFee
+  event__oasisFeeUSD
+  event__oasisFeeInQuoteToken
+  event__oasisFeeInCollateralToken
+  event__gasUsed
+  event__gasPrice
+  event__gasFeeUSD
+  event__gasFeeInQuoteToken
+  event__gasFeeInCollateralToken
+  event__totalFee
+  event__totalFeeInQuoteToken
+  event__totalFeeInCollateralToken
+  event__totalFeeUSD
+  event__multipleBefore
+  event__multipleAfter
+  event__netValueBefore
+  event__netValueAfter
+  event__ltvBefore
+  event__ltvAfter
+  event__liquidationPriceBefore
+  event__liquidationPriceAfter
+  event__originationFee
+  event__originationFeeUSD
+  event__originationFeeInQuoteToken
+  event__originationFeeInCollateralToken
+  event__interestRate
+  event__quoteTokensDelta
+  event__quoteTokensBefore
+  event__quoteTokensAfter
+  event__quoteTokensMoved
+  event__collateralLpsRemoved
+  event__moveQuoteFromIndex
+  event__moveQuoteToIndex
+  event__addOrRemoveIndex
+  event__ethPrice
+  event__timestamp
+  event__blockNumber
+  event__txHash
+  from
+  to
+  token
+  amount
+  priceInUSD
+  amountUSD
+  txHash
+}
+
+type User {
+  id: Bytes!
+  address: Bytes!
+  vaultCount: BigInt!
+  proxys(skip: Int = 0, first: Int = 100, orderBy: Account_orderBy, orderDirection: OrderDirection, where: Account_filter): [Account!]
+  permittedProxys(skip: Int = 0, first: Int = 100, orderBy: Permission_orderBy, orderDirection: OrderDirection, where: Permission_filter): [Permission!]
+  earnPositions(skip: Int = 0, first: Int = 100, orderBy: EarnPositionBucket_orderBy, orderDirection: OrderDirection, where: EarnPositionBucket_filter): [EarnPositionBucket!]
+  borrowPositions(skip: Int = 0, first: Int = 100, orderBy: BorrowPosition_orderBy, orderDirection: OrderDirection, where: BorrowPosition_filter): [BorrowPosition!]
+  nfts(skip: Int = 0, first: Int = 100, orderBy: NFT_orderBy, orderDirection: OrderDirection, where: NFT_filter): [NFT!]
+  oasisAjnaRewardClaims(skip: Int = 0, first: Int = 100, orderBy: Claimed_orderBy, orderDirection: OrderDirection, where: Claimed_filter): [Claimed!]
+}
+
+input User_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  vaultCount: BigInt
+  vaultCount_not: BigInt
+  vaultCount_gt: BigInt
+  vaultCount_lt: BigInt
+  vaultCount_gte: BigInt
+  vaultCount_lte: BigInt
+  vaultCount_in: [BigInt!]
+  vaultCount_not_in: [BigInt!]
+  proxys_: Account_filter
+  permittedProxys_: Permission_filter
+  earnPositions_: EarnPositionBucket_filter
+  borrowPositions_: BorrowPosition_filter
+  nfts_: NFT_filter
+  oasisAjnaRewardClaims_: Claimed_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [User_filter]
+  or: [User_filter]
+}
+
+enum User_orderBy {
+  id
+  address
+  vaultCount
+  proxys
+  permittedProxys
+  earnPositions
+  borrowPositions
+  nfts
+  oasisAjnaRewardClaims
+}
+
+type Week {
+  id: ID!
+  week: BigInt!
+  weekStartTimestamp: BigInt!
+  weekEndTimestamp: BigInt
+  borrowWeeklyRewards(skip: Int = 0, first: Int = 100, orderBy: BorrowDailyReward_orderBy, orderDirection: OrderDirection, where: BorrowDailyReward_filter): [BorrowDailyReward!]
+  earnWeeklyRewards(skip: Int = 0, first: Int = 100, orderBy: EarnDailyReward_orderBy, orderDirection: OrderDirection, where: EarnDailyReward_filter): [EarnDailyReward!]
+  days(skip: Int = 0, first: Int = 100, orderBy: Day_orderBy, orderDirection: OrderDirection, where: Day_filter): [Day!]!
+}
+
+input Week_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  week: BigInt
+  week_not: BigInt
+  week_gt: BigInt
+  week_lt: BigInt
+  week_gte: BigInt
+  week_lte: BigInt
+  week_in: [BigInt!]
+  week_not_in: [BigInt!]
+  weekStartTimestamp: BigInt
+  weekStartTimestamp_not: BigInt
+  weekStartTimestamp_gt: BigInt
+  weekStartTimestamp_lt: BigInt
+  weekStartTimestamp_gte: BigInt
+  weekStartTimestamp_lte: BigInt
+  weekStartTimestamp_in: [BigInt!]
+  weekStartTimestamp_not_in: [BigInt!]
+  weekEndTimestamp: BigInt
+  weekEndTimestamp_not: BigInt
+  weekEndTimestamp_gt: BigInt
+  weekEndTimestamp_lt: BigInt
+  weekEndTimestamp_gte: BigInt
+  weekEndTimestamp_lte: BigInt
+  weekEndTimestamp_in: [BigInt!]
+  weekEndTimestamp_not_in: [BigInt!]
+  borrowWeeklyRewards_: BorrowDailyReward_filter
+  earnWeeklyRewards_: EarnDailyReward_filter
+  days_: Day_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Week_filter]
+  or: [Week_filter]
+}
+
+enum Week_orderBy {
+  id
+  week
+  weekStartTimestamp
+  weekEndTimestamp
+  borrowWeeklyRewards
+  earnWeeklyRewards
+  days
+}
+

--- a/packages/ajna-subgraph/src/index.ts
+++ b/packages/ajna-subgraph/src/index.ts
@@ -1,0 +1,81 @@
+import { request } from 'graphql-request'
+
+import { ChainId } from '@summerfi/serverless-shared'
+import type { Address } from '@summerfi/serverless-shared'
+import { Logger } from '@aws-lambda-powertools/logger'
+import { CollateralLockedDocument } from './types/graphql/generated'
+
+const chainIdSubgraphMap: Partial<Record<ChainId, string>> = {
+  [ChainId.MAINNET]: 'summer-ajna-v2',
+  [ChainId.BASE]: 'summer-ajna-v2-base',
+  [ChainId.OPTIMISM]: 'summer-ajna-v2-optimism',
+  [ChainId.ARBITRUM]: 'summer-ajna-v2-arbitrum',
+}
+
+const getEndpoint = (chainId: ChainId, baseUrl: string) => {
+  const subgraph = chainIdSubgraphMap[chainId]
+  if (!subgraph) {
+    throw new Error(`No subgraph for chainId ${chainId}`)
+  }
+  return `${baseUrl}/${subgraph}`
+}
+interface SubgraphClientConfig {
+  chainId: ChainId
+  urlBase: string
+  logger?: Logger
+}
+
+export interface GetCollateralLockedParams {
+  collaterals: { address: Address; decimals: number }[]
+  blockNumber: number
+}
+
+export interface CollateralLocked {
+  collateral: Address
+  amount: string
+  owner: Address
+}
+
+/**
+ * The key of the first record is the owner of the collaterals, second record is the collateral address
+ */
+export type CollateralLockedRecord = Record<Address, Record<Address, CollateralLocked>>
+
+export interface CollateralLockedResult {
+  lockedCollaterals: CollateralLocked[]
+}
+
+export type GetCollateralLocked = (
+  params: GetCollateralLockedParams,
+) => Promise<CollateralLockedResult>
+
+async function getCollateralLocked(
+  params: GetCollateralLockedParams,
+  config: SubgraphClientConfig,
+): Promise<CollateralLockedResult> {
+  const url = getEndpoint(config.chainId, config.urlBase)
+  const result = await request(url, CollateralLockedDocument, {
+    collateralAddresses: params.collaterals.map((c) => c.address),
+    block: params.blockNumber,
+  })
+
+  const mapped: CollateralLocked[] = result.borrowPositions.map((c) => ({
+    collateral: c.pool.collateralToken?.address as Address,
+    amount: c.collateral.toString(),
+    owner: (c.account?.user.address ?? `0x0`) as Address,
+  }))
+
+  return {
+    lockedCollaterals: mapped,
+  }
+}
+
+export interface AjnaSubgraphClient {
+  getCollateralLocked: GetCollateralLocked
+}
+
+export function getAjnaSubgraphClient(config: SubgraphClientConfig): AjnaSubgraphClient {
+  return {
+    getCollateralLocked: (params: GetCollateralLockedParams) => getCollateralLocked(params, config),
+  }
+}

--- a/packages/ajna-subgraph/tsconfig.json
+++ b/packages/ajna-subgraph/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@summerfi/typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/packages/morpho-blue-subgraph/.eslintrc.cjs
+++ b/packages/morpho-blue-subgraph/.eslintrc.cjs
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  ignorePatterns: ['src/types/graphql/**'],
+  extends: ['@summerfi/eslint-config/library.cjs'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+  },
+}

--- a/packages/morpho-blue-subgraph/graphql.config.yml
+++ b/packages/morpho-blue-subgraph/graphql.config.yml
@@ -1,0 +1,32 @@
+schema: schema.graphql
+documents: './queries/**/*.graphql'
+config:
+  namingConvention:
+    enumValues: keep
+generates:
+  src/types/graphql/generated.ts:
+    plugins:
+      - add:
+          content:
+            - '// @ts-nocheck'
+            - '// This file was automatically generated and should not be edited.'
+      - typescript
+      - typescript-operations:
+          strictScalars: true
+          immutableTypes: true
+          scalars:
+            BigDecimal: string
+            BigInt: bigint
+            Int8: number
+            BooleanType: boolean
+            CustomData: Record<string, unknown>
+            Date: string
+            DateTime: string
+            FloatType: number
+            IntType: number
+            ItemId: string
+            JsonField: unknown
+            Bytes: string
+            MetaTagAttributes: Record<string, string>
+            UploadId: string
+      - typed-document-node

--- a/packages/morpho-blue-subgraph/package.json
+++ b/packages/morpho-blue-subgraph/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@summerfi/morpho-blue-subgraph",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "tsc": "tsc",
+    "watch": "tsc -w",
+    "test": "jest --passWithNoTests",
+    "build": "tsc -b -v",
+    "prebuild": "pnpm run generate-ts-types",
+    "generate-ts-types": "graphql-codegen --config graphql.config.yml",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^1.17.0",
+    "graphql-request": "^6.1.0",
+    "@summerfi/serverless-shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@summerfi/eslint-config": "workspace:*",
+    "@summerfi/typescript-config": "workspace:*",
+    "@types/node": "^20.11.5",
+    "eslint": "^8.56.0"
+  }
+}

--- a/packages/morpho-blue-subgraph/queries/collateral-locked.graphql
+++ b/packages/morpho-blue-subgraph/queries/collateral-locked.graphql
@@ -1,0 +1,16 @@
+query CollateralLocked($collateralAddresses: [String!]!, $block: Int!) {
+  borrowPositions(where: { market_: { collateralToken_in: $collateralAddresses }, collateral_gt: 0, account_not: null}, block: { number: $block }) {
+    market {
+      collateralToken {
+        address
+        decimals
+      }
+    }
+    collateral
+    account {
+      user {
+        address
+      }
+    }
+  }
+}

--- a/packages/morpho-blue-subgraph/schema.graphql
+++ b/packages/morpho-blue-subgraph/schema.graphql
@@ -1,0 +1,6202 @@
+"""
+Marks the GraphQL type as indexable entity.  Each type that should be an entity
+is required to be annotated with this directive.
+"""
+directive @entity on OBJECT
+
+"""Defined a Subgraph ID for an object type"""
+directive @subgraphId(id: String!) on OBJECT
+
+"""
+creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
+"""
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+
+  """The block number"""
+  number: Int!
+
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+
+  """The deployment ID"""
+  deployment: String!
+
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
+
+type Account {
+  id: Bytes!
+  address: Bytes!
+  user: User!
+  vaultId: BigInt!
+  isDPM: Boolean!
+  protocol: String
+  positionType: PositionType
+  collateralToken: Bytes
+  debtToken: Bytes
+  borrowPositions(skip: Int = 0, first: Int = 100, orderBy: BorrowPosition_orderBy, orderDirection: OrderDirection, where: BorrowPosition_filter): [BorrowPosition!]!
+  earnPositions(skip: Int = 0, first: Int = 100, orderBy: EarnPosition_orderBy, orderDirection: OrderDirection, where: EarnPosition_filter): [EarnPosition!]!
+  liquidationPrice: BigDecimal!
+}
+
+input Account_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  vaultId: BigInt
+  vaultId_not: BigInt
+  vaultId_gt: BigInt
+  vaultId_lt: BigInt
+  vaultId_gte: BigInt
+  vaultId_lte: BigInt
+  vaultId_in: [BigInt!]
+  vaultId_not_in: [BigInt!]
+  isDPM: Boolean
+  isDPM_not: Boolean
+  isDPM_in: [Boolean!]
+  isDPM_not_in: [Boolean!]
+  protocol: String
+  protocol_not: String
+  protocol_gt: String
+  protocol_lt: String
+  protocol_gte: String
+  protocol_lte: String
+  protocol_in: [String!]
+  protocol_not_in: [String!]
+  protocol_contains: String
+  protocol_contains_nocase: String
+  protocol_not_contains: String
+  protocol_not_contains_nocase: String
+  protocol_starts_with: String
+  protocol_starts_with_nocase: String
+  protocol_not_starts_with: String
+  protocol_not_starts_with_nocase: String
+  protocol_ends_with: String
+  protocol_ends_with_nocase: String
+  protocol_not_ends_with: String
+  protocol_not_ends_with_nocase: String
+  positionType: PositionType
+  positionType_not: PositionType
+  positionType_in: [PositionType!]
+  positionType_not_in: [PositionType!]
+  collateralToken: Bytes
+  collateralToken_not: Bytes
+  collateralToken_gt: Bytes
+  collateralToken_lt: Bytes
+  collateralToken_gte: Bytes
+  collateralToken_lte: Bytes
+  collateralToken_in: [Bytes!]
+  collateralToken_not_in: [Bytes!]
+  collateralToken_contains: Bytes
+  collateralToken_not_contains: Bytes
+  debtToken: Bytes
+  debtToken_not: Bytes
+  debtToken_gt: Bytes
+  debtToken_lt: Bytes
+  debtToken_gte: Bytes
+  debtToken_lte: Bytes
+  debtToken_in: [Bytes!]
+  debtToken_not_in: [Bytes!]
+  debtToken_contains: Bytes
+  debtToken_not_contains: Bytes
+  borrowPositions_: BorrowPosition_filter
+  earnPositions_: EarnPosition_filter
+  liquidationPrice: BigDecimal
+  liquidationPrice_not: BigDecimal
+  liquidationPrice_gt: BigDecimal
+  liquidationPrice_lt: BigDecimal
+  liquidationPrice_gte: BigDecimal
+  liquidationPrice_lte: BigDecimal
+  liquidationPrice_in: [BigDecimal!]
+  liquidationPrice_not_in: [BigDecimal!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Account_filter]
+  or: [Account_filter]
+}
+
+enum Account_orderBy {
+  id
+  address
+  user
+  user__id
+  user__address
+  user__vaultCount
+  vaultId
+  isDPM
+  protocol
+  positionType
+  collateralToken
+  debtToken
+  borrowPositions
+  earnPositions
+  liquidationPrice
+}
+
+type AssetSwap {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: Bytes!
+  assetIn: Bytes!
+  assetOut: Bytes!
+  amountIn: BigInt!
+  amountOut: BigInt!
+  proxy: Bytes
+}
+
+input AssetSwap_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  assetIn: Bytes
+  assetIn_not: Bytes
+  assetIn_gt: Bytes
+  assetIn_lt: Bytes
+  assetIn_gte: Bytes
+  assetIn_lte: Bytes
+  assetIn_in: [Bytes!]
+  assetIn_not_in: [Bytes!]
+  assetIn_contains: Bytes
+  assetIn_not_contains: Bytes
+  assetOut: Bytes
+  assetOut_not: Bytes
+  assetOut_gt: Bytes
+  assetOut_lt: Bytes
+  assetOut_gte: Bytes
+  assetOut_lte: Bytes
+  assetOut_in: [Bytes!]
+  assetOut_not_in: [Bytes!]
+  assetOut_contains: Bytes
+  assetOut_not_contains: Bytes
+  amountIn: BigInt
+  amountIn_not: BigInt
+  amountIn_gt: BigInt
+  amountIn_lt: BigInt
+  amountIn_gte: BigInt
+  amountIn_lte: BigInt
+  amountIn_in: [BigInt!]
+  amountIn_not_in: [BigInt!]
+  amountOut: BigInt
+  amountOut_not: BigInt
+  amountOut_gt: BigInt
+  amountOut_lt: BigInt
+  amountOut_gte: BigInt
+  amountOut_lte: BigInt
+  amountOut_in: [BigInt!]
+  amountOut_not_in: [BigInt!]
+  proxy: Bytes
+  proxy_not: Bytes
+  proxy_gt: Bytes
+  proxy_lt: Bytes
+  proxy_gte: Bytes
+  proxy_lte: Bytes
+  proxy_in: [Bytes!]
+  proxy_not_in: [Bytes!]
+  proxy_contains: Bytes
+  proxy_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AssetSwap_filter]
+  or: [AssetSwap_filter]
+}
+
+enum AssetSwap_orderBy {
+  id
+  assetIn
+  assetOut
+  amountIn
+  amountOut
+  proxy
+}
+
+scalar BigDecimal
+
+scalar BigInt
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+type BorrowerEvent {
+  id: Bytes!
+  position: BorrowPosition!
+  account: Account
+  kind: String!
+  market: Market!
+  debtToken: Token!
+  collateralToken: Token!
+  debtTokenPriceUSD: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  collateralOraclePrice: BigDecimal!
+  debtBefore: BigDecimal!
+  debtAfter: BigDecimal!
+  debtDelta: BigDecimal!
+  collateralBefore: BigDecimal!
+  collateralAfter: BigDecimal!
+  collateralDelta: BigDecimal!
+  caller: Bytes!
+  onBehalfOf: Bytes!
+  receiver: Bytes
+  quoteRepaid: BigInt!
+  collateralWithdrawn: BigInt!
+  amountBorrowed: BigInt!
+  collateralDeposited: BigInt!
+  sharesReceived: BigInt!
+  sharesBurned: BigInt!
+  borrower: Bytes!
+  repaidAssets: BigInt!
+  repaidShares: BigInt!
+  seizedAssets: BigInt!
+  badDebtShares: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input BorrowerEvent_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  position: String
+  position_not: String
+  position_gt: String
+  position_lt: String
+  position_gte: String
+  position_lte: String
+  position_in: [String!]
+  position_not_in: [String!]
+  position_contains: String
+  position_contains_nocase: String
+  position_not_contains: String
+  position_not_contains_nocase: String
+  position_starts_with: String
+  position_starts_with_nocase: String
+  position_not_starts_with: String
+  position_not_starts_with_nocase: String
+  position_ends_with: String
+  position_ends_with_nocase: String
+  position_not_ends_with: String
+  position_not_ends_with_nocase: String
+  position_: BorrowPosition_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  collateralOraclePrice: BigDecimal
+  collateralOraclePrice_not: BigDecimal
+  collateralOraclePrice_gt: BigDecimal
+  collateralOraclePrice_lt: BigDecimal
+  collateralOraclePrice_gte: BigDecimal
+  collateralOraclePrice_lte: BigDecimal
+  collateralOraclePrice_in: [BigDecimal!]
+  collateralOraclePrice_not_in: [BigDecimal!]
+  debtBefore: BigDecimal
+  debtBefore_not: BigDecimal
+  debtBefore_gt: BigDecimal
+  debtBefore_lt: BigDecimal
+  debtBefore_gte: BigDecimal
+  debtBefore_lte: BigDecimal
+  debtBefore_in: [BigDecimal!]
+  debtBefore_not_in: [BigDecimal!]
+  debtAfter: BigDecimal
+  debtAfter_not: BigDecimal
+  debtAfter_gt: BigDecimal
+  debtAfter_lt: BigDecimal
+  debtAfter_gte: BigDecimal
+  debtAfter_lte: BigDecimal
+  debtAfter_in: [BigDecimal!]
+  debtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  collateralBefore: BigDecimal
+  collateralBefore_not: BigDecimal
+  collateralBefore_gt: BigDecimal
+  collateralBefore_lt: BigDecimal
+  collateralBefore_gte: BigDecimal
+  collateralBefore_lte: BigDecimal
+  collateralBefore_in: [BigDecimal!]
+  collateralBefore_not_in: [BigDecimal!]
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalfOf: Bytes
+  onBehalfOf_not: Bytes
+  onBehalfOf_gt: Bytes
+  onBehalfOf_lt: Bytes
+  onBehalfOf_gte: Bytes
+  onBehalfOf_lte: Bytes
+  onBehalfOf_in: [Bytes!]
+  onBehalfOf_not_in: [Bytes!]
+  onBehalfOf_contains: Bytes
+  onBehalfOf_not_contains: Bytes
+  receiver: Bytes
+  receiver_not: Bytes
+  receiver_gt: Bytes
+  receiver_lt: Bytes
+  receiver_gte: Bytes
+  receiver_lte: Bytes
+  receiver_in: [Bytes!]
+  receiver_not_in: [Bytes!]
+  receiver_contains: Bytes
+  receiver_not_contains: Bytes
+  quoteRepaid: BigInt
+  quoteRepaid_not: BigInt
+  quoteRepaid_gt: BigInt
+  quoteRepaid_lt: BigInt
+  quoteRepaid_gte: BigInt
+  quoteRepaid_lte: BigInt
+  quoteRepaid_in: [BigInt!]
+  quoteRepaid_not_in: [BigInt!]
+  collateralWithdrawn: BigInt
+  collateralWithdrawn_not: BigInt
+  collateralWithdrawn_gt: BigInt
+  collateralWithdrawn_lt: BigInt
+  collateralWithdrawn_gte: BigInt
+  collateralWithdrawn_lte: BigInt
+  collateralWithdrawn_in: [BigInt!]
+  collateralWithdrawn_not_in: [BigInt!]
+  amountBorrowed: BigInt
+  amountBorrowed_not: BigInt
+  amountBorrowed_gt: BigInt
+  amountBorrowed_lt: BigInt
+  amountBorrowed_gte: BigInt
+  amountBorrowed_lte: BigInt
+  amountBorrowed_in: [BigInt!]
+  amountBorrowed_not_in: [BigInt!]
+  collateralDeposited: BigInt
+  collateralDeposited_not: BigInt
+  collateralDeposited_gt: BigInt
+  collateralDeposited_lt: BigInt
+  collateralDeposited_gte: BigInt
+  collateralDeposited_lte: BigInt
+  collateralDeposited_in: [BigInt!]
+  collateralDeposited_not_in: [BigInt!]
+  sharesReceived: BigInt
+  sharesReceived_not: BigInt
+  sharesReceived_gt: BigInt
+  sharesReceived_lt: BigInt
+  sharesReceived_gte: BigInt
+  sharesReceived_lte: BigInt
+  sharesReceived_in: [BigInt!]
+  sharesReceived_not_in: [BigInt!]
+  sharesBurned: BigInt
+  sharesBurned_not: BigInt
+  sharesBurned_gt: BigInt
+  sharesBurned_lt: BigInt
+  sharesBurned_gte: BigInt
+  sharesBurned_lte: BigInt
+  sharesBurned_in: [BigInt!]
+  sharesBurned_not_in: [BigInt!]
+  borrower: Bytes
+  borrower_not: Bytes
+  borrower_gt: Bytes
+  borrower_lt: Bytes
+  borrower_gte: Bytes
+  borrower_lte: Bytes
+  borrower_in: [Bytes!]
+  borrower_not_in: [Bytes!]
+  borrower_contains: Bytes
+  borrower_not_contains: Bytes
+  repaidAssets: BigInt
+  repaidAssets_not: BigInt
+  repaidAssets_gt: BigInt
+  repaidAssets_lt: BigInt
+  repaidAssets_gte: BigInt
+  repaidAssets_lte: BigInt
+  repaidAssets_in: [BigInt!]
+  repaidAssets_not_in: [BigInt!]
+  repaidShares: BigInt
+  repaidShares_not: BigInt
+  repaidShares_gt: BigInt
+  repaidShares_lt: BigInt
+  repaidShares_gte: BigInt
+  repaidShares_lte: BigInt
+  repaidShares_in: [BigInt!]
+  repaidShares_not_in: [BigInt!]
+  seizedAssets: BigInt
+  seizedAssets_not: BigInt
+  seizedAssets_gt: BigInt
+  seizedAssets_lt: BigInt
+  seizedAssets_gte: BigInt
+  seizedAssets_lte: BigInt
+  seizedAssets_in: [BigInt!]
+  seizedAssets_not_in: [BigInt!]
+  badDebtShares: BigInt
+  badDebtShares_not: BigInt
+  badDebtShares_gt: BigInt
+  badDebtShares_lt: BigInt
+  badDebtShares_gte: BigInt
+  badDebtShares_lte: BigInt
+  badDebtShares_in: [BigInt!]
+  badDebtShares_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [BorrowerEvent_filter]
+  or: [BorrowerEvent_filter]
+}
+
+enum BorrowerEvent_orderBy {
+  id
+  position
+  position__id
+  position__debt
+  position__collateral
+  position___debtBeforeSummerEvent
+  position___collateralBeforeSummerEvent
+  position__borrowCumulativeDepositUSD
+  position__borrowCumulativeDepositInQuoteToken
+  position__borrowCumulativeDepositInCollateralToken
+  position__borrowCumulativeWithdrawUSD
+  position__borrowCumulativeWithdrawInQuoteToken
+  position__borrowCumulativeWithdrawInCollateralToken
+  position__borrowCumulativeCollateralDeposit
+  position__borrowCumulativeCollateralWithdraw
+  position__borrowCumulativeDebtDeposit
+  position__borrowCumulativeDebtWithdraw
+  position__borrowCumulativeFeesUSD
+  position__borrowCumulativeFeesInQuoteToken
+  position__borrowCumulativeFeesInCollateralToken
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  account__liquidationPrice
+  kind
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  debtTokenPriceUSD
+  collateralTokenPriceUSD
+  collateralOraclePrice
+  debtBefore
+  debtAfter
+  debtDelta
+  collateralBefore
+  collateralAfter
+  collateralDelta
+  caller
+  onBehalfOf
+  receiver
+  quoteRepaid
+  collateralWithdrawn
+  amountBorrowed
+  collateralDeposited
+  sharesReceived
+  sharesBurned
+  borrower
+  repaidAssets
+  repaidShares
+  seizedAssets
+  badDebtShares
+  txHash
+  blockNumber
+  timestamp
+}
+
+type BorrowPosition {
+  id: ID!
+  market: Market!
+  account: Account
+  user: User!
+  debt: BigInt!
+  collateral: BigInt!
+  _debtBeforeSummerEvent: BigInt!
+  _collateralBeforeSummerEvent: BigInt!
+  borrowCumulativeDepositUSD: BigDecimal!
+  borrowCumulativeDepositInQuoteToken: BigDecimal!
+  borrowCumulativeDepositInCollateralToken: BigDecimal!
+  borrowCumulativeWithdrawUSD: BigDecimal!
+  borrowCumulativeWithdrawInQuoteToken: BigDecimal!
+  borrowCumulativeWithdrawInCollateralToken: BigDecimal!
+  borrowCumulativeCollateralDeposit: BigDecimal!
+  borrowCumulativeCollateralWithdraw: BigDecimal!
+  borrowCumulativeDebtDeposit: BigDecimal!
+  borrowCumulativeDebtWithdraw: BigDecimal!
+  borrowCumulativeFeesUSD: BigDecimal!
+  borrowCumulativeFeesInQuoteToken: BigDecimal!
+  borrowCumulativeFeesInCollateralToken: BigDecimal!
+  protocolEvents(skip: Int = 0, first: Int = 100, orderBy: BorrowerEvent_orderBy, orderDirection: OrderDirection, where: BorrowerEvent_filter): [BorrowerEvent!]
+  oasisEvents(skip: Int = 0, first: Int = 100, orderBy: SummerEvent_orderBy, orderDirection: OrderDirection, where: SummerEvent_filter): [SummerEvent!]
+  liquidations(skip: Int = 0, first: Int = 100, orderBy: Liquidation_orderBy, orderDirection: OrderDirection, where: Liquidation_filter): [Liquidation!]!
+}
+
+input BorrowPosition_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  debt: BigInt
+  debt_not: BigInt
+  debt_gt: BigInt
+  debt_lt: BigInt
+  debt_gte: BigInt
+  debt_lte: BigInt
+  debt_in: [BigInt!]
+  debt_not_in: [BigInt!]
+  collateral: BigInt
+  collateral_not: BigInt
+  collateral_gt: BigInt
+  collateral_lt: BigInt
+  collateral_gte: BigInt
+  collateral_lte: BigInt
+  collateral_in: [BigInt!]
+  collateral_not_in: [BigInt!]
+  _debtBeforeSummerEvent: BigInt
+  _debtBeforeSummerEvent_not: BigInt
+  _debtBeforeSummerEvent_gt: BigInt
+  _debtBeforeSummerEvent_lt: BigInt
+  _debtBeforeSummerEvent_gte: BigInt
+  _debtBeforeSummerEvent_lte: BigInt
+  _debtBeforeSummerEvent_in: [BigInt!]
+  _debtBeforeSummerEvent_not_in: [BigInt!]
+  _collateralBeforeSummerEvent: BigInt
+  _collateralBeforeSummerEvent_not: BigInt
+  _collateralBeforeSummerEvent_gt: BigInt
+  _collateralBeforeSummerEvent_lt: BigInt
+  _collateralBeforeSummerEvent_gte: BigInt
+  _collateralBeforeSummerEvent_lte: BigInt
+  _collateralBeforeSummerEvent_in: [BigInt!]
+  _collateralBeforeSummerEvent_not_in: [BigInt!]
+  borrowCumulativeDepositUSD: BigDecimal
+  borrowCumulativeDepositUSD_not: BigDecimal
+  borrowCumulativeDepositUSD_gt: BigDecimal
+  borrowCumulativeDepositUSD_lt: BigDecimal
+  borrowCumulativeDepositUSD_gte: BigDecimal
+  borrowCumulativeDepositUSD_lte: BigDecimal
+  borrowCumulativeDepositUSD_in: [BigDecimal!]
+  borrowCumulativeDepositUSD_not_in: [BigDecimal!]
+  borrowCumulativeDepositInQuoteToken: BigDecimal
+  borrowCumulativeDepositInQuoteToken_not: BigDecimal
+  borrowCumulativeDepositInQuoteToken_gt: BigDecimal
+  borrowCumulativeDepositInQuoteToken_lt: BigDecimal
+  borrowCumulativeDepositInQuoteToken_gte: BigDecimal
+  borrowCumulativeDepositInQuoteToken_lte: BigDecimal
+  borrowCumulativeDepositInQuoteToken_in: [BigDecimal!]
+  borrowCumulativeDepositInQuoteToken_not_in: [BigDecimal!]
+  borrowCumulativeDepositInCollateralToken: BigDecimal
+  borrowCumulativeDepositInCollateralToken_not: BigDecimal
+  borrowCumulativeDepositInCollateralToken_gt: BigDecimal
+  borrowCumulativeDepositInCollateralToken_lt: BigDecimal
+  borrowCumulativeDepositInCollateralToken_gte: BigDecimal
+  borrowCumulativeDepositInCollateralToken_lte: BigDecimal
+  borrowCumulativeDepositInCollateralToken_in: [BigDecimal!]
+  borrowCumulativeDepositInCollateralToken_not_in: [BigDecimal!]
+  borrowCumulativeWithdrawUSD: BigDecimal
+  borrowCumulativeWithdrawUSD_not: BigDecimal
+  borrowCumulativeWithdrawUSD_gt: BigDecimal
+  borrowCumulativeWithdrawUSD_lt: BigDecimal
+  borrowCumulativeWithdrawUSD_gte: BigDecimal
+  borrowCumulativeWithdrawUSD_lte: BigDecimal
+  borrowCumulativeWithdrawUSD_in: [BigDecimal!]
+  borrowCumulativeWithdrawUSD_not_in: [BigDecimal!]
+  borrowCumulativeWithdrawInQuoteToken: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_not: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_gt: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_lt: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_gte: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_lte: BigDecimal
+  borrowCumulativeWithdrawInQuoteToken_in: [BigDecimal!]
+  borrowCumulativeWithdrawInQuoteToken_not_in: [BigDecimal!]
+  borrowCumulativeWithdrawInCollateralToken: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_not: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_gt: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_lt: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_gte: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_lte: BigDecimal
+  borrowCumulativeWithdrawInCollateralToken_in: [BigDecimal!]
+  borrowCumulativeWithdrawInCollateralToken_not_in: [BigDecimal!]
+  borrowCumulativeCollateralDeposit: BigDecimal
+  borrowCumulativeCollateralDeposit_not: BigDecimal
+  borrowCumulativeCollateralDeposit_gt: BigDecimal
+  borrowCumulativeCollateralDeposit_lt: BigDecimal
+  borrowCumulativeCollateralDeposit_gte: BigDecimal
+  borrowCumulativeCollateralDeposit_lte: BigDecimal
+  borrowCumulativeCollateralDeposit_in: [BigDecimal!]
+  borrowCumulativeCollateralDeposit_not_in: [BigDecimal!]
+  borrowCumulativeCollateralWithdraw: BigDecimal
+  borrowCumulativeCollateralWithdraw_not: BigDecimal
+  borrowCumulativeCollateralWithdraw_gt: BigDecimal
+  borrowCumulativeCollateralWithdraw_lt: BigDecimal
+  borrowCumulativeCollateralWithdraw_gte: BigDecimal
+  borrowCumulativeCollateralWithdraw_lte: BigDecimal
+  borrowCumulativeCollateralWithdraw_in: [BigDecimal!]
+  borrowCumulativeCollateralWithdraw_not_in: [BigDecimal!]
+  borrowCumulativeDebtDeposit: BigDecimal
+  borrowCumulativeDebtDeposit_not: BigDecimal
+  borrowCumulativeDebtDeposit_gt: BigDecimal
+  borrowCumulativeDebtDeposit_lt: BigDecimal
+  borrowCumulativeDebtDeposit_gte: BigDecimal
+  borrowCumulativeDebtDeposit_lte: BigDecimal
+  borrowCumulativeDebtDeposit_in: [BigDecimal!]
+  borrowCumulativeDebtDeposit_not_in: [BigDecimal!]
+  borrowCumulativeDebtWithdraw: BigDecimal
+  borrowCumulativeDebtWithdraw_not: BigDecimal
+  borrowCumulativeDebtWithdraw_gt: BigDecimal
+  borrowCumulativeDebtWithdraw_lt: BigDecimal
+  borrowCumulativeDebtWithdraw_gte: BigDecimal
+  borrowCumulativeDebtWithdraw_lte: BigDecimal
+  borrowCumulativeDebtWithdraw_in: [BigDecimal!]
+  borrowCumulativeDebtWithdraw_not_in: [BigDecimal!]
+  borrowCumulativeFeesUSD: BigDecimal
+  borrowCumulativeFeesUSD_not: BigDecimal
+  borrowCumulativeFeesUSD_gt: BigDecimal
+  borrowCumulativeFeesUSD_lt: BigDecimal
+  borrowCumulativeFeesUSD_gte: BigDecimal
+  borrowCumulativeFeesUSD_lte: BigDecimal
+  borrowCumulativeFeesUSD_in: [BigDecimal!]
+  borrowCumulativeFeesUSD_not_in: [BigDecimal!]
+  borrowCumulativeFeesInQuoteToken: BigDecimal
+  borrowCumulativeFeesInQuoteToken_not: BigDecimal
+  borrowCumulativeFeesInQuoteToken_gt: BigDecimal
+  borrowCumulativeFeesInQuoteToken_lt: BigDecimal
+  borrowCumulativeFeesInQuoteToken_gte: BigDecimal
+  borrowCumulativeFeesInQuoteToken_lte: BigDecimal
+  borrowCumulativeFeesInQuoteToken_in: [BigDecimal!]
+  borrowCumulativeFeesInQuoteToken_not_in: [BigDecimal!]
+  borrowCumulativeFeesInCollateralToken: BigDecimal
+  borrowCumulativeFeesInCollateralToken_not: BigDecimal
+  borrowCumulativeFeesInCollateralToken_gt: BigDecimal
+  borrowCumulativeFeesInCollateralToken_lt: BigDecimal
+  borrowCumulativeFeesInCollateralToken_gte: BigDecimal
+  borrowCumulativeFeesInCollateralToken_lte: BigDecimal
+  borrowCumulativeFeesInCollateralToken_in: [BigDecimal!]
+  borrowCumulativeFeesInCollateralToken_not_in: [BigDecimal!]
+  protocolEvents_: BorrowerEvent_filter
+  oasisEvents_: SummerEvent_filter
+  liquidations: [String!]
+  liquidations_not: [String!]
+  liquidations_contains: [String!]
+  liquidations_contains_nocase: [String!]
+  liquidations_not_contains: [String!]
+  liquidations_not_contains_nocase: [String!]
+  liquidations_: Liquidation_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [BorrowPosition_filter]
+  or: [BorrowPosition_filter]
+}
+
+enum BorrowPosition_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  account__liquidationPrice
+  user
+  user__id
+  user__address
+  user__vaultCount
+  debt
+  collateral
+  _debtBeforeSummerEvent
+  _collateralBeforeSummerEvent
+  borrowCumulativeDepositUSD
+  borrowCumulativeDepositInQuoteToken
+  borrowCumulativeDepositInCollateralToken
+  borrowCumulativeWithdrawUSD
+  borrowCumulativeWithdrawInQuoteToken
+  borrowCumulativeWithdrawInCollateralToken
+  borrowCumulativeCollateralDeposit
+  borrowCumulativeCollateralWithdraw
+  borrowCumulativeDebtDeposit
+  borrowCumulativeDebtWithdraw
+  borrowCumulativeFeesUSD
+  borrowCumulativeFeesInQuoteToken
+  borrowCumulativeFeesInCollateralToken
+  protocolEvents
+  oasisEvents
+  liquidations
+}
+
+scalar Bytes
+
+type EarnPosition {
+  id: ID!
+  market: Market!
+  account: Account!
+  user: User!
+  earnCumulativeDepositUSD: BigDecimal!
+  earnCumulativeDepositInQuoteToken: BigDecimal!
+  earnCumulativeDepositInCollateralToken: BigDecimal!
+  earnCumulativeWithdrawUSD: BigDecimal!
+  earnCumulativeWithdrawInQuoteToken: BigDecimal!
+  earnCumulativeWithdrawInCollateralToken: BigDecimal!
+  earnCumulativeFeesUSD: BigDecimal!
+  earnCumulativeFeesInQuoteToken: BigDecimal!
+  earnCumulativeFeesInCollateralToken: BigDecimal!
+  earnCumulativeQuoteTokenDeposit: BigDecimal!
+  earnCumulativeQuoteTokenWithdraw: BigDecimal!
+  oasisEvents(skip: Int = 0, first: Int = 100, orderBy: SummerEvent_orderBy, orderDirection: OrderDirection, where: SummerEvent_filter): [SummerEvent!]
+  protocolEvents(skip: Int = 0, first: Int = 100, orderBy: LenderEvent_orderBy, orderDirection: OrderDirection, where: LenderEvent_filter): [LenderEvent!]
+}
+
+input EarnPosition_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  earnCumulativeDepositUSD: BigDecimal
+  earnCumulativeDepositUSD_not: BigDecimal
+  earnCumulativeDepositUSD_gt: BigDecimal
+  earnCumulativeDepositUSD_lt: BigDecimal
+  earnCumulativeDepositUSD_gte: BigDecimal
+  earnCumulativeDepositUSD_lte: BigDecimal
+  earnCumulativeDepositUSD_in: [BigDecimal!]
+  earnCumulativeDepositUSD_not_in: [BigDecimal!]
+  earnCumulativeDepositInQuoteToken: BigDecimal
+  earnCumulativeDepositInQuoteToken_not: BigDecimal
+  earnCumulativeDepositInQuoteToken_gt: BigDecimal
+  earnCumulativeDepositInQuoteToken_lt: BigDecimal
+  earnCumulativeDepositInQuoteToken_gte: BigDecimal
+  earnCumulativeDepositInQuoteToken_lte: BigDecimal
+  earnCumulativeDepositInQuoteToken_in: [BigDecimal!]
+  earnCumulativeDepositInQuoteToken_not_in: [BigDecimal!]
+  earnCumulativeDepositInCollateralToken: BigDecimal
+  earnCumulativeDepositInCollateralToken_not: BigDecimal
+  earnCumulativeDepositInCollateralToken_gt: BigDecimal
+  earnCumulativeDepositInCollateralToken_lt: BigDecimal
+  earnCumulativeDepositInCollateralToken_gte: BigDecimal
+  earnCumulativeDepositInCollateralToken_lte: BigDecimal
+  earnCumulativeDepositInCollateralToken_in: [BigDecimal!]
+  earnCumulativeDepositInCollateralToken_not_in: [BigDecimal!]
+  earnCumulativeWithdrawUSD: BigDecimal
+  earnCumulativeWithdrawUSD_not: BigDecimal
+  earnCumulativeWithdrawUSD_gt: BigDecimal
+  earnCumulativeWithdrawUSD_lt: BigDecimal
+  earnCumulativeWithdrawUSD_gte: BigDecimal
+  earnCumulativeWithdrawUSD_lte: BigDecimal
+  earnCumulativeWithdrawUSD_in: [BigDecimal!]
+  earnCumulativeWithdrawUSD_not_in: [BigDecimal!]
+  earnCumulativeWithdrawInQuoteToken: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_not: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_gt: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_lt: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_gte: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_lte: BigDecimal
+  earnCumulativeWithdrawInQuoteToken_in: [BigDecimal!]
+  earnCumulativeWithdrawInQuoteToken_not_in: [BigDecimal!]
+  earnCumulativeWithdrawInCollateralToken: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_not: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_gt: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_lt: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_gte: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_lte: BigDecimal
+  earnCumulativeWithdrawInCollateralToken_in: [BigDecimal!]
+  earnCumulativeWithdrawInCollateralToken_not_in: [BigDecimal!]
+  earnCumulativeFeesUSD: BigDecimal
+  earnCumulativeFeesUSD_not: BigDecimal
+  earnCumulativeFeesUSD_gt: BigDecimal
+  earnCumulativeFeesUSD_lt: BigDecimal
+  earnCumulativeFeesUSD_gte: BigDecimal
+  earnCumulativeFeesUSD_lte: BigDecimal
+  earnCumulativeFeesUSD_in: [BigDecimal!]
+  earnCumulativeFeesUSD_not_in: [BigDecimal!]
+  earnCumulativeFeesInQuoteToken: BigDecimal
+  earnCumulativeFeesInQuoteToken_not: BigDecimal
+  earnCumulativeFeesInQuoteToken_gt: BigDecimal
+  earnCumulativeFeesInQuoteToken_lt: BigDecimal
+  earnCumulativeFeesInQuoteToken_gte: BigDecimal
+  earnCumulativeFeesInQuoteToken_lte: BigDecimal
+  earnCumulativeFeesInQuoteToken_in: [BigDecimal!]
+  earnCumulativeFeesInQuoteToken_not_in: [BigDecimal!]
+  earnCumulativeFeesInCollateralToken: BigDecimal
+  earnCumulativeFeesInCollateralToken_not: BigDecimal
+  earnCumulativeFeesInCollateralToken_gt: BigDecimal
+  earnCumulativeFeesInCollateralToken_lt: BigDecimal
+  earnCumulativeFeesInCollateralToken_gte: BigDecimal
+  earnCumulativeFeesInCollateralToken_lte: BigDecimal
+  earnCumulativeFeesInCollateralToken_in: [BigDecimal!]
+  earnCumulativeFeesInCollateralToken_not_in: [BigDecimal!]
+  earnCumulativeQuoteTokenDeposit: BigDecimal
+  earnCumulativeQuoteTokenDeposit_not: BigDecimal
+  earnCumulativeQuoteTokenDeposit_gt: BigDecimal
+  earnCumulativeQuoteTokenDeposit_lt: BigDecimal
+  earnCumulativeQuoteTokenDeposit_gte: BigDecimal
+  earnCumulativeQuoteTokenDeposit_lte: BigDecimal
+  earnCumulativeQuoteTokenDeposit_in: [BigDecimal!]
+  earnCumulativeQuoteTokenDeposit_not_in: [BigDecimal!]
+  earnCumulativeQuoteTokenWithdraw: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_not: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_gt: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_lt: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_gte: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_lte: BigDecimal
+  earnCumulativeQuoteTokenWithdraw_in: [BigDecimal!]
+  earnCumulativeQuoteTokenWithdraw_not_in: [BigDecimal!]
+  oasisEvents_: SummerEvent_filter
+  protocolEvents_: LenderEvent_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [EarnPosition_filter]
+  or: [EarnPosition_filter]
+}
+
+enum EarnPosition_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  account__liquidationPrice
+  user
+  user__id
+  user__address
+  user__vaultCount
+  earnCumulativeDepositUSD
+  earnCumulativeDepositInQuoteToken
+  earnCumulativeDepositInCollateralToken
+  earnCumulativeWithdrawUSD
+  earnCumulativeWithdrawInQuoteToken
+  earnCumulativeWithdrawInCollateralToken
+  earnCumulativeFeesUSD
+  earnCumulativeFeesInQuoteToken
+  earnCumulativeFeesInCollateralToken
+  earnCumulativeQuoteTokenDeposit
+  earnCumulativeQuoteTokenWithdraw
+  oasisEvents
+  protocolEvents
+}
+
+type FeePaid {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: Bytes!
+  beneficiary: Bytes!
+  amount: BigInt!
+  token: Bytes!
+}
+
+input FeePaid_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  beneficiary: Bytes
+  beneficiary_not: Bytes
+  beneficiary_gt: Bytes
+  beneficiary_lt: Bytes
+  beneficiary_gte: Bytes
+  beneficiary_lte: Bytes
+  beneficiary_in: [Bytes!]
+  beneficiary_not_in: [Bytes!]
+  beneficiary_contains: Bytes
+  beneficiary_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  token: Bytes
+  token_not: Bytes
+  token_gt: Bytes
+  token_lt: Bytes
+  token_gte: Bytes
+  token_lte: Bytes
+  token_in: [Bytes!]
+  token_not_in: [Bytes!]
+  token_contains: Bytes
+  token_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [FeePaid_filter]
+  or: [FeePaid_filter]
+}
+
+enum FeePaid_orderBy {
+  id
+  beneficiary
+  amount
+  token
+}
+
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
+type InterestRate {
+  id: Bytes!
+  market: Market!
+  type: String!
+  rate: BigDecimal!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input InterestRate_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  type: String
+  type_not: String
+  type_gt: String
+  type_lt: String
+  type_gte: String
+  type_lte: String
+  type_in: [String!]
+  type_not_in: [String!]
+  type_contains: String
+  type_contains_nocase: String
+  type_not_contains: String
+  type_not_contains_nocase: String
+  type_starts_with: String
+  type_starts_with_nocase: String
+  type_not_starts_with: String
+  type_not_starts_with_nocase: String
+  type_ends_with: String
+  type_ends_with_nocase: String
+  type_not_ends_with: String
+  type_not_ends_with_nocase: String
+  rate: BigDecimal
+  rate_not: BigDecimal
+  rate_gt: BigDecimal
+  rate_lt: BigDecimal
+  rate_gte: BigDecimal
+  rate_lte: BigDecimal
+  rate_in: [BigDecimal!]
+  rate_not_in: [BigDecimal!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [InterestRate_filter]
+  or: [InterestRate_filter]
+}
+
+enum InterestRate_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  type
+  rate
+  blockNumber
+  timestamp
+}
+
+type LenderEvent {
+  id: Bytes!
+  earnPosition: EarnPosition!
+  account: Account
+  kind: String!
+  market: Market!
+  debtToken: Token!
+  collateralToken: Token!
+  debtTokenPriceUSD: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  quoteBefore: BigDecimal!
+  quoteAfter: BigDecimal!
+  quoteDelta: BigDecimal!
+  onBehalfOf: Bytes!
+  quoteDesposited: BigInt
+  quoteWithdrawn: BigInt
+  sharesReceived: BigInt
+  sharesBurned: BigInt
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input LenderEvent_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  earnPosition: String
+  earnPosition_not: String
+  earnPosition_gt: String
+  earnPosition_lt: String
+  earnPosition_gte: String
+  earnPosition_lte: String
+  earnPosition_in: [String!]
+  earnPosition_not_in: [String!]
+  earnPosition_contains: String
+  earnPosition_contains_nocase: String
+  earnPosition_not_contains: String
+  earnPosition_not_contains_nocase: String
+  earnPosition_starts_with: String
+  earnPosition_starts_with_nocase: String
+  earnPosition_not_starts_with: String
+  earnPosition_not_starts_with_nocase: String
+  earnPosition_ends_with: String
+  earnPosition_ends_with_nocase: String
+  earnPosition_not_ends_with: String
+  earnPosition_not_ends_with_nocase: String
+  earnPosition_: EarnPosition_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  quoteBefore: BigDecimal
+  quoteBefore_not: BigDecimal
+  quoteBefore_gt: BigDecimal
+  quoteBefore_lt: BigDecimal
+  quoteBefore_gte: BigDecimal
+  quoteBefore_lte: BigDecimal
+  quoteBefore_in: [BigDecimal!]
+  quoteBefore_not_in: [BigDecimal!]
+  quoteAfter: BigDecimal
+  quoteAfter_not: BigDecimal
+  quoteAfter_gt: BigDecimal
+  quoteAfter_lt: BigDecimal
+  quoteAfter_gte: BigDecimal
+  quoteAfter_lte: BigDecimal
+  quoteAfter_in: [BigDecimal!]
+  quoteAfter_not_in: [BigDecimal!]
+  quoteDelta: BigDecimal
+  quoteDelta_not: BigDecimal
+  quoteDelta_gt: BigDecimal
+  quoteDelta_lt: BigDecimal
+  quoteDelta_gte: BigDecimal
+  quoteDelta_lte: BigDecimal
+  quoteDelta_in: [BigDecimal!]
+  quoteDelta_not_in: [BigDecimal!]
+  onBehalfOf: Bytes
+  onBehalfOf_not: Bytes
+  onBehalfOf_gt: Bytes
+  onBehalfOf_lt: Bytes
+  onBehalfOf_gte: Bytes
+  onBehalfOf_lte: Bytes
+  onBehalfOf_in: [Bytes!]
+  onBehalfOf_not_in: [Bytes!]
+  onBehalfOf_contains: Bytes
+  onBehalfOf_not_contains: Bytes
+  quoteDesposited: BigInt
+  quoteDesposited_not: BigInt
+  quoteDesposited_gt: BigInt
+  quoteDesposited_lt: BigInt
+  quoteDesposited_gte: BigInt
+  quoteDesposited_lte: BigInt
+  quoteDesposited_in: [BigInt!]
+  quoteDesposited_not_in: [BigInt!]
+  quoteWithdrawn: BigInt
+  quoteWithdrawn_not: BigInt
+  quoteWithdrawn_gt: BigInt
+  quoteWithdrawn_lt: BigInt
+  quoteWithdrawn_gte: BigInt
+  quoteWithdrawn_lte: BigInt
+  quoteWithdrawn_in: [BigInt!]
+  quoteWithdrawn_not_in: [BigInt!]
+  sharesReceived: BigInt
+  sharesReceived_not: BigInt
+  sharesReceived_gt: BigInt
+  sharesReceived_lt: BigInt
+  sharesReceived_gte: BigInt
+  sharesReceived_lte: BigInt
+  sharesReceived_in: [BigInt!]
+  sharesReceived_not_in: [BigInt!]
+  sharesBurned: BigInt
+  sharesBurned_not: BigInt
+  sharesBurned_gt: BigInt
+  sharesBurned_lt: BigInt
+  sharesBurned_gte: BigInt
+  sharesBurned_lte: BigInt
+  sharesBurned_in: [BigInt!]
+  sharesBurned_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [LenderEvent_filter]
+  or: [LenderEvent_filter]
+}
+
+enum LenderEvent_orderBy {
+  id
+  earnPosition
+  earnPosition__id
+  earnPosition__earnCumulativeDepositUSD
+  earnPosition__earnCumulativeDepositInQuoteToken
+  earnPosition__earnCumulativeDepositInCollateralToken
+  earnPosition__earnCumulativeWithdrawUSD
+  earnPosition__earnCumulativeWithdrawInQuoteToken
+  earnPosition__earnCumulativeWithdrawInCollateralToken
+  earnPosition__earnCumulativeFeesUSD
+  earnPosition__earnCumulativeFeesInQuoteToken
+  earnPosition__earnCumulativeFeesInCollateralToken
+  earnPosition__earnCumulativeQuoteTokenDeposit
+  earnPosition__earnCumulativeQuoteTokenWithdraw
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  account__liquidationPrice
+  kind
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  debtTokenPriceUSD
+  collateralTokenPriceUSD
+  quoteBefore
+  quoteAfter
+  quoteDelta
+  onBehalfOf
+  quoteDesposited
+  quoteWithdrawn
+  sharesReceived
+  sharesBurned
+  txHash
+  blockNumber
+  timestamp
+}
+
+type Liquidation {
+  id: Bytes!
+}
+
+input Liquidation_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Liquidation_filter]
+  or: [Liquidation_filter]
+}
+
+enum Liquidation_orderBy {
+  id
+}
+
+type Market {
+  id: Bytes!
+  debtToken: Token
+  quoteToken: Token
+  collateralToken: Token
+  oracle: Bytes!
+  interestModel: Bytes!
+  liquidataionLTV: BigInt
+  liquidationRatio: BigInt
+  lastUpdate: BigInt!
+  fee: BigInt!
+  latestInterestRates(skip: Int = 0, first: Int = 100, orderBy: InterestRate_orderBy, orderDirection: OrderDirection, where: InterestRate_filter): [InterestRate!]
+  interestRate: InterestRate
+  interestRates(skip: Int = 0, first: Int = 100, orderBy: InterestRate_orderBy, orderDirection: OrderDirection, where: InterestRate_filter): [InterestRate!]!
+}
+
+input Market_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  quoteToken: String
+  quoteToken_not: String
+  quoteToken_gt: String
+  quoteToken_lt: String
+  quoteToken_gte: String
+  quoteToken_lte: String
+  quoteToken_in: [String!]
+  quoteToken_not_in: [String!]
+  quoteToken_contains: String
+  quoteToken_contains_nocase: String
+  quoteToken_not_contains: String
+  quoteToken_not_contains_nocase: String
+  quoteToken_starts_with: String
+  quoteToken_starts_with_nocase: String
+  quoteToken_not_starts_with: String
+  quoteToken_not_starts_with_nocase: String
+  quoteToken_ends_with: String
+  quoteToken_ends_with_nocase: String
+  quoteToken_not_ends_with: String
+  quoteToken_not_ends_with_nocase: String
+  quoteToken_: Token_filter
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  oracle: Bytes
+  oracle_not: Bytes
+  oracle_gt: Bytes
+  oracle_lt: Bytes
+  oracle_gte: Bytes
+  oracle_lte: Bytes
+  oracle_in: [Bytes!]
+  oracle_not_in: [Bytes!]
+  oracle_contains: Bytes
+  oracle_not_contains: Bytes
+  interestModel: Bytes
+  interestModel_not: Bytes
+  interestModel_gt: Bytes
+  interestModel_lt: Bytes
+  interestModel_gte: Bytes
+  interestModel_lte: Bytes
+  interestModel_in: [Bytes!]
+  interestModel_not_in: [Bytes!]
+  interestModel_contains: Bytes
+  interestModel_not_contains: Bytes
+  liquidataionLTV: BigInt
+  liquidataionLTV_not: BigInt
+  liquidataionLTV_gt: BigInt
+  liquidataionLTV_lt: BigInt
+  liquidataionLTV_gte: BigInt
+  liquidataionLTV_lte: BigInt
+  liquidataionLTV_in: [BigInt!]
+  liquidataionLTV_not_in: [BigInt!]
+  liquidationRatio: BigInt
+  liquidationRatio_not: BigInt
+  liquidationRatio_gt: BigInt
+  liquidationRatio_lt: BigInt
+  liquidationRatio_gte: BigInt
+  liquidationRatio_lte: BigInt
+  liquidationRatio_in: [BigInt!]
+  liquidationRatio_not_in: [BigInt!]
+  lastUpdate: BigInt
+  lastUpdate_not: BigInt
+  lastUpdate_gt: BigInt
+  lastUpdate_lt: BigInt
+  lastUpdate_gte: BigInt
+  lastUpdate_lte: BigInt
+  lastUpdate_in: [BigInt!]
+  lastUpdate_not_in: [BigInt!]
+  fee: BigInt
+  fee_not: BigInt
+  fee_gt: BigInt
+  fee_lt: BigInt
+  fee_gte: BigInt
+  fee_lte: BigInt
+  fee_in: [BigInt!]
+  fee_not_in: [BigInt!]
+  latestInterestRates: [String!]
+  latestInterestRates_not: [String!]
+  latestInterestRates_contains: [String!]
+  latestInterestRates_contains_nocase: [String!]
+  latestInterestRates_not_contains: [String!]
+  latestInterestRates_not_contains_nocase: [String!]
+  latestInterestRates_: InterestRate_filter
+  interestRate: String
+  interestRate_not: String
+  interestRate_gt: String
+  interestRate_lt: String
+  interestRate_gte: String
+  interestRate_lte: String
+  interestRate_in: [String!]
+  interestRate_not_in: [String!]
+  interestRate_contains: String
+  interestRate_contains_nocase: String
+  interestRate_not_contains: String
+  interestRate_not_contains_nocase: String
+  interestRate_starts_with: String
+  interestRate_starts_with_nocase: String
+  interestRate_not_starts_with: String
+  interestRate_not_starts_with_nocase: String
+  interestRate_ends_with: String
+  interestRate_ends_with_nocase: String
+  interestRate_not_ends_with: String
+  interestRate_not_ends_with_nocase: String
+  interestRate_: InterestRate_filter
+  interestRates_: InterestRate_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Market_filter]
+  or: [Market_filter]
+}
+
+enum Market_orderBy {
+  id
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  quoteToken
+  quoteToken__id
+  quoteToken__address
+  quoteToken__decimals
+  quoteToken__precision
+  quoteToken__symbol
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  oracle
+  interestModel
+  liquidataionLTV
+  liquidationRatio
+  lastUpdate
+  fee
+  latestInterestRates
+  interestRate
+  interestRate__id
+  interestRate__type
+  interestRate__rate
+  interestRate__blockNumber
+  interestRate__timestamp
+  interestRates
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type Permission {
+  id: ID!
+  user: User!
+  account: Account!
+}
+
+input Permission_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  user: String
+  user_not: String
+  user_gt: String
+  user_lt: String
+  user_gte: String
+  user_lte: String
+  user_in: [String!]
+  user_not_in: [String!]
+  user_contains: String
+  user_contains_nocase: String
+  user_not_contains: String
+  user_not_contains_nocase: String
+  user_starts_with: String
+  user_starts_with_nocase: String
+  user_not_starts_with: String
+  user_not_starts_with_nocase: String
+  user_ends_with: String
+  user_ends_with_nocase: String
+  user_not_ends_with: String
+  user_not_ends_with_nocase: String
+  user_: User_filter
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Permission_filter]
+  or: [Permission_filter]
+}
+
+enum Permission_orderBy {
+  id
+  user
+  user__id
+  user__address
+  user__vaultCount
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  account__liquidationPrice
+}
+
+enum PositionType {
+  Borrow
+  Earn
+  Multiply
+}
+
+type ProtocolBorrow {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  onBehalf: Bytes!
+  receiver: Bytes!
+  assets: BigInt!
+  shares: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolBorrow_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalf: Bytes
+  onBehalf_not: Bytes
+  onBehalf_gt: Bytes
+  onBehalf_lt: Bytes
+  onBehalf_gte: Bytes
+  onBehalf_lte: Bytes
+  onBehalf_in: [Bytes!]
+  onBehalf_not_in: [Bytes!]
+  onBehalf_contains: Bytes
+  onBehalf_not_contains: Bytes
+  receiver: Bytes
+  receiver_not: Bytes
+  receiver_gt: Bytes
+  receiver_lt: Bytes
+  receiver_gte: Bytes
+  receiver_lte: Bytes
+  receiver_in: [Bytes!]
+  receiver_not_in: [Bytes!]
+  receiver_contains: Bytes
+  receiver_not_contains: Bytes
+  assets: BigInt
+  assets_not: BigInt
+  assets_gt: BigInt
+  assets_lt: BigInt
+  assets_gte: BigInt
+  assets_lte: BigInt
+  assets_in: [BigInt!]
+  assets_not_in: [BigInt!]
+  shares: BigInt
+  shares_not: BigInt
+  shares_gt: BigInt
+  shares_lt: BigInt
+  shares_gte: BigInt
+  shares_lte: BigInt
+  shares_in: [BigInt!]
+  shares_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolBorrow_filter]
+  or: [ProtocolBorrow_filter]
+}
+
+enum ProtocolBorrow_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  onBehalf
+  receiver
+  assets
+  shares
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ProtocolDeposit {
+  id: Bytes!
+}
+
+input ProtocolDeposit_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolDeposit_filter]
+  or: [ProtocolDeposit_filter]
+}
+
+enum ProtocolDeposit_orderBy {
+  id
+}
+
+type ProtocolLiquidate {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  borrower: Bytes!
+  repaidAssets: BigInt!
+  repaidShares: BigInt!
+  seizedAssets: BigInt!
+  badDebtShares: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolLiquidate_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  borrower: Bytes
+  borrower_not: Bytes
+  borrower_gt: Bytes
+  borrower_lt: Bytes
+  borrower_gte: Bytes
+  borrower_lte: Bytes
+  borrower_in: [Bytes!]
+  borrower_not_in: [Bytes!]
+  borrower_contains: Bytes
+  borrower_not_contains: Bytes
+  repaidAssets: BigInt
+  repaidAssets_not: BigInt
+  repaidAssets_gt: BigInt
+  repaidAssets_lt: BigInt
+  repaidAssets_gte: BigInt
+  repaidAssets_lte: BigInt
+  repaidAssets_in: [BigInt!]
+  repaidAssets_not_in: [BigInt!]
+  repaidShares: BigInt
+  repaidShares_not: BigInt
+  repaidShares_gt: BigInt
+  repaidShares_lt: BigInt
+  repaidShares_gte: BigInt
+  repaidShares_lte: BigInt
+  repaidShares_in: [BigInt!]
+  repaidShares_not_in: [BigInt!]
+  seizedAssets: BigInt
+  seizedAssets_not: BigInt
+  seizedAssets_gt: BigInt
+  seizedAssets_lt: BigInt
+  seizedAssets_gte: BigInt
+  seizedAssets_lte: BigInt
+  seizedAssets_in: [BigInt!]
+  seizedAssets_not_in: [BigInt!]
+  badDebtShares: BigInt
+  badDebtShares_not: BigInt
+  badDebtShares_gt: BigInt
+  badDebtShares_lt: BigInt
+  badDebtShares_gte: BigInt
+  badDebtShares_lte: BigInt
+  badDebtShares_in: [BigInt!]
+  badDebtShares_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolLiquidate_filter]
+  or: [ProtocolLiquidate_filter]
+}
+
+enum ProtocolLiquidate_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  borrower
+  repaidAssets
+  repaidShares
+  seizedAssets
+  badDebtShares
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ProtocolRepay {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  onBehalf: Bytes!
+  assets: BigInt!
+  shares: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolRepay_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalf: Bytes
+  onBehalf_not: Bytes
+  onBehalf_gt: Bytes
+  onBehalf_lt: Bytes
+  onBehalf_gte: Bytes
+  onBehalf_lte: Bytes
+  onBehalf_in: [Bytes!]
+  onBehalf_not_in: [Bytes!]
+  onBehalf_contains: Bytes
+  onBehalf_not_contains: Bytes
+  assets: BigInt
+  assets_not: BigInt
+  assets_gt: BigInt
+  assets_lt: BigInt
+  assets_gte: BigInt
+  assets_lte: BigInt
+  assets_in: [BigInt!]
+  assets_not_in: [BigInt!]
+  shares: BigInt
+  shares_not: BigInt
+  shares_gt: BigInt
+  shares_lt: BigInt
+  shares_gte: BigInt
+  shares_lte: BigInt
+  shares_in: [BigInt!]
+  shares_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolRepay_filter]
+  or: [ProtocolRepay_filter]
+}
+
+enum ProtocolRepay_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  onBehalf
+  assets
+  shares
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ProtocolSupply {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  onBehalf: Bytes!
+  assets: BigInt!
+  shares: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolSupply_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalf: Bytes
+  onBehalf_not: Bytes
+  onBehalf_gt: Bytes
+  onBehalf_lt: Bytes
+  onBehalf_gte: Bytes
+  onBehalf_lte: Bytes
+  onBehalf_in: [Bytes!]
+  onBehalf_not_in: [Bytes!]
+  onBehalf_contains: Bytes
+  onBehalf_not_contains: Bytes
+  assets: BigInt
+  assets_not: BigInt
+  assets_gt: BigInt
+  assets_lt: BigInt
+  assets_gte: BigInt
+  assets_lte: BigInt
+  assets_in: [BigInt!]
+  assets_not_in: [BigInt!]
+  shares: BigInt
+  shares_not: BigInt
+  shares_gt: BigInt
+  shares_lt: BigInt
+  shares_gte: BigInt
+  shares_lte: BigInt
+  shares_in: [BigInt!]
+  shares_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolSupply_filter]
+  or: [ProtocolSupply_filter]
+}
+
+enum ProtocolSupply_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  onBehalf
+  assets
+  shares
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ProtocolSupplyCollateral {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  onBehalf: Bytes!
+  assets: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolSupplyCollateral_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalf: Bytes
+  onBehalf_not: Bytes
+  onBehalf_gt: Bytes
+  onBehalf_lt: Bytes
+  onBehalf_gte: Bytes
+  onBehalf_lte: Bytes
+  onBehalf_in: [Bytes!]
+  onBehalf_not_in: [Bytes!]
+  onBehalf_contains: Bytes
+  onBehalf_not_contains: Bytes
+  assets: BigInt
+  assets_not: BigInt
+  assets_gt: BigInt
+  assets_lt: BigInt
+  assets_gte: BigInt
+  assets_lte: BigInt
+  assets_in: [BigInt!]
+  assets_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolSupplyCollateral_filter]
+  or: [ProtocolSupplyCollateral_filter]
+}
+
+enum ProtocolSupplyCollateral_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  onBehalf
+  assets
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ProtocolWithdraw {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  onBehalf: Bytes!
+  assets: BigInt!
+  shares: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolWithdraw_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalf: Bytes
+  onBehalf_not: Bytes
+  onBehalf_gt: Bytes
+  onBehalf_lt: Bytes
+  onBehalf_gte: Bytes
+  onBehalf_lte: Bytes
+  onBehalf_in: [Bytes!]
+  onBehalf_not_in: [Bytes!]
+  onBehalf_contains: Bytes
+  onBehalf_not_contains: Bytes
+  assets: BigInt
+  assets_not: BigInt
+  assets_gt: BigInt
+  assets_lt: BigInt
+  assets_gte: BigInt
+  assets_lte: BigInt
+  assets_in: [BigInt!]
+  assets_not_in: [BigInt!]
+  shares: BigInt
+  shares_not: BigInt
+  shares_gt: BigInt
+  shares_lt: BigInt
+  shares_gte: BigInt
+  shares_lte: BigInt
+  shares_in: [BigInt!]
+  shares_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolWithdraw_filter]
+  or: [ProtocolWithdraw_filter]
+}
+
+enum ProtocolWithdraw_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  onBehalf
+  assets
+  shares
+  txHash
+  blockNumber
+  timestamp
+}
+
+type ProtocolWithdrawCollateral {
+  id: Bytes!
+  market: Market!
+  caller: Bytes!
+  onBehalf: Bytes!
+  receiver: Bytes!
+  assets: BigInt!
+  txHash: Bytes!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+input ProtocolWithdrawCollateral_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  caller: Bytes
+  caller_not: Bytes
+  caller_gt: Bytes
+  caller_lt: Bytes
+  caller_gte: Bytes
+  caller_lte: Bytes
+  caller_in: [Bytes!]
+  caller_not_in: [Bytes!]
+  caller_contains: Bytes
+  caller_not_contains: Bytes
+  onBehalf: Bytes
+  onBehalf_not: Bytes
+  onBehalf_gt: Bytes
+  onBehalf_lt: Bytes
+  onBehalf_gte: Bytes
+  onBehalf_lte: Bytes
+  onBehalf_in: [Bytes!]
+  onBehalf_not_in: [Bytes!]
+  onBehalf_contains: Bytes
+  onBehalf_not_contains: Bytes
+  receiver: Bytes
+  receiver_not: Bytes
+  receiver_gt: Bytes
+  receiver_lt: Bytes
+  receiver_gte: Bytes
+  receiver_lte: Bytes
+  receiver_in: [Bytes!]
+  receiver_not_in: [Bytes!]
+  receiver_contains: Bytes
+  receiver_not_contains: Bytes
+  assets: BigInt
+  assets_not: BigInt
+  assets_gt: BigInt
+  assets_lt: BigInt
+  assets_gte: BigInt
+  assets_lte: BigInt
+  assets_in: [BigInt!]
+  assets_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ProtocolWithdrawCollateral_filter]
+  or: [ProtocolWithdrawCollateral_filter]
+}
+
+enum ProtocolWithdrawCollateral_orderBy {
+  id
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  caller
+  onBehalf
+  receiver
+  assets
+  txHash
+  blockNumber
+  timestamp
+}
+
+type Query {
+  user(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): User
+  users(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: User_orderBy
+    orderDirection: OrderDirection
+    where: User_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [User!]!
+  account(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Account
+  accounts(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Account_orderBy
+    orderDirection: OrderDirection
+    where: Account_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Account!]!
+  permission(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Permission
+  permissions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Permission_orderBy
+    orderDirection: OrderDirection
+    where: Permission_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Permission!]!
+  market(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Market
+  markets(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Market_orderBy
+    orderDirection: OrderDirection
+    where: Market_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Market!]!
+  liquidation(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Liquidation
+  liquidations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Liquidation_orderBy
+    orderDirection: OrderDirection
+    where: Liquidation_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Liquidation!]!
+  earnPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnPosition
+  earnPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnPosition_orderBy
+    orderDirection: OrderDirection
+    where: EarnPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnPosition!]!
+  borrowPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowPosition
+  borrowPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowPosition_orderBy
+    orderDirection: OrderDirection
+    where: BorrowPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowPosition!]!
+  borrowerEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowerEvent
+  borrowerEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowerEvent_orderBy
+    orderDirection: OrderDirection
+    where: BorrowerEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowerEvent!]!
+  lenderEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): LenderEvent
+  lenderEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: LenderEvent_orderBy
+    orderDirection: OrderDirection
+    where: LenderEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [LenderEvent!]!
+  summerEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SummerEvent
+  summerEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SummerEvent_orderBy
+    orderDirection: OrderDirection
+    where: SummerEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SummerEvent!]!
+  token(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  transfer(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    where: Transfer_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Transfer!]!
+  assetSwap(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AssetSwap
+  assetSwaps(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AssetSwap_orderBy
+    orderDirection: OrderDirection
+    where: AssetSwap_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AssetSwap!]!
+  slippageSaved(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SlippageSaved
+  slippageSaveds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SlippageSaved_orderBy
+    orderDirection: OrderDirection
+    where: SlippageSaved_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SlippageSaved!]!
+  feePaid(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FeePaid
+  feePaids(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: FeePaid_orderBy
+    orderDirection: OrderDirection
+    where: FeePaid_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [FeePaid!]!
+  protocolSupply(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolSupply
+  protocolSupplies(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolSupply_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolSupply_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolSupply!]!
+  protocolWithdraw(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolWithdraw
+  protocolWithdraws(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolWithdraw_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolWithdraw_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolWithdraw!]!
+  protocolSupplyCollateral(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolSupplyCollateral
+  protocolSupplyCollaterals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolSupplyCollateral_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolSupplyCollateral_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolSupplyCollateral!]!
+  protocolWithdrawCollateral(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolWithdrawCollateral
+  protocolWithdrawCollaterals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolWithdrawCollateral_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolWithdrawCollateral_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolWithdrawCollateral!]!
+  protocolBorrow(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolBorrow
+  protocolBorrows(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolBorrow_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolBorrow_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolBorrow!]!
+  protocolDeposit(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolDeposit
+  protocolDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolDeposit_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolDeposit_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolDeposit!]!
+  protocolRepay(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolRepay
+  protocolRepays(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolRepay_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolRepay_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolRepay!]!
+  protocolLiquidate(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolLiquidate
+  protocolLiquidates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolLiquidate_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolLiquidate_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolLiquidate!]!
+  interestRate(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): InterestRate
+  interestRates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: InterestRate_orderBy
+    orderDirection: OrderDirection
+    where: InterestRate_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [InterestRate!]!
+
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type SlippageSaved {
+  """
+  id is a tx_hash-actionLogIndex
+  it uses action log index to easily combine all swap events into one
+  
+  """
+  id: Bytes!
+  minimumPossible: BigInt!
+  actualAmount: BigInt!
+}
+
+input SlippageSaved_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  minimumPossible: BigInt
+  minimumPossible_not: BigInt
+  minimumPossible_gt: BigInt
+  minimumPossible_lt: BigInt
+  minimumPossible_gte: BigInt
+  minimumPossible_lte: BigInt
+  minimumPossible_in: [BigInt!]
+  minimumPossible_not_in: [BigInt!]
+  actualAmount: BigInt
+  actualAmount_not: BigInt
+  actualAmount_gt: BigInt
+  actualAmount_lt: BigInt
+  actualAmount_gte: BigInt
+  actualAmount_lte: BigInt
+  actualAmount_in: [BigInt!]
+  actualAmount_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [SlippageSaved_filter]
+  or: [SlippageSaved_filter]
+}
+
+enum SlippageSaved_orderBy {
+  id
+  minimumPossible
+  actualAmount
+}
+
+type Subscription {
+  user(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): User
+  users(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: User_orderBy
+    orderDirection: OrderDirection
+    where: User_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [User!]!
+  account(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Account
+  accounts(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Account_orderBy
+    orderDirection: OrderDirection
+    where: Account_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Account!]!
+  permission(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Permission
+  permissions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Permission_orderBy
+    orderDirection: OrderDirection
+    where: Permission_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Permission!]!
+  market(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Market
+  markets(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Market_orderBy
+    orderDirection: OrderDirection
+    where: Market_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Market!]!
+  liquidation(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Liquidation
+  liquidations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Liquidation_orderBy
+    orderDirection: OrderDirection
+    where: Liquidation_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Liquidation!]!
+  earnPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): EarnPosition
+  earnPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: EarnPosition_orderBy
+    orderDirection: OrderDirection
+    where: EarnPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [EarnPosition!]!
+  borrowPosition(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowPosition
+  borrowPositions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowPosition_orderBy
+    orderDirection: OrderDirection
+    where: BorrowPosition_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowPosition!]!
+  borrowerEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): BorrowerEvent
+  borrowerEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: BorrowerEvent_orderBy
+    orderDirection: OrderDirection
+    where: BorrowerEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [BorrowerEvent!]!
+  lenderEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): LenderEvent
+  lenderEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: LenderEvent_orderBy
+    orderDirection: OrderDirection
+    where: LenderEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [LenderEvent!]!
+  summerEvent(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SummerEvent
+  summerEvents(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SummerEvent_orderBy
+    orderDirection: OrderDirection
+    where: SummerEvent_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SummerEvent!]!
+  token(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Token
+  tokens(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Token_orderBy
+    orderDirection: OrderDirection
+    where: Token_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Token!]!
+  transfer(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    where: Transfer_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Transfer!]!
+  assetSwap(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AssetSwap
+  assetSwaps(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AssetSwap_orderBy
+    orderDirection: OrderDirection
+    where: AssetSwap_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AssetSwap!]!
+  slippageSaved(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): SlippageSaved
+  slippageSaveds(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: SlippageSaved_orderBy
+    orderDirection: OrderDirection
+    where: SlippageSaved_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [SlippageSaved!]!
+  feePaid(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FeePaid
+  feePaids(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: FeePaid_orderBy
+    orderDirection: OrderDirection
+    where: FeePaid_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [FeePaid!]!
+  protocolSupply(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolSupply
+  protocolSupplies(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolSupply_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolSupply_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolSupply!]!
+  protocolWithdraw(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolWithdraw
+  protocolWithdraws(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolWithdraw_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolWithdraw_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolWithdraw!]!
+  protocolSupplyCollateral(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolSupplyCollateral
+  protocolSupplyCollaterals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolSupplyCollateral_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolSupplyCollateral_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolSupplyCollateral!]!
+  protocolWithdrawCollateral(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolWithdrawCollateral
+  protocolWithdrawCollaterals(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolWithdrawCollateral_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolWithdrawCollateral_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolWithdrawCollateral!]!
+  protocolBorrow(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolBorrow
+  protocolBorrows(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolBorrow_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolBorrow_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolBorrow!]!
+  protocolDeposit(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolDeposit
+  protocolDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolDeposit_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolDeposit_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolDeposit!]!
+  protocolRepay(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolRepay
+  protocolRepays(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolRepay_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolRepay_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolRepay!]!
+  protocolLiquidate(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ProtocolLiquidate
+  protocolLiquidates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: ProtocolLiquidate_orderBy
+    orderDirection: OrderDirection
+    where: ProtocolLiquidate_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [ProtocolLiquidate!]!
+  interestRate(
+    id: ID!
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): InterestRate
+  interestRates(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: InterestRate_orderBy
+    orderDirection: OrderDirection
+    where: InterestRate_filter
+
+    """
+    The block at which the query should be executed. Can either be a `{ hash:
+    Bytes }` value containing a block hash, a `{ number: Int }` containing the
+    block number, or a `{ number_gte: Int }` containing the minimum block
+    number. In the case of `number_gte`, the query will be executed on the
+    latest block only if the subgraph has progressed to or past the minimum
+    block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [InterestRate!]!
+
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+}
+
+type SummerEvent {
+  id: Bytes!
+  kind: String!
+  account: Account!
+  earnPosition: EarnPosition
+  borrowPosition: BorrowPosition
+  market: Market
+  isOpen: Boolean
+  debtToken: Token
+  debtAddress: Bytes!
+  debtBefore: BigDecimal!
+  debtAfter: BigDecimal!
+  debtDelta: BigDecimal!
+  debtTokenPriceUSD: BigDecimal!
+  collateralToken: Token
+  collateralAddress: Bytes!
+  collateralBefore: BigDecimal!
+  collateralAfter: BigDecimal!
+  collateralDelta: BigDecimal!
+  collateralTokenPriceUSD: BigDecimal!
+  debtOraclePrice: BigDecimal!
+  collateralOraclePrice: BigDecimal!
+  swapFromToken: Bytes
+  swapToToken: Bytes
+  swapFromAmount: BigDecimal
+  swapToAmount: BigDecimal
+  marketPrice: BigDecimal
+  depositTransfers(skip: Int = 0, first: Int = 100, orderBy: Transfer_orderBy, orderDirection: OrderDirection, where: Transfer_filter): [Transfer!]!
+  depositedUSD: BigDecimal
+  depositedInQuoteToken: BigDecimal!
+  withdrawTransfers(skip: Int = 0, first: Int = 100, orderBy: Transfer_orderBy, orderDirection: OrderDirection, where: Transfer_filter): [Transfer!]!
+  withdrawnUSD: BigDecimal
+  withdrawnInQuoteToken: BigDecimal!
+  oasisFeeToken: Bytes
+  oasisFee: BigDecimal!
+  oasisFeeUSD: BigDecimal!
+  oasisFeeInQuoteToken: BigDecimal!
+  oasisFeeInCollateralToken: BigDecimal!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  gasFeeUSD: BigDecimal!
+  gasFeeInQuoteToken: BigDecimal!
+  gasFeeInCollateralToken: BigDecimal!
+  totalFee: BigDecimal!
+  totalFeeInQuoteToken: BigDecimal!
+  totalFeeInCollateralToken: BigDecimal!
+  multipleBefore: BigDecimal
+  multipleAfter: BigDecimal
+  netValueBefore: BigDecimal
+  netValueAfter: BigDecimal
+  ltvBefore: BigDecimal
+  ltvAfter: BigDecimal
+  liquidationPriceBefore: BigDecimal
+  liquidationPriceAfter: BigDecimal
+  quoteTokensDelta: BigDecimal
+  quoteTokensBefore: BigDecimal
+  quoteTokensAfter: BigDecimal
+  ethPrice: BigDecimal!
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  txHash: Bytes!
+}
+
+input SummerEvent_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  kind: String
+  kind_not: String
+  kind_gt: String
+  kind_lt: String
+  kind_gte: String
+  kind_lte: String
+  kind_in: [String!]
+  kind_not_in: [String!]
+  kind_contains: String
+  kind_contains_nocase: String
+  kind_not_contains: String
+  kind_not_contains_nocase: String
+  kind_starts_with: String
+  kind_starts_with_nocase: String
+  kind_not_starts_with: String
+  kind_not_starts_with_nocase: String
+  kind_ends_with: String
+  kind_ends_with_nocase: String
+  kind_not_ends_with: String
+  kind_not_ends_with_nocase: String
+  account: String
+  account_not: String
+  account_gt: String
+  account_lt: String
+  account_gte: String
+  account_lte: String
+  account_in: [String!]
+  account_not_in: [String!]
+  account_contains: String
+  account_contains_nocase: String
+  account_not_contains: String
+  account_not_contains_nocase: String
+  account_starts_with: String
+  account_starts_with_nocase: String
+  account_not_starts_with: String
+  account_not_starts_with_nocase: String
+  account_ends_with: String
+  account_ends_with_nocase: String
+  account_not_ends_with: String
+  account_not_ends_with_nocase: String
+  account_: Account_filter
+  earnPosition: String
+  earnPosition_not: String
+  earnPosition_gt: String
+  earnPosition_lt: String
+  earnPosition_gte: String
+  earnPosition_lte: String
+  earnPosition_in: [String!]
+  earnPosition_not_in: [String!]
+  earnPosition_contains: String
+  earnPosition_contains_nocase: String
+  earnPosition_not_contains: String
+  earnPosition_not_contains_nocase: String
+  earnPosition_starts_with: String
+  earnPosition_starts_with_nocase: String
+  earnPosition_not_starts_with: String
+  earnPosition_not_starts_with_nocase: String
+  earnPosition_ends_with: String
+  earnPosition_ends_with_nocase: String
+  earnPosition_not_ends_with: String
+  earnPosition_not_ends_with_nocase: String
+  earnPosition_: EarnPosition_filter
+  borrowPosition: String
+  borrowPosition_not: String
+  borrowPosition_gt: String
+  borrowPosition_lt: String
+  borrowPosition_gte: String
+  borrowPosition_lte: String
+  borrowPosition_in: [String!]
+  borrowPosition_not_in: [String!]
+  borrowPosition_contains: String
+  borrowPosition_contains_nocase: String
+  borrowPosition_not_contains: String
+  borrowPosition_not_contains_nocase: String
+  borrowPosition_starts_with: String
+  borrowPosition_starts_with_nocase: String
+  borrowPosition_not_starts_with: String
+  borrowPosition_not_starts_with_nocase: String
+  borrowPosition_ends_with: String
+  borrowPosition_ends_with_nocase: String
+  borrowPosition_not_ends_with: String
+  borrowPosition_not_ends_with_nocase: String
+  borrowPosition_: BorrowPosition_filter
+  market: String
+  market_not: String
+  market_gt: String
+  market_lt: String
+  market_gte: String
+  market_lte: String
+  market_in: [String!]
+  market_not_in: [String!]
+  market_contains: String
+  market_contains_nocase: String
+  market_not_contains: String
+  market_not_contains_nocase: String
+  market_starts_with: String
+  market_starts_with_nocase: String
+  market_not_starts_with: String
+  market_not_starts_with_nocase: String
+  market_ends_with: String
+  market_ends_with_nocase: String
+  market_not_ends_with: String
+  market_not_ends_with_nocase: String
+  market_: Market_filter
+  isOpen: Boolean
+  isOpen_not: Boolean
+  isOpen_in: [Boolean!]
+  isOpen_not_in: [Boolean!]
+  debtToken: String
+  debtToken_not: String
+  debtToken_gt: String
+  debtToken_lt: String
+  debtToken_gte: String
+  debtToken_lte: String
+  debtToken_in: [String!]
+  debtToken_not_in: [String!]
+  debtToken_contains: String
+  debtToken_contains_nocase: String
+  debtToken_not_contains: String
+  debtToken_not_contains_nocase: String
+  debtToken_starts_with: String
+  debtToken_starts_with_nocase: String
+  debtToken_not_starts_with: String
+  debtToken_not_starts_with_nocase: String
+  debtToken_ends_with: String
+  debtToken_ends_with_nocase: String
+  debtToken_not_ends_with: String
+  debtToken_not_ends_with_nocase: String
+  debtToken_: Token_filter
+  debtAddress: Bytes
+  debtAddress_not: Bytes
+  debtAddress_gt: Bytes
+  debtAddress_lt: Bytes
+  debtAddress_gte: Bytes
+  debtAddress_lte: Bytes
+  debtAddress_in: [Bytes!]
+  debtAddress_not_in: [Bytes!]
+  debtAddress_contains: Bytes
+  debtAddress_not_contains: Bytes
+  debtBefore: BigDecimal
+  debtBefore_not: BigDecimal
+  debtBefore_gt: BigDecimal
+  debtBefore_lt: BigDecimal
+  debtBefore_gte: BigDecimal
+  debtBefore_lte: BigDecimal
+  debtBefore_in: [BigDecimal!]
+  debtBefore_not_in: [BigDecimal!]
+  debtAfter: BigDecimal
+  debtAfter_not: BigDecimal
+  debtAfter_gt: BigDecimal
+  debtAfter_lt: BigDecimal
+  debtAfter_gte: BigDecimal
+  debtAfter_lte: BigDecimal
+  debtAfter_in: [BigDecimal!]
+  debtAfter_not_in: [BigDecimal!]
+  debtDelta: BigDecimal
+  debtDelta_not: BigDecimal
+  debtDelta_gt: BigDecimal
+  debtDelta_lt: BigDecimal
+  debtDelta_gte: BigDecimal
+  debtDelta_lte: BigDecimal
+  debtDelta_in: [BigDecimal!]
+  debtDelta_not_in: [BigDecimal!]
+  debtTokenPriceUSD: BigDecimal
+  debtTokenPriceUSD_not: BigDecimal
+  debtTokenPriceUSD_gt: BigDecimal
+  debtTokenPriceUSD_lt: BigDecimal
+  debtTokenPriceUSD_gte: BigDecimal
+  debtTokenPriceUSD_lte: BigDecimal
+  debtTokenPriceUSD_in: [BigDecimal!]
+  debtTokenPriceUSD_not_in: [BigDecimal!]
+  collateralToken: String
+  collateralToken_not: String
+  collateralToken_gt: String
+  collateralToken_lt: String
+  collateralToken_gte: String
+  collateralToken_lte: String
+  collateralToken_in: [String!]
+  collateralToken_not_in: [String!]
+  collateralToken_contains: String
+  collateralToken_contains_nocase: String
+  collateralToken_not_contains: String
+  collateralToken_not_contains_nocase: String
+  collateralToken_starts_with: String
+  collateralToken_starts_with_nocase: String
+  collateralToken_not_starts_with: String
+  collateralToken_not_starts_with_nocase: String
+  collateralToken_ends_with: String
+  collateralToken_ends_with_nocase: String
+  collateralToken_not_ends_with: String
+  collateralToken_not_ends_with_nocase: String
+  collateralToken_: Token_filter
+  collateralAddress: Bytes
+  collateralAddress_not: Bytes
+  collateralAddress_gt: Bytes
+  collateralAddress_lt: Bytes
+  collateralAddress_gte: Bytes
+  collateralAddress_lte: Bytes
+  collateralAddress_in: [Bytes!]
+  collateralAddress_not_in: [Bytes!]
+  collateralAddress_contains: Bytes
+  collateralAddress_not_contains: Bytes
+  collateralBefore: BigDecimal
+  collateralBefore_not: BigDecimal
+  collateralBefore_gt: BigDecimal
+  collateralBefore_lt: BigDecimal
+  collateralBefore_gte: BigDecimal
+  collateralBefore_lte: BigDecimal
+  collateralBefore_in: [BigDecimal!]
+  collateralBefore_not_in: [BigDecimal!]
+  collateralAfter: BigDecimal
+  collateralAfter_not: BigDecimal
+  collateralAfter_gt: BigDecimal
+  collateralAfter_lt: BigDecimal
+  collateralAfter_gte: BigDecimal
+  collateralAfter_lte: BigDecimal
+  collateralAfter_in: [BigDecimal!]
+  collateralAfter_not_in: [BigDecimal!]
+  collateralDelta: BigDecimal
+  collateralDelta_not: BigDecimal
+  collateralDelta_gt: BigDecimal
+  collateralDelta_lt: BigDecimal
+  collateralDelta_gte: BigDecimal
+  collateralDelta_lte: BigDecimal
+  collateralDelta_in: [BigDecimal!]
+  collateralDelta_not_in: [BigDecimal!]
+  collateralTokenPriceUSD: BigDecimal
+  collateralTokenPriceUSD_not: BigDecimal
+  collateralTokenPriceUSD_gt: BigDecimal
+  collateralTokenPriceUSD_lt: BigDecimal
+  collateralTokenPriceUSD_gte: BigDecimal
+  collateralTokenPriceUSD_lte: BigDecimal
+  collateralTokenPriceUSD_in: [BigDecimal!]
+  collateralTokenPriceUSD_not_in: [BigDecimal!]
+  debtOraclePrice: BigDecimal
+  debtOraclePrice_not: BigDecimal
+  debtOraclePrice_gt: BigDecimal
+  debtOraclePrice_lt: BigDecimal
+  debtOraclePrice_gte: BigDecimal
+  debtOraclePrice_lte: BigDecimal
+  debtOraclePrice_in: [BigDecimal!]
+  debtOraclePrice_not_in: [BigDecimal!]
+  collateralOraclePrice: BigDecimal
+  collateralOraclePrice_not: BigDecimal
+  collateralOraclePrice_gt: BigDecimal
+  collateralOraclePrice_lt: BigDecimal
+  collateralOraclePrice_gte: BigDecimal
+  collateralOraclePrice_lte: BigDecimal
+  collateralOraclePrice_in: [BigDecimal!]
+  collateralOraclePrice_not_in: [BigDecimal!]
+  swapFromToken: Bytes
+  swapFromToken_not: Bytes
+  swapFromToken_gt: Bytes
+  swapFromToken_lt: Bytes
+  swapFromToken_gte: Bytes
+  swapFromToken_lte: Bytes
+  swapFromToken_in: [Bytes!]
+  swapFromToken_not_in: [Bytes!]
+  swapFromToken_contains: Bytes
+  swapFromToken_not_contains: Bytes
+  swapToToken: Bytes
+  swapToToken_not: Bytes
+  swapToToken_gt: Bytes
+  swapToToken_lt: Bytes
+  swapToToken_gte: Bytes
+  swapToToken_lte: Bytes
+  swapToToken_in: [Bytes!]
+  swapToToken_not_in: [Bytes!]
+  swapToToken_contains: Bytes
+  swapToToken_not_contains: Bytes
+  swapFromAmount: BigDecimal
+  swapFromAmount_not: BigDecimal
+  swapFromAmount_gt: BigDecimal
+  swapFromAmount_lt: BigDecimal
+  swapFromAmount_gte: BigDecimal
+  swapFromAmount_lte: BigDecimal
+  swapFromAmount_in: [BigDecimal!]
+  swapFromAmount_not_in: [BigDecimal!]
+  swapToAmount: BigDecimal
+  swapToAmount_not: BigDecimal
+  swapToAmount_gt: BigDecimal
+  swapToAmount_lt: BigDecimal
+  swapToAmount_gte: BigDecimal
+  swapToAmount_lte: BigDecimal
+  swapToAmount_in: [BigDecimal!]
+  swapToAmount_not_in: [BigDecimal!]
+  marketPrice: BigDecimal
+  marketPrice_not: BigDecimal
+  marketPrice_gt: BigDecimal
+  marketPrice_lt: BigDecimal
+  marketPrice_gte: BigDecimal
+  marketPrice_lte: BigDecimal
+  marketPrice_in: [BigDecimal!]
+  marketPrice_not_in: [BigDecimal!]
+  depositTransfers: [String!]
+  depositTransfers_not: [String!]
+  depositTransfers_contains: [String!]
+  depositTransfers_contains_nocase: [String!]
+  depositTransfers_not_contains: [String!]
+  depositTransfers_not_contains_nocase: [String!]
+  depositTransfers_: Transfer_filter
+  depositedUSD: BigDecimal
+  depositedUSD_not: BigDecimal
+  depositedUSD_gt: BigDecimal
+  depositedUSD_lt: BigDecimal
+  depositedUSD_gte: BigDecimal
+  depositedUSD_lte: BigDecimal
+  depositedUSD_in: [BigDecimal!]
+  depositedUSD_not_in: [BigDecimal!]
+  depositedInQuoteToken: BigDecimal
+  depositedInQuoteToken_not: BigDecimal
+  depositedInQuoteToken_gt: BigDecimal
+  depositedInQuoteToken_lt: BigDecimal
+  depositedInQuoteToken_gte: BigDecimal
+  depositedInQuoteToken_lte: BigDecimal
+  depositedInQuoteToken_in: [BigDecimal!]
+  depositedInQuoteToken_not_in: [BigDecimal!]
+  withdrawTransfers: [String!]
+  withdrawTransfers_not: [String!]
+  withdrawTransfers_contains: [String!]
+  withdrawTransfers_contains_nocase: [String!]
+  withdrawTransfers_not_contains: [String!]
+  withdrawTransfers_not_contains_nocase: [String!]
+  withdrawTransfers_: Transfer_filter
+  withdrawnUSD: BigDecimal
+  withdrawnUSD_not: BigDecimal
+  withdrawnUSD_gt: BigDecimal
+  withdrawnUSD_lt: BigDecimal
+  withdrawnUSD_gte: BigDecimal
+  withdrawnUSD_lte: BigDecimal
+  withdrawnUSD_in: [BigDecimal!]
+  withdrawnUSD_not_in: [BigDecimal!]
+  withdrawnInQuoteToken: BigDecimal
+  withdrawnInQuoteToken_not: BigDecimal
+  withdrawnInQuoteToken_gt: BigDecimal
+  withdrawnInQuoteToken_lt: BigDecimal
+  withdrawnInQuoteToken_gte: BigDecimal
+  withdrawnInQuoteToken_lte: BigDecimal
+  withdrawnInQuoteToken_in: [BigDecimal!]
+  withdrawnInQuoteToken_not_in: [BigDecimal!]
+  oasisFeeToken: Bytes
+  oasisFeeToken_not: Bytes
+  oasisFeeToken_gt: Bytes
+  oasisFeeToken_lt: Bytes
+  oasisFeeToken_gte: Bytes
+  oasisFeeToken_lte: Bytes
+  oasisFeeToken_in: [Bytes!]
+  oasisFeeToken_not_in: [Bytes!]
+  oasisFeeToken_contains: Bytes
+  oasisFeeToken_not_contains: Bytes
+  oasisFee: BigDecimal
+  oasisFee_not: BigDecimal
+  oasisFee_gt: BigDecimal
+  oasisFee_lt: BigDecimal
+  oasisFee_gte: BigDecimal
+  oasisFee_lte: BigDecimal
+  oasisFee_in: [BigDecimal!]
+  oasisFee_not_in: [BigDecimal!]
+  oasisFeeUSD: BigDecimal
+  oasisFeeUSD_not: BigDecimal
+  oasisFeeUSD_gt: BigDecimal
+  oasisFeeUSD_lt: BigDecimal
+  oasisFeeUSD_gte: BigDecimal
+  oasisFeeUSD_lte: BigDecimal
+  oasisFeeUSD_in: [BigDecimal!]
+  oasisFeeUSD_not_in: [BigDecimal!]
+  oasisFeeInQuoteToken: BigDecimal
+  oasisFeeInQuoteToken_not: BigDecimal
+  oasisFeeInQuoteToken_gt: BigDecimal
+  oasisFeeInQuoteToken_lt: BigDecimal
+  oasisFeeInQuoteToken_gte: BigDecimal
+  oasisFeeInQuoteToken_lte: BigDecimal
+  oasisFeeInQuoteToken_in: [BigDecimal!]
+  oasisFeeInQuoteToken_not_in: [BigDecimal!]
+  oasisFeeInCollateralToken: BigDecimal
+  oasisFeeInCollateralToken_not: BigDecimal
+  oasisFeeInCollateralToken_gt: BigDecimal
+  oasisFeeInCollateralToken_lt: BigDecimal
+  oasisFeeInCollateralToken_gte: BigDecimal
+  oasisFeeInCollateralToken_lte: BigDecimal
+  oasisFeeInCollateralToken_in: [BigDecimal!]
+  oasisFeeInCollateralToken_not_in: [BigDecimal!]
+  gasUsed: BigInt
+  gasUsed_not: BigInt
+  gasUsed_gt: BigInt
+  gasUsed_lt: BigInt
+  gasUsed_gte: BigInt
+  gasUsed_lte: BigInt
+  gasUsed_in: [BigInt!]
+  gasUsed_not_in: [BigInt!]
+  gasPrice: BigInt
+  gasPrice_not: BigInt
+  gasPrice_gt: BigInt
+  gasPrice_lt: BigInt
+  gasPrice_gte: BigInt
+  gasPrice_lte: BigInt
+  gasPrice_in: [BigInt!]
+  gasPrice_not_in: [BigInt!]
+  gasFeeUSD: BigDecimal
+  gasFeeUSD_not: BigDecimal
+  gasFeeUSD_gt: BigDecimal
+  gasFeeUSD_lt: BigDecimal
+  gasFeeUSD_gte: BigDecimal
+  gasFeeUSD_lte: BigDecimal
+  gasFeeUSD_in: [BigDecimal!]
+  gasFeeUSD_not_in: [BigDecimal!]
+  gasFeeInQuoteToken: BigDecimal
+  gasFeeInQuoteToken_not: BigDecimal
+  gasFeeInQuoteToken_gt: BigDecimal
+  gasFeeInQuoteToken_lt: BigDecimal
+  gasFeeInQuoteToken_gte: BigDecimal
+  gasFeeInQuoteToken_lte: BigDecimal
+  gasFeeInQuoteToken_in: [BigDecimal!]
+  gasFeeInQuoteToken_not_in: [BigDecimal!]
+  gasFeeInCollateralToken: BigDecimal
+  gasFeeInCollateralToken_not: BigDecimal
+  gasFeeInCollateralToken_gt: BigDecimal
+  gasFeeInCollateralToken_lt: BigDecimal
+  gasFeeInCollateralToken_gte: BigDecimal
+  gasFeeInCollateralToken_lte: BigDecimal
+  gasFeeInCollateralToken_in: [BigDecimal!]
+  gasFeeInCollateralToken_not_in: [BigDecimal!]
+  totalFee: BigDecimal
+  totalFee_not: BigDecimal
+  totalFee_gt: BigDecimal
+  totalFee_lt: BigDecimal
+  totalFee_gte: BigDecimal
+  totalFee_lte: BigDecimal
+  totalFee_in: [BigDecimal!]
+  totalFee_not_in: [BigDecimal!]
+  totalFeeInQuoteToken: BigDecimal
+  totalFeeInQuoteToken_not: BigDecimal
+  totalFeeInQuoteToken_gt: BigDecimal
+  totalFeeInQuoteToken_lt: BigDecimal
+  totalFeeInQuoteToken_gte: BigDecimal
+  totalFeeInQuoteToken_lte: BigDecimal
+  totalFeeInQuoteToken_in: [BigDecimal!]
+  totalFeeInQuoteToken_not_in: [BigDecimal!]
+  totalFeeInCollateralToken: BigDecimal
+  totalFeeInCollateralToken_not: BigDecimal
+  totalFeeInCollateralToken_gt: BigDecimal
+  totalFeeInCollateralToken_lt: BigDecimal
+  totalFeeInCollateralToken_gte: BigDecimal
+  totalFeeInCollateralToken_lte: BigDecimal
+  totalFeeInCollateralToken_in: [BigDecimal!]
+  totalFeeInCollateralToken_not_in: [BigDecimal!]
+  multipleBefore: BigDecimal
+  multipleBefore_not: BigDecimal
+  multipleBefore_gt: BigDecimal
+  multipleBefore_lt: BigDecimal
+  multipleBefore_gte: BigDecimal
+  multipleBefore_lte: BigDecimal
+  multipleBefore_in: [BigDecimal!]
+  multipleBefore_not_in: [BigDecimal!]
+  multipleAfter: BigDecimal
+  multipleAfter_not: BigDecimal
+  multipleAfter_gt: BigDecimal
+  multipleAfter_lt: BigDecimal
+  multipleAfter_gte: BigDecimal
+  multipleAfter_lte: BigDecimal
+  multipleAfter_in: [BigDecimal!]
+  multipleAfter_not_in: [BigDecimal!]
+  netValueBefore: BigDecimal
+  netValueBefore_not: BigDecimal
+  netValueBefore_gt: BigDecimal
+  netValueBefore_lt: BigDecimal
+  netValueBefore_gte: BigDecimal
+  netValueBefore_lte: BigDecimal
+  netValueBefore_in: [BigDecimal!]
+  netValueBefore_not_in: [BigDecimal!]
+  netValueAfter: BigDecimal
+  netValueAfter_not: BigDecimal
+  netValueAfter_gt: BigDecimal
+  netValueAfter_lt: BigDecimal
+  netValueAfter_gte: BigDecimal
+  netValueAfter_lte: BigDecimal
+  netValueAfter_in: [BigDecimal!]
+  netValueAfter_not_in: [BigDecimal!]
+  ltvBefore: BigDecimal
+  ltvBefore_not: BigDecimal
+  ltvBefore_gt: BigDecimal
+  ltvBefore_lt: BigDecimal
+  ltvBefore_gte: BigDecimal
+  ltvBefore_lte: BigDecimal
+  ltvBefore_in: [BigDecimal!]
+  ltvBefore_not_in: [BigDecimal!]
+  ltvAfter: BigDecimal
+  ltvAfter_not: BigDecimal
+  ltvAfter_gt: BigDecimal
+  ltvAfter_lt: BigDecimal
+  ltvAfter_gte: BigDecimal
+  ltvAfter_lte: BigDecimal
+  ltvAfter_in: [BigDecimal!]
+  ltvAfter_not_in: [BigDecimal!]
+  liquidationPriceBefore: BigDecimal
+  liquidationPriceBefore_not: BigDecimal
+  liquidationPriceBefore_gt: BigDecimal
+  liquidationPriceBefore_lt: BigDecimal
+  liquidationPriceBefore_gte: BigDecimal
+  liquidationPriceBefore_lte: BigDecimal
+  liquidationPriceBefore_in: [BigDecimal!]
+  liquidationPriceBefore_not_in: [BigDecimal!]
+  liquidationPriceAfter: BigDecimal
+  liquidationPriceAfter_not: BigDecimal
+  liquidationPriceAfter_gt: BigDecimal
+  liquidationPriceAfter_lt: BigDecimal
+  liquidationPriceAfter_gte: BigDecimal
+  liquidationPriceAfter_lte: BigDecimal
+  liquidationPriceAfter_in: [BigDecimal!]
+  liquidationPriceAfter_not_in: [BigDecimal!]
+  quoteTokensDelta: BigDecimal
+  quoteTokensDelta_not: BigDecimal
+  quoteTokensDelta_gt: BigDecimal
+  quoteTokensDelta_lt: BigDecimal
+  quoteTokensDelta_gte: BigDecimal
+  quoteTokensDelta_lte: BigDecimal
+  quoteTokensDelta_in: [BigDecimal!]
+  quoteTokensDelta_not_in: [BigDecimal!]
+  quoteTokensBefore: BigDecimal
+  quoteTokensBefore_not: BigDecimal
+  quoteTokensBefore_gt: BigDecimal
+  quoteTokensBefore_lt: BigDecimal
+  quoteTokensBefore_gte: BigDecimal
+  quoteTokensBefore_lte: BigDecimal
+  quoteTokensBefore_in: [BigDecimal!]
+  quoteTokensBefore_not_in: [BigDecimal!]
+  quoteTokensAfter: BigDecimal
+  quoteTokensAfter_not: BigDecimal
+  quoteTokensAfter_gt: BigDecimal
+  quoteTokensAfter_lt: BigDecimal
+  quoteTokensAfter_gte: BigDecimal
+  quoteTokensAfter_lte: BigDecimal
+  quoteTokensAfter_in: [BigDecimal!]
+  quoteTokensAfter_not_in: [BigDecimal!]
+  ethPrice: BigDecimal
+  ethPrice_not: BigDecimal
+  ethPrice_gt: BigDecimal
+  ethPrice_lt: BigDecimal
+  ethPrice_gte: BigDecimal
+  ethPrice_lte: BigDecimal
+  ethPrice_in: [BigDecimal!]
+  ethPrice_not_in: [BigDecimal!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  txHash: Bytes
+  txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
+  txHash_in: [Bytes!]
+  txHash_not_in: [Bytes!]
+  txHash_contains: Bytes
+  txHash_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [SummerEvent_filter]
+  or: [SummerEvent_filter]
+}
+
+enum SummerEvent_orderBy {
+  id
+  kind
+  account
+  account__id
+  account__address
+  account__vaultId
+  account__isDPM
+  account__protocol
+  account__positionType
+  account__collateralToken
+  account__debtToken
+  account__liquidationPrice
+  earnPosition
+  earnPosition__id
+  earnPosition__earnCumulativeDepositUSD
+  earnPosition__earnCumulativeDepositInQuoteToken
+  earnPosition__earnCumulativeDepositInCollateralToken
+  earnPosition__earnCumulativeWithdrawUSD
+  earnPosition__earnCumulativeWithdrawInQuoteToken
+  earnPosition__earnCumulativeWithdrawInCollateralToken
+  earnPosition__earnCumulativeFeesUSD
+  earnPosition__earnCumulativeFeesInQuoteToken
+  earnPosition__earnCumulativeFeesInCollateralToken
+  earnPosition__earnCumulativeQuoteTokenDeposit
+  earnPosition__earnCumulativeQuoteTokenWithdraw
+  borrowPosition
+  borrowPosition__id
+  borrowPosition__debt
+  borrowPosition__collateral
+  borrowPosition___debtBeforeSummerEvent
+  borrowPosition___collateralBeforeSummerEvent
+  borrowPosition__borrowCumulativeDepositUSD
+  borrowPosition__borrowCumulativeDepositInQuoteToken
+  borrowPosition__borrowCumulativeDepositInCollateralToken
+  borrowPosition__borrowCumulativeWithdrawUSD
+  borrowPosition__borrowCumulativeWithdrawInQuoteToken
+  borrowPosition__borrowCumulativeWithdrawInCollateralToken
+  borrowPosition__borrowCumulativeCollateralDeposit
+  borrowPosition__borrowCumulativeCollateralWithdraw
+  borrowPosition__borrowCumulativeDebtDeposit
+  borrowPosition__borrowCumulativeDebtWithdraw
+  borrowPosition__borrowCumulativeFeesUSD
+  borrowPosition__borrowCumulativeFeesInQuoteToken
+  borrowPosition__borrowCumulativeFeesInCollateralToken
+  market
+  market__id
+  market__oracle
+  market__interestModel
+  market__liquidataionLTV
+  market__liquidationRatio
+  market__lastUpdate
+  market__fee
+  isOpen
+  debtToken
+  debtToken__id
+  debtToken__address
+  debtToken__decimals
+  debtToken__precision
+  debtToken__symbol
+  debtAddress
+  debtBefore
+  debtAfter
+  debtDelta
+  debtTokenPriceUSD
+  collateralToken
+  collateralToken__id
+  collateralToken__address
+  collateralToken__decimals
+  collateralToken__precision
+  collateralToken__symbol
+  collateralAddress
+  collateralBefore
+  collateralAfter
+  collateralDelta
+  collateralTokenPriceUSD
+  debtOraclePrice
+  collateralOraclePrice
+  swapFromToken
+  swapToToken
+  swapFromAmount
+  swapToAmount
+  marketPrice
+  depositTransfers
+  depositedUSD
+  depositedInQuoteToken
+  withdrawTransfers
+  withdrawnUSD
+  withdrawnInQuoteToken
+  oasisFeeToken
+  oasisFee
+  oasisFeeUSD
+  oasisFeeInQuoteToken
+  oasisFeeInCollateralToken
+  gasUsed
+  gasPrice
+  gasFeeUSD
+  gasFeeInQuoteToken
+  gasFeeInCollateralToken
+  totalFee
+  totalFeeInQuoteToken
+  totalFeeInCollateralToken
+  multipleBefore
+  multipleAfter
+  netValueBefore
+  netValueAfter
+  ltvBefore
+  ltvAfter
+  liquidationPriceBefore
+  liquidationPriceAfter
+  quoteTokensDelta
+  quoteTokensBefore
+  quoteTokensAfter
+  ethPrice
+  timestamp
+  blockNumber
+  txHash
+}
+
+type Token {
+  id: Bytes!
+  address: Bytes!
+  decimals: BigInt!
+  precision: BigInt!
+  symbol: String!
+}
+
+input Token_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  decimals: BigInt
+  decimals_not: BigInt
+  decimals_gt: BigInt
+  decimals_lt: BigInt
+  decimals_gte: BigInt
+  decimals_lte: BigInt
+  decimals_in: [BigInt!]
+  decimals_not_in: [BigInt!]
+  precision: BigInt
+  precision_not: BigInt
+  precision_gt: BigInt
+  precision_lt: BigInt
+  precision_gte: BigInt
+  precision_lte: BigInt
+  precision_in: [BigInt!]
+  precision_not_in: [BigInt!]
+  symbol: String
+  symbol_not: String
+  symbol_gt: String
+  symbol_lt: String
+  symbol_gte: String
+  symbol_lte: String
+  symbol_in: [String!]
+  symbol_not_in: [String!]
+  symbol_contains: String
+  symbol_contains_nocase: String
+  symbol_not_contains: String
+  symbol_not_contains_nocase: String
+  symbol_starts_with: String
+  symbol_starts_with_nocase: String
+  symbol_not_starts_with: String
+  symbol_not_starts_with_nocase: String
+  symbol_ends_with: String
+  symbol_ends_with_nocase: String
+  symbol_not_ends_with: String
+  symbol_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Token_filter]
+  or: [Token_filter]
+}
+
+enum Token_orderBy {
+  id
+  address
+  decimals
+  precision
+  symbol
+}
+
+type Transfer {
+  id: Bytes!
+  event: SummerEvent!
+  from: Bytes!
+  to: Bytes!
+  token: Bytes!
+  amount: BigDecimal!
+  priceInUSD: BigDecimal!
+  amountUSD: BigDecimal!
+  txHash: String!
+}
+
+input Transfer_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  event: String
+  event_not: String
+  event_gt: String
+  event_lt: String
+  event_gte: String
+  event_lte: String
+  event_in: [String!]
+  event_not_in: [String!]
+  event_contains: String
+  event_contains_nocase: String
+  event_not_contains: String
+  event_not_contains_nocase: String
+  event_starts_with: String
+  event_starts_with_nocase: String
+  event_not_starts_with: String
+  event_not_starts_with_nocase: String
+  event_ends_with: String
+  event_ends_with_nocase: String
+  event_not_ends_with: String
+  event_not_ends_with_nocase: String
+  event_: SummerEvent_filter
+  from: Bytes
+  from_not: Bytes
+  from_gt: Bytes
+  from_lt: Bytes
+  from_gte: Bytes
+  from_lte: Bytes
+  from_in: [Bytes!]
+  from_not_in: [Bytes!]
+  from_contains: Bytes
+  from_not_contains: Bytes
+  to: Bytes
+  to_not: Bytes
+  to_gt: Bytes
+  to_lt: Bytes
+  to_gte: Bytes
+  to_lte: Bytes
+  to_in: [Bytes!]
+  to_not_in: [Bytes!]
+  to_contains: Bytes
+  to_not_contains: Bytes
+  token: Bytes
+  token_not: Bytes
+  token_gt: Bytes
+  token_lt: Bytes
+  token_gte: Bytes
+  token_lte: Bytes
+  token_in: [Bytes!]
+  token_not_in: [Bytes!]
+  token_contains: Bytes
+  token_not_contains: Bytes
+  amount: BigDecimal
+  amount_not: BigDecimal
+  amount_gt: BigDecimal
+  amount_lt: BigDecimal
+  amount_gte: BigDecimal
+  amount_lte: BigDecimal
+  amount_in: [BigDecimal!]
+  amount_not_in: [BigDecimal!]
+  priceInUSD: BigDecimal
+  priceInUSD_not: BigDecimal
+  priceInUSD_gt: BigDecimal
+  priceInUSD_lt: BigDecimal
+  priceInUSD_gte: BigDecimal
+  priceInUSD_lte: BigDecimal
+  priceInUSD_in: [BigDecimal!]
+  priceInUSD_not_in: [BigDecimal!]
+  amountUSD: BigDecimal
+  amountUSD_not: BigDecimal
+  amountUSD_gt: BigDecimal
+  amountUSD_lt: BigDecimal
+  amountUSD_gte: BigDecimal
+  amountUSD_lte: BigDecimal
+  amountUSD_in: [BigDecimal!]
+  amountUSD_not_in: [BigDecimal!]
+  txHash: String
+  txHash_not: String
+  txHash_gt: String
+  txHash_lt: String
+  txHash_gte: String
+  txHash_lte: String
+  txHash_in: [String!]
+  txHash_not_in: [String!]
+  txHash_contains: String
+  txHash_contains_nocase: String
+  txHash_not_contains: String
+  txHash_not_contains_nocase: String
+  txHash_starts_with: String
+  txHash_starts_with_nocase: String
+  txHash_not_starts_with: String
+  txHash_not_starts_with_nocase: String
+  txHash_ends_with: String
+  txHash_ends_with_nocase: String
+  txHash_not_ends_with: String
+  txHash_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Transfer_filter]
+  or: [Transfer_filter]
+}
+
+enum Transfer_orderBy {
+  id
+  event
+  event__id
+  event__kind
+  event__isOpen
+  event__debtAddress
+  event__debtBefore
+  event__debtAfter
+  event__debtDelta
+  event__debtTokenPriceUSD
+  event__collateralAddress
+  event__collateralBefore
+  event__collateralAfter
+  event__collateralDelta
+  event__collateralTokenPriceUSD
+  event__debtOraclePrice
+  event__collateralOraclePrice
+  event__swapFromToken
+  event__swapToToken
+  event__swapFromAmount
+  event__swapToAmount
+  event__marketPrice
+  event__depositedUSD
+  event__depositedInQuoteToken
+  event__withdrawnUSD
+  event__withdrawnInQuoteToken
+  event__oasisFeeToken
+  event__oasisFee
+  event__oasisFeeUSD
+  event__oasisFeeInQuoteToken
+  event__oasisFeeInCollateralToken
+  event__gasUsed
+  event__gasPrice
+  event__gasFeeUSD
+  event__gasFeeInQuoteToken
+  event__gasFeeInCollateralToken
+  event__totalFee
+  event__totalFeeInQuoteToken
+  event__totalFeeInCollateralToken
+  event__multipleBefore
+  event__multipleAfter
+  event__netValueBefore
+  event__netValueAfter
+  event__ltvBefore
+  event__ltvAfter
+  event__liquidationPriceBefore
+  event__liquidationPriceAfter
+  event__quoteTokensDelta
+  event__quoteTokensBefore
+  event__quoteTokensAfter
+  event__ethPrice
+  event__timestamp
+  event__blockNumber
+  event__txHash
+  from
+  to
+  token
+  amount
+  priceInUSD
+  amountUSD
+  txHash
+}
+
+type User {
+  id: Bytes!
+  address: Bytes!
+  vaultCount: BigInt!
+  proxies(skip: Int = 0, first: Int = 100, orderBy: Account_orderBy, orderDirection: OrderDirection, where: Account_filter): [Account!]
+  permittedProxies(skip: Int = 0, first: Int = 100, orderBy: Permission_orderBy, orderDirection: OrderDirection, where: Permission_filter): [Permission!]
+}
+
+input User_filter {
+  id: Bytes
+  id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
+  id_in: [Bytes!]
+  id_not_in: [Bytes!]
+  id_contains: Bytes
+  id_not_contains: Bytes
+  address: Bytes
+  address_not: Bytes
+  address_gt: Bytes
+  address_lt: Bytes
+  address_gte: Bytes
+  address_lte: Bytes
+  address_in: [Bytes!]
+  address_not_in: [Bytes!]
+  address_contains: Bytes
+  address_not_contains: Bytes
+  vaultCount: BigInt
+  vaultCount_not: BigInt
+  vaultCount_gt: BigInt
+  vaultCount_lt: BigInt
+  vaultCount_gte: BigInt
+  vaultCount_lte: BigInt
+  vaultCount_in: [BigInt!]
+  vaultCount_not_in: [BigInt!]
+  proxies_: Account_filter
+  permittedProxies_: Permission_filter
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [User_filter]
+  or: [User_filter]
+}
+
+enum User_orderBy {
+  id
+  address
+  vaultCount
+  proxies
+  permittedProxies
+}
+

--- a/packages/morpho-blue-subgraph/src/index.ts
+++ b/packages/morpho-blue-subgraph/src/index.ts
@@ -1,0 +1,80 @@
+import { request } from 'graphql-request'
+
+import { ChainId } from '@summerfi/serverless-shared'
+import type { Address } from '@summerfi/serverless-shared'
+import { Logger } from '@aws-lambda-powertools/logger'
+import { CollateralLockedDocument } from './types/graphql/generated'
+
+const chainIdSubgraphMap: Partial<Record<ChainId, string>> = {
+  [ChainId.MAINNET]: 'summer-morpho-blue',
+}
+
+const getEndpoint = (chainId: ChainId, baseUrl: string) => {
+  const subgraph = chainIdSubgraphMap[chainId]
+  if (!subgraph) {
+    throw new Error(`No subgraph for chainId ${chainId}`)
+  }
+  return `${baseUrl}/${subgraph}`
+}
+interface SubgraphClientConfig {
+  chainId: ChainId.MAINNET
+  urlBase: string
+  logger?: Logger
+}
+
+export interface GetCollateralLockedParams {
+  collaterals: { address: Address; decimals: number }[]
+  blockNumber: number
+}
+
+export interface CollateralLocked {
+  collateral: Address
+  amount: string
+  owner: Address
+}
+
+/**
+ * The key of the first record is the owner of the collaterals, second record is the collateral address
+ */
+export type CollateralLockedRecord = Record<Address, Record<Address, CollateralLocked>>
+
+export interface CollateralLockedResult {
+  lockedCollaterals: CollateralLocked[]
+}
+
+export type GetCollateralLocked = (
+  params: GetCollateralLockedParams,
+) => Promise<CollateralLockedResult>
+
+async function getCollateralLocked(
+  params: GetCollateralLockedParams,
+  config: SubgraphClientConfig,
+): Promise<CollateralLockedResult> {
+  const url = getEndpoint(config.chainId, config.urlBase)
+  const result = await request(url, CollateralLockedDocument, {
+    collateralAddresses: params.collaterals.map((c) => c.address),
+    block: params.blockNumber,
+  })
+
+  const mapped: CollateralLocked[] = result.borrowPositions.map((c) => ({
+    collateral: c.market.collateralToken?.address as Address,
+    amount: c.collateral.toString(),
+    owner: (c.account?.user.address ?? `0x0`) as Address,
+  }))
+
+  return {
+    lockedCollaterals: mapped,
+  }
+}
+
+export interface MorphoBlueSubgraphClient {
+  getCollateralLocked: GetCollateralLocked
+}
+
+export function getMorphoBlueSubgraphClient(
+  config: SubgraphClientConfig,
+): MorphoBlueSubgraphClient {
+  return {
+    getCollateralLocked: (params: GetCollateralLockedParams) => getCollateralLocked(params, config),
+  }
+}

--- a/packages/morpho-blue-subgraph/tsconfig.json
+++ b/packages/morpho-blue-subgraph/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@summerfi/typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/packages/typescript-config/tsconfig.base.json
+++ b/packages/typescript-config/tsconfig.base.json
@@ -31,6 +31,15 @@
     },
     {
       "path": "../automation-subgraph/tsconfig.json"
+    },
+    {
+      "path": "../aave-spark-subgraph/tsconfig.json"
+    },
+    {
+      "path": "../ajna-subgraph/tsconfig.json"
+    },
+    {
+      "path": "../morpho-blue-subgraph/tsconfig.json"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,105 @@ importers:
         specifier: ^7.2.3
         version: 7.2.3
 
+  external-api/get-collateral-locked-function:
+    dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@aws-lambda-powertools/metrics':
+        specifier: ^1.17.0
+        version: 1.18.1
+      '@aws-lambda-powertools/tracer':
+        specifier: ^1.17.0
+        version: 1.18.1
+      '@summerfi/aave-spark-subgraph':
+        specifier: workspace:*
+        version: link:../../packages/aave-spark-subgraph
+      '@summerfi/ajna-subgraph':
+        specifier: workspace:*
+        version: link:../../packages/ajna-subgraph
+      '@summerfi/morpho-blue-subgraph':
+        specifier: workspace:*
+        version: link:../../packages/morpho-blue-subgraph
+      '@summerfi/serverless-contracts':
+        specifier: workspace:*
+        version: link:../../packages/serverless-contracts
+      '@summerfi/serverless-shared':
+        specifier: workspace:*
+        version: link:../../packages/serverless-shared
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
+    devDependencies:
+      '@summerfi/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@summerfi/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^20.11.5
+        version: 20.11.5
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
+
+  packages/aave-spark-subgraph:
+    dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@summerfi/serverless-shared':
+        specifier: workspace:*
+        version: link:../serverless-shared
+      graphql-request:
+        specifier: ^6.1.0
+        version: 6.1.0(graphql@16.8.1)
+    devDependencies:
+      '@summerfi/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@summerfi/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^20.11.5
+        version: 20.11.5
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
+
+  packages/ajna-subgraph:
+    dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@summerfi/serverless-shared':
+        specifier: workspace:*
+        version: link:../serverless-shared
+      graphql-request:
+        specifier: ^6.1.0
+        version: 6.1.0(graphql@16.8.1)
+    devDependencies:
+      '@summerfi/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@summerfi/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^20.11.5
+        version: 20.11.5
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
+
   packages/automation-subgraph:
     dependencies:
       '@aws-lambda-powertools/logger':
@@ -336,6 +435,31 @@ importers:
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.24.0)(esbuild@0.19.11)(jest@29.7.0)(typescript@5.3.3)
+
+  packages/morpho-blue-subgraph:
+    dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@summerfi/serverless-shared':
+        specifier: workspace:*
+        version: link:../serverless-shared
+      graphql-request:
+        specifier: ^6.1.0
+        version: 6.1.0(graphql@16.8.1)
+    devDependencies:
+      '@summerfi/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@summerfi/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^20.11.5
+        version: 20.11.5
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
 
   packages/prices-subgraph:
     dependencies:
@@ -1143,10 +1267,6 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@aws-lambda-powertools/commons@1.17.0:
-    resolution: {integrity: sha512-eZbOUGKH+oNG49oObXucffTdUyj0XmQTnddgDWmSWLgAQ4/L60n7x80hYOTCmDqATxPoA4ADa+fzAxGx0hyaxQ==}
-    dev: false
-
   /@aws-lambda-powertools/commons@1.18.1:
     resolution: {integrity: sha512-gFRgQ2GJDghKvf+fXvT0kQVftgOT05W+hCa7RkfZj6HSjVAO+9DZZeJL3JK1HcsLAjWRj7W9ra0/MqB3Abf+PQ==}
     dev: false
@@ -1159,7 +1279,7 @@ packages:
       '@middy/core':
         optional: true
     dependencies:
-      '@aws-lambda-powertools/commons': 1.17.0
+      '@aws-lambda-powertools/commons': 1.18.1
       lodash.merge: 4.6.2
     dev: false
 
@@ -7987,6 +8107,10 @@ packages:
 
   /bignumber.js@9.0.1:
     resolution: {integrity: sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==}
+    dev: false
+
+  /bignumber.js@9.1.2:
+    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
     dev: false
 
   /binary-extensions@2.2.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,6 @@ packages:
   - 'apps/**'
   - 'sdk/**'
   - 'summerfi-api/**'
+  - 'external-api/**'
   - '!**/test/**'
   - '!**/.sst/**'

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,5 +1,6 @@
 import { SSTConfig } from 'sst'
 import { API } from './stacks/summer-stack'
+import { ExternalAPI } from './stacks/partners-stack'
 
 const availableStage = ['dev', 'feature', 'staging', 'production']
 
@@ -28,6 +29,7 @@ export const sstConfig: SSTConfig = {
       app.setDefaultRemovalPolicy('destroy')
     }
     app.stack(API)
+    app.stack(ExternalAPI)
   },
 }
 

--- a/stacks/partners-stack.ts
+++ b/stacks/partners-stack.ts
@@ -1,0 +1,37 @@
+import { Api, Function, StackContext } from 'sst/constructs'
+
+export function ExternalAPI(stackContext: StackContext) {
+  const { stack } = stackContext
+  const apiForPartners = new Api(stack, 'for-partners', {
+    defaults: {
+      function: {},
+    },
+    routes: {},
+  })
+
+  const { SUBGRAPH_BASE } = process.env
+  if (!SUBGRAPH_BASE) {
+    throw new Error('SUBGRAPH_BASE is required to deploy the triggers functions')
+  }
+
+  const getLockedWeEth = new Function(stack, 'get-locked-weeth', {
+    handler: 'external-api/get-collateral-locked-function/src/index.handler',
+    runtime: 'nodejs20.x',
+    environment: {
+      SUBGRAPH_BASE: SUBGRAPH_BASE,
+      POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',
+    },
+    tracing: 'active',
+    disableCloudWatchLogs: false,
+    applicationLogLevel: 'INFO',
+    systemLogLevel: 'INFO',
+  })
+
+  apiForPartners.addRoutes(stack, {
+    'GET /api/locked-weeth': getLockedWeEth,
+  })
+
+  stack.addOutputs({
+    PartnerApiEndpoint: apiForPartners.url,
+  })
+}


### PR DESCRIPTION
This commit adds a new function for obtaining locked collateral across all SummerFi positions (for Ajna, Morpho Blue, Aave & Spark). It is added to a new stack because we need to provide this function to our partner. Currently, it only returns data for `weETH` & `eETH`, but that could easily change in the future.