### PR TITLE
chore: [sc-15362] [API]  Return null when there is no data

### DIFF
--- a/summerfi-api/get-apy-function/src/contracts.ts
+++ b/summerfi-api/get-apy-function/src/contracts.ts
@@ -70,7 +70,7 @@ export type AaveLikePosition = z.infer<typeof aaveLikePositionSchema>
 export type MorphoBluePosition = z.infer<typeof morphoBluePositionSchema>
 export type AjnaPosition = z.infer<typeof ajnaPositionSchema>
 
-export type ApyResult = CalculateRates & { apy: number }
+export type ApyResult = CalculateRates & { apy?: number | null }
 
 export interface ApyResponse {
   position: AaveLikePosition | MorphoBluePosition | AjnaPosition

--- a/summerfi-api/get-apy-function/src/protocols/types.ts
+++ b/summerfi-api/get-apy-function/src/protocols/types.ts
@@ -38,9 +38,9 @@ export type GroupedRates = ReadonlyMap<ShortDate, Readonly<RatesWithAverage>>
 export interface CalculateRates {
   apy1d: number
   apy7d: number
-  apy30d: number
-  apy90d: number
-  apy365d: number
+  apy30d: number | null
+  apy90d: number | null
+  apy365d: number | null
 }
 
 export interface ProtocolResponse<TProtocolData> {


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/15362

Updated the logic for Annual Percentage Yield (APY) calculations in the `final-apy-calculation.ts` file to be more efficient, taking into account when there are no borrow or supply rates to avoid unnecessary calculations. Additionally, adjusted the response fetching from the AaveSparkSubgraph in the `get-unified-protocol-rates.ts` file to cache the responses separately for collateral and debt. Type definitions for rates have been updated in `protocols/types.ts` to allow null values.
