### PR TITLE
feat: [sc-14928] [CI Task] Allow ConnectorTokens to be available through the 1inch API call

### DIFF
--- a/packages/serverless-shared/src/responses.ts
+++ b/packages/serverless-shared/src/responses.ts
@@ -55,3 +55,11 @@ export function ResponseInternalServerError(
     body: createErrorBody(message),
   }
 }
+
+export function ResponseForbidden(message: string = 'Forbidden'): APIGatewayProxyResultV2 {
+  return {
+    statusCode: 403,
+    headers: createHeaders(),
+    body: createErrorBody(message),
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1338,6 +1338,46 @@ importers:
         specifier: ^1.0.4
         version: 1.1.3
 
+  summerfi-api/swap-proxy-function:
+    dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^2.0.2
+        version: 2.0.2
+      '@aws-lambda-powertools/metrics':
+        specifier: ^2.0.2
+        version: 2.0.2
+      '@aws-lambda-powertools/tracer':
+        specifier: ^2.0.2
+        version: 2.0.2
+      '@summerfi/serverless-shared':
+        specifier: workspace:*
+        version: link:../../packages/serverless-shared
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
+      viem:
+        specifier: ^1.19.11
+        version: 1.21.4(typescript@5.3.3)(zod@3.22.4)
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
+    devDependencies:
+      '@summerfi/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@summerfi/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^20.11.5
+        version: 20.11.5
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.11.5)(ts-node@10.9.2)
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:

--- a/stacks/summer-stack.ts
+++ b/stacks/summer-stack.ts
@@ -4,6 +4,7 @@ import { addSdkConfig } from './sdk'
 import { addMigrationsConfig } from './migrations'
 import { addPortfolioConfig } from './portfolio'
 import { addMorpho } from './morpho'
+import { addSwap } from './swap'
 
 export function API(stackContext: StackContext) {
   const { stack } = stackContext
@@ -19,6 +20,7 @@ export function API(stackContext: StackContext) {
   addMigrationsConfig({ ...stackContext, api })
   addPortfolioConfig({ ...stackContext, api })
   addMorpho({ ...stackContext, api })
+  addSwap({ ...stackContext, api })
 
   stack.addOutputs({
     ApiEndpoint: api.url,

--- a/stacks/swap.ts
+++ b/stacks/swap.ts
@@ -1,0 +1,21 @@
+import { Api, Function, StackContext } from 'sst/constructs'
+
+export function addSwap({ stack, api }: StackContext & { api: Api }) {
+  const { ONE_INCH_API_URL } = process.env
+  if (!ONE_INCH_API_URL) {
+    throw new Error('ONE_INCH_API_URL is required to deploy the swap proxy functions')
+  }
+
+  const swapProxyFunction = new Function(stack, 'swap-proxy-function', {
+    handler: 'summerfi-api/swap-proxy-function/src/index.handler',
+    runtime: 'nodejs20.x',
+    environment: {
+      ONE_INCH_API_URL: ONE_INCH_API_URL,
+      POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',
+    },
+  })
+
+  api.addRoutes(stack, {
+    'GET /api/exchange/{proxy+}': swapProxyFunction,
+  })
+}

--- a/summerfi-api/swap-proxy-function/.eslintrc.cjs
+++ b/summerfi-api/swap-proxy-function/.eslintrc.cjs
@@ -1,0 +1,6 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ['@summerfi/eslint-config/function.cjs'],
+  parser: '@typescript-eslint/parser',
+}

--- a/summerfi-api/swap-proxy-function/jest.config.js
+++ b/summerfi-api/swap-proxy-function/jest.config.js
@@ -1,0 +1,15 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {},
+      },
+    ],
+  },
+}

--- a/summerfi-api/swap-proxy-function/package.json
+++ b/summerfi-api/swap-proxy-function/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@summerfi/swap-proxy-function",
+  "version": "0.0.1",
+  "scripts": {
+    "tsc": "tsc",
+    "watch": "tsc -w",
+    "test": "jest --passWithNoTests",
+    "build": "tsc -b -v",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.0.2",
+    "@aws-lambda-powertools/metrics": "^2.0.2",
+    "@aws-lambda-powertools/tracer": "^2.0.2",
+    "@summerfi/serverless-shared": "workspace:*",
+    "viem": "^1.19.11",
+    "zod": "^3.22.4",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@summerfi/eslint-config": "workspace:*",
+    "@summerfi/typescript-config": "workspace:*",
+    "@types/node": "^20.11.5",
+    "eslint": "^8.56.0",
+    "jest": "^29.7.0"
+  }
+}

--- a/summerfi-api/swap-proxy-function/src/index.ts
+++ b/summerfi-api/swap-proxy-function/src/index.ts
@@ -1,0 +1,56 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2, Context } from 'aws-lambda'
+import {
+  createHeaders,
+  ResponseForbidden,
+  ResponseInternalServerError,
+} from '@summerfi/serverless-shared'
+import { z } from 'zod'
+
+import { Logger } from '@aws-lambda-powertools/logger'
+
+const logger = new Logger({ serviceName: 'swap-proxy-function' })
+
+const pathParams = z.object({
+  proxy: z.string(),
+})
+
+export const handler = async (
+  event: APIGatewayProxyEventV2,
+  context: Context,
+): Promise<APIGatewayProxyResultV2> => {
+  const ONE_INCH_API_URL = process.env.ONE_INCH_API_URL
+
+  logger.addContext(context)
+  if (!ONE_INCH_API_URL) {
+    logger.error('ONE_INCH_API_URL is not set')
+    return ResponseInternalServerError('ONE_INCH_API_URL is not set')
+  }
+
+  const apiKey = event.headers['auth-key']
+
+  if (!apiKey) {
+    logger.warn('auth-key is not set')
+    return ResponseForbidden('auth-key is not set')
+  }
+
+  const { proxy } = pathParams.parse(event.pathParameters)
+
+  const query = new URLSearchParams()
+  Object.entries(event.queryStringParameters ?? {}).forEach(([key, value]) => {
+    if (value && key !== 'protocols') {
+      query.set(key, value)
+    }
+  })
+
+  const url = `${ONE_INCH_API_URL}/${proxy}${query.toString() ? `?${query.toString()}` : ''}`
+  const headers = { ['auth-key']: apiKey }
+  const response = await fetch(url, { headers })
+
+  return {
+    headers: createHeaders(),
+    statusCode: response.status,
+    body: await response.text(),
+  }
+}
+
+export default handler

--- a/summerfi-api/swap-proxy-function/tsconfig.json
+++ b/summerfi-api/swap-proxy-function/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@summerfi/typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14928

Introduced a new swap-proxy-function in the summerfi-api. This function includes an AWS api-gateway event handler and setup related codes, together with its relevant configurations. Updated the serverless-shared package by adding a forbidden response type. Integrated the new function into the summer-stack.