### PR TITLE
Add SECURITY_GROUP_ID and handle errors for missing env variables

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -31,6 +31,7 @@ jobs:
       REDIS_CACHE_USER: ${{ secrets.REDIS_CACHE_USER }}
       REDIS_CACHE_PASSWORD: ${{ secrets.REDIS_CACHE_PASSWORD }}
       VPC_ID: ${{ secrets.VPC_ID }}
+      SECURITY_GROUP_ID: ${{ secrets.SECURITY_GROUP_ID }}
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -31,6 +31,7 @@ jobs:
       REDIS_CACHE_USER: ${{ secrets.REDIS_CACHE_USER }}
       REDIS_CACHE_PASSWORD: ${{ secrets.REDIS_CACHE_PASSWORD }}
       VPC_ID: ${{ secrets.VPC_ID }}
+      SECURITY_GROUP_ID: ${{ secrets.SECURITY_GROUP_ID }}
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -121,7 +121,10 @@ export const sstConfig: SSTConfig = {
   stacks(app) {
     if (app.stage !== 'production' && app.stage !== 'staging') {
       app.setDefaultRemovalPolicy('destroy')
+    } else {
+      app.setDefaultRemovalPolicy('retain')
     }
+
     app.stack(API)
     app.stack(ExternalAPI)
   },

--- a/stacks/rays-db.ts
+++ b/stacks/rays-db.ts
@@ -15,8 +15,8 @@ export function addRaysDb({
   }
 
   if (!vpc) {
-    console.warn('VPC and VPC subnets are required for RDS. Please add them to the stack context')
-    return null
+    console.error('VPC and VPC subnets are required for RDS. Please add them to the stack context')
+    throw new Error('VPC and VPC subnets are required for RDS')
   }
 
   const scalingStaging = {

--- a/stacks/redis.ts
+++ b/stacks/redis.ts
@@ -14,8 +14,8 @@ export function addRedis({
   }
 
   if (!vpc) {
-    console.warn('VPC is required for Redis. Please add it to the stack context')
-    return null
+    console.error('VPC is required for Redis. Please add it to the stack context')
+    throw new Error('VPC is required for Redis')
   }
 
   const redis = new elasticache.CfnServerlessCache(stack, 'redis-cache', {

--- a/stacks/vpc.ts
+++ b/stacks/vpc.ts
@@ -13,11 +13,11 @@ export function attachVPC({ stack, isDev }: StackContext & { isDev: boolean }): 
 
   if (!VPC_ID || !SECURITY_GROUP_ID) {
     if (!isDev) {
-      console.warn(
+      console.error(
         'VPC_ID or SECURITY_GROUP_ID are not set, VPC will not be attached to the stack. This is only allowed in dev stages.',
       )
+      throw new Error('VPC_ID or SECURITY_GROUP_ID are not set')
     }
-    return null
   }
 
   const vpcSubnets = {


### PR DESCRIPTION
Added SECURITY_GROUP_ID to the GitHub Actions workflows for both staging and production environments. Changed the handling of missing environment variables from simple warning logs to throwing errors. Updated the default stack removal policy depending on the stage.