### PR TITLE
Update '@oasisdex/dma-library' version in dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1095,8 +1095,8 @@ importers:
         specifier: 1.6.4-alpha.1
         version: 1.6.4-alpha.1
       '@oasisdex/dma-library':
-        specifier: 0.5.21-dma-v2-workers.27-auto-withdraw-to-ltv
-        version: 0.5.21-dma-v2-workers.27-auto-withdraw-to-ltv
+        specifier: 0.5.21-dma-v2-workers.31-auto-withdraw-to-ltv
+        version: 0.5.21-dma-v2-workers.31-auto-withdraw-to-ltv
       '@summerfi/prices-subgraph':
         specifier: workspace:*
         version: link:../../packages/prices-subgraph
@@ -5960,8 +5960,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@oasisdex/dma-library@0.5.21-dma-v2-workers.27-auto-withdraw-to-ltv:
-    resolution: {integrity: sha512-xzUfa8pTcJL0nXdXsQcvd4+RDWdULSF5Zym2Xpsm9L5rw/LsazfYbDD0x7PpdkCBmk89DRx9IaT/+/fqdI4mZA==}
+  /@oasisdex/dma-library@0.5.21-dma-v2-workers.31-auto-withdraw-to-ltv:
+    resolution: {integrity: sha512-OqcyWd2M9MMxR2uUEzNXfVN7Oh2tGs4FJ9trYhKMpRAaJrB1uZinCZOUurntmB2GqVFVbXeCvoMtdSgq/P5ESw==}
     dependencies:
       bignumber.js: 9.0.1
       ethers: 5.6.2

--- a/summerfi-api/setup-trigger-function/package.json
+++ b/summerfi-api/setup-trigger-function/package.json
@@ -14,7 +14,7 @@
     "@aws-lambda-powertools/metrics": "^1.17.0",
     "@aws-lambda-powertools/tracer": "^1.17.0",
     "@oasisdex/addresses": "0.1.16-dma-v2-workers.11",
-    "@oasisdex/dma-library": "0.5.21-dma-v2-workers.27-auto-withdraw-to-ltv",
+    "@oasisdex/dma-library": "0.5.21-dma-v2-workers.31-auto-withdraw-to-ltv",
     "@oasisdex/automation": "1.6.4-alpha.1",
     "@summerfi/serverless-contracts": "workspace:*",
     "@summerfi/serverless-shared": "workspace:*",


### PR DESCRIPTION
The version of '@oasisdex/dma-library' used in this project was updated from '0.5.21-dma-v2-workers.27-auto-withdraw-to-ltv' to '0.5.21-dma-v2-workers.31-auto-withdraw-to-ltv' in the pnpm-lock.yaml and setup-trigger-function/package.json files. This update reflects the anticipated changes and improvements in the newer version of the @oasisdex library.