### PR TITLE
Refactor APY calculation logic

### DIFF
--- a/packages/defi-llama-client/src/curated-yield-pools.ts
+++ b/packages/defi-llama-client/src/curated-yield-pools.ts
@@ -4,9 +4,10 @@ export const curatedYieldPools: { [key: string]: string } = {
   RETH: 'd4b3c522-6127-4b89-bedf-83641cdcd2eb', // project: 'rocket-pool'
   CBETH: '0f45d730-b279-4629-8e11-ccb5cc3038b4',
   SDAI: 'c8a24fee-ec00-4f38-86c0-9f6daebc4225', // it's `DAI` pool on DefiLlama
-  WEETH: '',
+  // WEETH: '',
   SUSDE: '66985a81-9c51-46ca-9977-42b4fe7bc6df',
-  EZETH: '',
+  // EZETH: '',
   OSETH: '4d01599c-69ae-41a3-bae1-5fab896f04c8',
   APXETH: 'acee1e4d-a73c-4e20-98f7-e87c13d446e4',
+  MEVETH: '5c96d741-3cdc-4f71-9f19-c808a76e401e',
 }

--- a/summerfi-api/get-apy-function/src/tokens-apy-service/index.ts
+++ b/summerfi-api/get-apy-function/src/tokens-apy-service/index.ts
@@ -65,34 +65,29 @@ export const getTokenApyService = ({
           return acc
         }, new Map<ShortDate, EnrichedPoolHistoryEntry[]>())
 
-      const perDay = Array.from(relevantData.entries()).map(([date, elements]) => {
-        const total = elements.reduce((acc, element) => acc + element.apy, 0)
-        const apy = total / elements.length
+      const perDay = Array.from(relevantData.entries())
+        .map(([date, elements]) => {
+          const total = elements.reduce((acc, element) => acc + element.apy, 0)
+          const apy = total / elements.length
 
-        return { date, apy, timestamp: getTimestamp(date) }
-      })
+          return { date, apy, timestamp: getTimestamp(date) }
+        })
+        .sort((a, b) => b.timestamp - a.timestamp)
 
       const timestamp7daysAgo = daysAgo(referenceDate, 7)
       const timestamp30daysAgo = daysAgo(referenceDate, 30)
       const timestamp90daysAgo = daysAgo(referenceDate, 90)
 
-      const apy7d =
-        perDay
-          .filter((entry) => entry.timestamp >= timestamp7daysAgo)
-          .reduce((acc, entry) => acc + entry.apy, 0) / 7
-      const apy30d =
-        perDay
-          .filter((entry) => entry.timestamp >= timestamp30daysAgo)
-          .reduce((acc, entry) => acc + entry.apy, 0) / 30
-      const apy90d =
-        perDay
-          .filter((entry) => entry.timestamp >= timestamp90daysAgo)
-          .reduce((acc, entry) => acc + entry.apy, 0) / 90
+      const elements7d = perDay.filter((entry) => entry.timestamp >= timestamp7daysAgo)
+      const elements30d = perDay.filter((entry) => entry.timestamp >= timestamp30daysAgo)
+      const elements90d = perDay.filter((entry) => entry.timestamp >= timestamp90daysAgo)
+
+      const apy7d = elements7d.reduce((acc, entry) => acc + entry.apy, 0) / elements7d.length
+      const apy30d = elements30d.reduce((acc, entry) => acc + entry.apy, 0) / elements30d.length
+      const apy90d = elements90d.reduce((acc, entry) => acc + entry.apy, 0) / elements90d.length
       const apy365d = perDay.reduce((acc, entry) => acc + entry.apy, 0) / perDay.length
 
-      const apy1d =
-        perDay.find((entry) => entry.timestamp === getTimestamp(getShortDate(referenceDate)))
-          ?.apy ?? 0
+      const apy1d = perDay[0].apy ?? 0
 
       return {
         token: { address, symbol },


### PR DESCRIPTION
The logic to calculate the Average Percentage Yield (APY) for each day, and for specific periods (i.e., 7, 30, 90, 365 days) has been refactored for optimization. APY calculation is now performed over actual data length, eliminating the division over fixed period values. The results are also systematically sorted by timestamp for consistent retrieval of data.