### PR TITLE
Update serverlessCacheName format in redis stack

### DIFF
--- a/stacks/redis.ts
+++ b/stacks/redis.ts
@@ -20,7 +20,7 @@ export function addRedis({
 
   const redis = new elasticache.CfnServerlessCache(stack, 'redis-cache', {
     engine: 'redis',
-    serverlessCacheName: `${stack.stage}-${stack.stackName}-stack-redis-cache`,
+    serverlessCacheName: `${stack.stage}-redis-cache`,
     majorEngineVersion: '7',
     securityGroupIds: [vpc.securityGroup.securityGroupId],
     subnetIds: vpc.vpc.selectSubnets(vpc.vpcSubnets).subnetIds,


### PR DESCRIPTION
Updated the `serverlessCacheName` property in redis.ts file to a simpler format. This was done to produce cleaner, more manageable identifiers for the Redis cache instances.