### PR TITLE
Update merge-main.yaml to improve merge process

### DIFF
--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -25,11 +28,12 @@ jobs:
           git config user.name ${{ github.actor }}
 
       - name: Merge dev -> main
-        uses: pascalgn/merge-fast-forward-action@v1.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SUCCESS_MESSAGE: "Release merged successfully via fast-forward"
-          FAILURE_MESSAGE: "Failed to merge release via fast-forward"
-          UPDATE_STATUS: "true"
-          PRODUCTION_BRANCH: "main"
-          STAGING_BRANCH: "dev"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout main
+          git pull origin main
+          git checkout main
+          git merge --ff-only dev
+          git push origin main
+          git status


### PR DESCRIPTION
The merge-main.yaml file in the GitHub workflows directory has been updated to streamline the process of merging from 'dev' into 'main'. This includes fetching the 'dev' branch with no depth limit during the checkout process. Moreover, it explicitly outlines the individual steps of the git merge process replacing the fast-forward merge action previously used.