### PR TITLE
fix: [sc-14865] [BUG] - SPARK MULTIPLY - SDAI/ETH - 3x automations cannot be set up

### DIFF
--- a/summerfi-api/setup-trigger-function/src/services/simulate-position.ts
+++ b/summerfi-api/setup-trigger-function/src/services/simulate-position.ts
@@ -91,10 +91,10 @@ export function simulatePosition(
 
   const collateralAmountAfterBuy = result.position.collateral.amount.isNaN()
     ? 0n
-    : BigInt(result.position.collateral.amount.abs().toString())
+    : BigInt(result.position.collateral.amount.abs().toFixed())
   const debtAmountAfterBuy = result.position.debt.amount.isNaN()
     ? 0n
-    : BigInt(result.position.debt.amount.toString())
+    : BigInt(result.position.debt.amount.toFixed())
   const calculatedTargetLTV = BigInt(
     result.position.riskRatio.loanToValue.times(10_000).integerValue().toNumber(),
   )


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14865

Switched from BigInt conversion of stringified amounts to rounding towards zero before conversion in simulate-position service, to maintain the accuracy of both collateral and debt amounts calculation. This change simplifies the calculation process and prevents potential errors associated with string conversion.
