### PR TITLE
fix: fix reward apy calculations

### DIFF
--- a/summerfi-api/get-meta-morpho-details-function/package.json
+++ b/summerfi-api/get-meta-morpho-details-function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@summerfi/get-meta-morpho-details-function",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "tsc": "tsc",
     "watch": "tsc -w",

--- a/summerfi-api/get-meta-morpho-details-function/src/index.ts
+++ b/summerfi-api/get-meta-morpho-details-function/src/index.ts
@@ -202,8 +202,6 @@ export const handler = async (
     ? new BigNumber(params.amount.toString()).shiftedBy(-metaMorphoVault.asset.decimals)
     : new BigNumber(1000)
 
-  const depositedAmountPrice = depositedAmount.times(metaMorphoVault.asset.priceUsd ?? 1)
-
   const rewardsByMarket: RewardsByMarket[] = allocations
     .map((a): RewardsByMarket | undefined => {
       const rewardMarket = rewards.result.find((r) => r.market.marketId === a.market.marketId)
@@ -233,7 +231,7 @@ export const handler = async (
           const humanReadable = userRewards.shiftedBy(-r.token.decimals)
 
           const apy = rewardTokenPrice
-            ? humanReadable.times(rewardTokenPrice).div(depositedAmountPrice).toNumber()
+            ? humanReadable.times(rewardTokenPrice).div(depositedAmount).toNumber()
             : 0
 
           return {


### PR DESCRIPTION
- the rewards amount is calcualted based on `1000` user deposit
- hence we can calculate rewards apr by dividing the rewards value per 1000 deposit by 1000