### PR TITLE
Add Redis cache secrets to GitHub workflows

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -27,6 +27,9 @@ jobs:
       DEBANK_API_KEY: ${{ secrets.DEBANK_API_KEY }}
       DEBANK_API_URL: ${{ secrets.DEBANK_API_URL }}
       POWERTOOLS_LOG_LEVEL: ${{ vars.POWERTOOLS_LOG_LEVEL }}
+      REDIS_CACHE_URL: ${{ secrets.REDIS_CACHE_URL }}
+      REDIS_CACHE_USER: ${{ secrets.REDIS_CACHE_USER }}
+      REDIS_CACHE_PASSWORD: ${{ secrets.REDIS_CACHE_PASSWORD }}
 
     steps:
       - name: Git clone the repository

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -27,6 +27,9 @@ jobs:
       DEBANK_API_KEY: ${{ secrets.DEBANK_API_KEY }}
       DEBANK_API_URL: ${{ secrets.DEBANK_API_URL }}
       POWERTOOLS_LOG_LEVEL: ${{ vars.POWERTOOLS_LOG_LEVEL }}
+      REDIS_CACHE_URL: ${{ secrets.REDIS_CACHE_URL }}
+      REDIS_CACHE_USER: ${{ secrets.REDIS_CACHE_USER }}
+      REDIS_CACHE_PASSWORD: ${{ secrets.REDIS_CACHE_PASSWORD }}
 
     steps:
       - name: Git clone the repository


### PR DESCRIPTION
The commit adds the Redis cache URL, user, and password secrets to the environment variables in both the production and staging deploy scripts. This is needed to ensure smooth operation of the caching feature in the deploying processes.