### PR TITLE
feat: [sc-14958] CI/CD For monorepo

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,16 +1,16 @@
-name: 'Deploy Staging'
-concurrency: staging
+name: 'Deploy Production'
+concurrency: prod
 on:
   push:
     branches:
-      - dev
+      - main
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout
 jobs:
   deploy:
-    name: Build & Deploy staging using SST
-    environment: staging
+    name: Build & Deploy production using SST
+    environment: production
     runs-on: ubuntu-latest
     env:
       ONE_INCH_API_KEY: ${{ secrets.ONE_INCH_API_KEY }}
@@ -51,7 +51,6 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          # role-duration-seconds: 14390 #adjust as needed for your build time
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install dependencies
@@ -65,4 +64,4 @@ jobs:
 
       - name: Deploy app
         run: |
-          pnpm run sst:deploy:staging
+          pnpm run sst:deploy:prod


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/14958

A new GitHub Actions workflow for deploying the application to production is created. Besides pushing to the main branch, it contains job steps for cloning the repository, setting up dependencies, building and deploying the app. The same build and deployment process is added to the existing staging deployment workflow.
