### PR TITLE
fix: [sc-14766] [BUG] - With Trailing Stop-Loss ON it's not possible to set up Take Profit

### DIFF
--- a/summerfi-api/setup-trigger-function/src/index.ts
+++ b/summerfi-api/setup-trigger-function/src/index.ts
@@ -21,11 +21,9 @@ export const handler = async (
 ): Promise<APIGatewayProxyResultV2> => {
   const RPC_GATEWAY = process.env.RPC_GATEWAY
   const GET_TRIGGERS_URL = process.env.GET_TRIGGERS_URL
-  const SKIP_VALIDATION = process.env.SKIP_VALIDATION
   const SUBGRAPH_BASE = process.env.SUBGRAPH_BASE
 
   logger.addContext(context)
-  const skipValidation = SKIP_VALIDATION === 'true'
   if (!RPC_GATEWAY) {
     logger.error('RPC_GATEWAY is not set')
     return ResponseInternalServerError('RPC_GATEWAY is not set')
@@ -106,6 +104,8 @@ export const handler = async (
   )
 
   let validationWarnings: ValidationIssue[] = []
+
+  const skipValidation = event.headers['x-summer-skip-validation'] === '1'
 
   if (!skipValidation) {
     const validation = await validate({

--- a/summerfi-api/setup-trigger-function/src/services/against-position-validators/spark-partial-take-profit-validator.ts
+++ b/summerfi-api/setup-trigger-function/src/services/against-position-validators/spark-partial-take-profit-validator.ts
@@ -8,18 +8,17 @@ import {
   CommonErrorCodes,
   PartialTakeProfitErrorCodes,
 } from '~types'
-import {
-  getPropertyFromTriggerParams,
-  GetTriggersResponse,
-} from '@summerfi/serverless-contracts/get-triggers-response'
+import { GetTriggersResponse } from '@summerfi/serverless-contracts/get-triggers-response'
 import { z } from 'zod'
 import { chainIdSchema, safeParseBigInt } from '@summerfi/serverless-shared'
+import { CurrentStopLoss } from '../trigger-encoders'
 
 const paramsSchema = z.object({
   position: positionSchema,
   triggerData: sparkPartialTakeProfitTriggerDataSchema,
   triggers: z.custom<GetTriggersResponse>(),
   action: supportedActionsSchema,
+  currentStopLoss: z.custom<CurrentStopLoss | undefined>(),
   chainId: chainIdSchema,
 })
 
@@ -84,21 +83,12 @@ const upsertErrorsValidation = paramsSchema
     },
   )
   .refine(
-    ({ triggerData, triggers }) => {
+    ({ triggerData, currentStopLoss }) => {
       const updatedStopLossData = triggerData.stopLoss?.triggerData.executionLTV
-      const currentStopLoss = triggers.triggerGroup.sparkStopLoss
-      if (!currentStopLoss && !updatedStopLossData) return true
 
       const getStopLossLtv = updatedStopLossData
         ? updatedStopLossData
-        : currentStopLoss
-          ? safeParseBigInt(
-              getPropertyFromTriggerParams({
-                trigger: currentStopLoss,
-                property: 'executionLtv',
-              }),
-            ) ?? 99n
-          : 99n
+        : currentStopLoss?.executionLTV ?? 99_00n
 
       return triggerData.executionLTV + triggerData.withdrawStep < getStopLossLtv
     },

--- a/summerfi-api/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
+++ b/summerfi-api/setup-trigger-function/src/services/get-aave-partial-take-profit-service-container.ts
@@ -117,6 +117,8 @@ export const getAavePartialTakeProfitServiceContainer: (
 
       const triggers = await getTriggers(trigger.dpm)
 
+      const currentStopLoss = getCurrentAaveStopLoss(triggers, position, logger)
+
       const validationResults: ValidationResults[] = []
 
       if (trigger.triggerData.stopLoss) {
@@ -141,6 +143,7 @@ export const getAavePartialTakeProfitServiceContainer: (
           triggerData: trigger.triggerData,
           action: trigger.action,
           triggers,
+          currentStopLoss: currentStopLoss,
           chainId,
         }),
       )

--- a/summerfi-api/setup-trigger-function/src/services/get-spark-partial-take-profit-service-container.ts
+++ b/summerfi-api/setup-trigger-function/src/services/get-spark-partial-take-profit-service-container.ts
@@ -116,6 +116,8 @@ export const getSparkPartialTakeProfitServiceContainer: (
 
       const triggers = await getTriggers(trigger.dpm)
 
+      const currentStopLoss = getCurrentSparkStopLoss(triggers, position, logger)
+
       const validationResults: ValidationResults[] = []
 
       if (trigger.triggerData.stopLoss) {
@@ -139,6 +141,7 @@ export const getSparkPartialTakeProfitServiceContainer: (
           position,
           triggerData: trigger.triggerData,
           action: trigger.action,
+          currentStopLoss,
           triggers,
           chainId,
         }),


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14766

Refactored how `spark-partial-take-profit` and `aave-partial-take-profit` services obtain stop loss data, simplifying the logic. The services now include `currentStopLoss` directly instead of extracting it from `GetTriggersResponse`. Additionally, a header-based validation skipping method has been implemented in the main API setup.