### PR TITLE
Add bash shell in merge-main workflow

### DIFF
--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           ref: dev
           fetch-depth: 0
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -28,8 +29,7 @@ jobs:
           git config user.name ${{ github.actor }}
 
       - name: Merge dev -> main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           git checkout main
           git pull origin main


### PR DESCRIPTION
The git merge operation in the "merge-main.yaml" GitHub Actions workflow was updated to explicitly declare the shell as bash. This change ensures that the workflow will run correctly, even in environments where bash is not the default shell.