### PR TITLE
Update afterSwap and realizedProfitInCollateral calculation

### DIFF
--- a/summerfi-api/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
+++ b/summerfi-api/setup-trigger-function/src/services/simulations/auto-take-profit/calculate-next-profit.ts
@@ -112,18 +112,14 @@ export const calculateNextProfit = ({
       token: currentPosition.collateral.token,
     }
 
-    const afterSwap = calculateBalance(
-      toSwap,
-      currentPosition.debt.token,
-      currentPosition.collateralPriceInDebt,
-    )
+    const afterSwap = calculateBalance(toSwap, currentPosition.debt.token, executionPrice)
 
     const realizedProfitInDebt = subtractPercentage(afterSwap, SLIPPAGE)
 
     const realizedProfitInCollateral = calculateBalance(
       realizedProfitInDebt,
       currentPosition.collateral.token,
-      reversePrice(currentPosition.collateralPriceInDebt),
+      reversePrice(executionPrice),
     )
 
     const totalProfitInCollateral = {


### PR DESCRIPTION
The calculations of afterSwap and realizedProfitInCollateral are updated to use executionPrice instead of currentPosition.collateralPriceInDebt. This simplifies the calculations as well as provides a more accurate representation of the values.