### PR TITLE
Add JSON log format to functions

### DIFF
--- a/stacks/migrations.ts
+++ b/stacks/migrations.ts
@@ -9,6 +9,7 @@ export function addMigrationsConfig({ stack, api }: StackContext & { api: Api })
   const getMigrationsFunction = new Function(stack, 'get-migrations-function', {
     handler: 'summerfi-api/get-migrations-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       RPC_GATEWAY: RPC_GATEWAY,
       POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',

--- a/stacks/morpho.ts
+++ b/stacks/morpho.ts
@@ -9,6 +9,7 @@ export function addMorpho({ stack, api }: StackContext & { api: Api }) {
   const getMetaMorphoDetails = new Function(stack, 'get-meta-morpho-details-function', {
     handler: 'summerfi-api/get-meta-morpho-details-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       RPC_GATEWAY: RPC_GATEWAY,
       POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',
@@ -18,6 +19,7 @@ export function addMorpho({ stack, api }: StackContext & { api: Api }) {
   const morphoClaims = new Function(stack, 'get-morpho-claims-function', {
     handler: 'summerfi-api/get-morpho-claims-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       RPC_GATEWAY: RPC_GATEWAY,
       POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',

--- a/stacks/partners-stack.ts
+++ b/stacks/partners-stack.ts
@@ -17,6 +17,7 @@ export function ExternalAPI(stackContext: StackContext) {
   const getLockedWeEth = new Function(stack, 'get-locked-weeth', {
     handler: 'external-api/get-collateral-locked-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       SUBGRAPH_BASE: SUBGRAPH_BASE,
       POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',

--- a/stacks/portfolio.ts
+++ b/stacks/portfolio.ts
@@ -14,6 +14,7 @@ export function addPortfolioConfig({ stack, api }: StackContext & { api: Api }) 
   const getPortfolioAssetsFunction = new Function(stack, 'get-portfolio-assets-function', {
     handler: 'summerfi-api/portfolio-assets-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       POWERTOOLS_LOG_LEVEL: POWERTOOLS_LOG_LEVEL || 'INFO',
       DEBANK_API_KEY: DEBANK_API_KEY,
@@ -24,6 +25,7 @@ export function addPortfolioConfig({ stack, api }: StackContext & { api: Api }) 
   const getPortfolioOverviewFunction = new Function(stack, 'get-portfolio-overview-function', {
     handler: 'summerfi-api/portfolio-overview-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       POWERTOOLS_LOG_LEVEL: POWERTOOLS_LOG_LEVEL || 'INFO',
       DEBANK_API_KEY: DEBANK_API_KEY,

--- a/stacks/sdk.ts
+++ b/stacks/sdk.ts
@@ -1,4 +1,5 @@
-import { Api, StackContext, Function } from 'sst/constructs'
+import { Api, Function, StackContext } from 'sst/constructs'
+
 require('dotenv').config({ path: './sdk/.env' })
 
 const {
@@ -35,6 +36,7 @@ export function addSdkConfig({ stack, api }: StackContext & { api: Api }) {
   const sdkRouterFunction = new Function(stack, 'sdk-router-function', {
     handler: 'summerfi-api/sdk-router-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       POWERTOOLS_LOG_LEVEL,
       ONE_INCH_API_KEY,

--- a/stacks/triggers.ts
+++ b/stacks/triggers.ts
@@ -11,6 +11,7 @@ export function addTriggersConfig({ stack, api }: StackContext & { api: Api }) {
   const getTriggersFunction = new Function(stack, 'get-triggers-function', {
     handler: 'summerfi-api/get-triggers-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       SUBGRAPH_BASE: SUBGRAPH_BASE,
       RPC_GATEWAY: RPC_GATEWAY,
@@ -25,6 +26,7 @@ export function addTriggersConfig({ stack, api }: StackContext & { api: Api }) {
   const setupTriggerFunction = new Function(stack, 'setup-trigger-function', {
     handler: 'summerfi-api/setup-trigger-function/src/index.handler',
     runtime: 'nodejs20.x',
+    logFormat: 'JSON',
     environment: {
       RPC_GATEWAY: RPC_GATEWAY,
       SKIP_VALIDATION: process.env.SKIP_VALIDATION || 'false',


### PR DESCRIPTION
The log format for various functions across different stacks, including sdkRouterFunction, getLockedWeEth, getMetaMorphoDetails, morphoClaims, getTriggersFunction, setupTriggerFunction, getPortfolioAssetsFunction, getPortfolioOverviewFunction, and getMigrationsFunction, has been set as JSON. This change assists in better log readability and follows logging best practices.