### PR TITLE
feat: [sc-15387] [API] Return user's points

### DIFF
--- a/packages/rays-db/src/database-types.ts
+++ b/packages/rays-db/src/database-types.ts
@@ -7,7 +7,7 @@ export type Generated<T> =
     ? ColumnType<S, I | undefined, U>
     : ColumnType<T, T | undefined, T>
 
-export type Json = ColumnType<JsonValue, string, string>
+export type Json = JsonValue
 
 export type JsonArray = JsonValue[]
 
@@ -15,73 +15,101 @@ export type JsonObject = {
   [K in string]?: JsonValue
 }
 
-export type JsonPrimitive = boolean | null | number | string
+export type JsonPrimitive = boolean | number | string | null
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive
+
+export type PositionType = 'Lend' | 'Supply'
 
 export type Protocol = 'AAVE_v2' | 'AAVE_v3' | 'Ajna' | 'ERC_4626' | 'MorphoBlue' | 'Spark'
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
 export interface EligibilityCondition {
-  id: Generated<number>
+  createdAt: Generated<Timestamp>
   description: string
   dueDate: Timestamp
-  type: string
-  createdAt: Generated<Timestamp>
+  id: Generated<number>
   metadata: Json
+  type: string
+}
+
+export interface Multiplier {
+  createdAt: Generated<Timestamp>
+  description: string | null
+  id: Generated<number>
+  type: string
+  value: number
 }
 
 export interface PointsDistribution {
+  createdAt: Generated<Timestamp>
+  description: string
+  eligibilityConditionId: number | null
   id: Generated<number>
   points: Generated<number>
-  description: string
-  type: string
-  createdAt: Generated<Timestamp>
   positionId: number
-  eligibilityConditionId: number | null
+  type: string
 }
 
 export interface Position {
-  id: Generated<number>
-  protocol: Protocol
-  chainId: number
-  market: string
   address: string
+  chainId: number
   createdAt: Generated<Timestamp>
+  id: Generated<number>
+  market: string
+  protocol: Protocol
   proxyId: number | null
+  type: Generated<PositionType>
   userAddressId: number
+}
+
+export interface PositionMultiplier {
+  createdAt: Generated<Timestamp>
+  id: Generated<number>
+  multiplierId: number
+  positionId: number
 }
 
 export interface Proxy {
-  id: Generated<number>
   address: string
   chainId: number
-  type: string
-  managedBy: string
-  userAddressId: number
   createdAt: Generated<Timestamp>
+  id: Generated<number>
+  managedBy: string
+  type: string
+  userAddressId: number
 }
 
 export interface User {
-  id: Generated<number>
   category: string | null
   createdAt: Generated<Timestamp>
+  id: Generated<number>
 }
 
 export interface UserAddress {
-  id: Generated<number>
   address: string
-  type: Generated<AddressType>
   createdAt: Generated<Timestamp>
+  id: Generated<number>
+  type: Generated<AddressType>
   userId: number
+}
+
+export interface UserAddressMultiplier {
+  createdAt: Generated<Timestamp>
+  id: Generated<number>
+  multiplierId: number
+  userAddressId: number
 }
 
 export interface Database {
   eligibilityCondition: EligibilityCondition
+  multiplier: Multiplier
   pointsDistribution: PointsDistribution
   position: Position
+  positionMultiplier: PositionMultiplier
   proxy: Proxy
   user: User
   userAddress: UserAddress
+  userAddressMultiplier: UserAddressMultiplier
 }

--- a/packages/rays-db/src/migrations/002_multipliers.mts
+++ b/packages/rays-db/src/migrations/002_multipliers.mts
@@ -1,0 +1,47 @@
+import { Kysely, sql } from 'kysely'
+
+/**
+ * @param db {Kysely<any>}
+ */
+export async function up(db: Kysely<never>) {
+  await db.schema.createType('position_type').asEnum(['Supply', 'Lend']).execute()
+
+  await db.schema.alterTable('position').addColumn('type', sql`position_type`, (col) => col.notNull().defaultTo('Lend')).execute()
+
+  await db.schema.createTable('multiplier')
+    .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn('value', 'integer', (col) => col.notNull())
+    .addColumn('type', 'varchar(100)', (col) => col.notNull())
+    .addColumn('description', 'varchar')
+    .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`NOW
+        ()`))
+    .execute()
+
+  await db.schema.createTable('position_multiplier')
+    .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn('position_id', 'integer', (col) => col.notNull().references('position.id').onDelete('restrict'))
+    .addColumn('multiplier_id', 'integer', (col) => col.notNull().references('multiplier.id').onDelete('restrict'))
+    .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`NOW
+        ()`))
+    .execute()
+
+  await db.schema.createTable('user_address_multiplier')
+    .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn('user_address_id', 'integer', (col) => col.notNull().references('user_address.id').onDelete('restrict'))
+    .addColumn('multiplier_id', 'integer', (col) => col.notNull().references('multiplier.id').onDelete('restrict'))
+    .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`NOW
+        ()`))
+    .execute()
+
+}
+
+/**
+ * @param db {Kysely<any>}
+ */
+export async function down(db: Kysely<never>) {
+  await db.schema.dropTable('user_multiplier').execute()
+  await db.schema.dropTable('position_multiplier').execute()
+  await db.schema.dropTable('multiplier').execute()
+  await db.schema.alterTable('position').dropColumn('type').execute()
+  await db.schema.dropType('position_type').execute()
+}

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -124,7 +124,7 @@ export const sstConfig: SSTConfig = {
     } else {
       app.setDefaultRemovalPolicy('retain')
     }
-
+    console.log(`\n`)
     app.stack(API)
     app.stack(ExternalAPI)
   },

--- a/stacks/rays-db.ts
+++ b/stacks/rays-db.ts
@@ -20,7 +20,7 @@ export function addRaysDb({
   }
 
   const scalingStaging = {
-    autoPause: true,
+    autoPause: 30, // auto pause after 30 minutes
     minCapacity: 'ACU_2' as const,
     maxCapacity: 'ACU_16' as const,
   }

--- a/stacks/redis.ts
+++ b/stacks/redis.ts
@@ -9,7 +9,7 @@ export function addRedis({
   isDev,
 }: Pick<SummerStackContext, 'stack' | 'vpc' | 'isDev'>): CacheContext | null {
   if (isDev) {
-    console.info('Redis is not attached in dev stages')
+    console.info('Redis is only created in staging and prod stages')
     return null
   }
 

--- a/summerfi-api/get-rays-function/src/index.ts
+++ b/summerfi-api/get-rays-function/src/index.ts
@@ -1,11 +1,35 @@
 import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2, Context } from 'aws-lambda'
-import { ResponseNotFound, ResponseOk } from '@summerfi/serverless-shared/responses'
+import { ResponseBadRequest, ResponseOk } from '@summerfi/serverless-shared/responses'
 import { Logger } from '@aws-lambda-powertools/logger'
 import { getRaysDB } from '@summerfi/rays-db'
 import { RDS } from 'sst/node/rds'
 import { RDSData } from '@aws-sdk/client-rds-data'
+import { addressSchema } from '@summerfi/serverless-shared'
+import { z } from 'zod'
 
 const logger = new Logger({ serviceName: 'get-rays-function' })
+
+export const queryParamsSchema = z.object({
+  address: addressSchema,
+})
+
+const groupBy = <T>(
+  array: Array<T>,
+  propertyKey: (element: T, index: number) => string | number,
+): Record<string | number, T[]> => {
+  return array.reduce(
+    (acc, element, currentIndex) => {
+      const key = propertyKey(element, currentIndex)
+
+      if (!acc[key]) {
+        acc[key] = []
+      }
+      acc[key].push(element)
+      return acc
+    },
+    {} as Record<string | number, T[]>,
+  )
+}
 
 export const handler = async (
   event: APIGatewayProxyEventV2,
@@ -13,9 +37,12 @@ export const handler = async (
 ): Promise<APIGatewayProxyResultV2> => {
   logger.addContext(context)
 
-  if (!event.queryStringParameters) {
-    return ResponseNotFound()
+  const parsedResult = queryParamsSchema.safeParse(event.queryStringParameters)
+  if (!parsedResult.success) {
+    return ResponseBadRequest({ body: { message: parsedResult.error.message } })
   }
+
+  const { address } = parsedResult.data
 
   const dbConfig =
     process.env.IS_LOCAL === 'true'
@@ -31,18 +58,83 @@ export const handler = async (
 
   const db = await getRaysDB(dbConfig)
 
-  const { address } =
-    'address' in event.queryStringParameters ? event.queryStringParameters : { address: '' }
-
-  const result = await db
+  const query = db
     .selectFrom('pointsDistribution')
+    .leftJoin(
+      'eligibilityCondition',
+      'pointsDistribution.eligibilityConditionId',
+      'eligibilityCondition.id',
+    )
     .innerJoin('position', 'pointsDistribution.positionId', 'position.id')
+    .leftJoin('positionMultiplier', 'position.id', 'positionMultiplier.positionId')
+    .leftJoin('multiplier as p_multiplier', 'positionMultiplier.multiplierId', 'p_multiplier.id')
     .innerJoin('userAddress', 'position.userAddressId', 'userAddress.id')
-    .where('userAddress.address', '=', address ?? '')
-    .select(['userAddress.address', 'pointsDistribution.points'])
-    .executeTakeFirst()
+    .leftJoin('userAddressMultiplier', 'userAddress.id', 'userAddressMultiplier.userAddressId')
+    .leftJoin(
+      'multiplier as user_multiplier',
+      'userAddressMultiplier.multiplierId',
+      'user_multiplier.id',
+    )
+    .where('userAddress.address', '=', address)
+    .select([
+      'userAddress.address',
+      'position.id as position_id',
+      'pointsDistribution.points',
+      'eligibilityCondition.dueDate',
+      'p_multiplier.value as position_multiplier',
+      'user_multiplier.value as user_multiplier',
+    ])
 
-  return ResponseOk({ body: { message: 'Hello World!', result: result } })
+  const results = await query.execute()
+
+  const userMultiplier =
+    results.find((result) => result.user_multiplier != null)?.user_multiplier ?? 1 // the value will be the same for all results
+
+  const byDueDate = groupBy(results, (result) => result.dueDate?.getTime() ?? 0)
+
+  const result = Object.entries(byDueDate).map(([dueDate, points]) => {
+    const notNullPoints = points ?? []
+    const perPosition = groupBy(notNullPoints, (result) => result.position_id)
+    const perPositionTotal = Object.entries(perPosition).map(([positionId, positionPoints]) => {
+      const notNullPositionPoints = positionPoints ?? []
+      const allPositionPoints = notNullPositionPoints.reduce(
+        (acc, result) => acc + result.points,
+        0,
+      )
+      const multiplier =
+        notNullPositionPoints.find((result) => result.position_multiplier != null)
+          ?.position_multiplier ?? 1 // the value will be the same for all results
+      return {
+        positionId,
+        positionPoints: allPositionPoints,
+        multiplier,
+        total: allPositionPoints * multiplier,
+      }
+    })
+
+    const totalPoints = perPositionTotal.reduce((acc, result) => acc + result.total, 0)
+    return {
+      dueDate: Number(dueDate),
+      totalPoints,
+      breakdowns: perPositionTotal,
+    }
+  })
+
+  const eligiblePoints = result.find((result) => result.dueDate === 0)?.totalPoints ?? 0
+  const multipliedPoints = eligiblePoints * userMultiplier
+  const allPossiblePoints =
+    result.reduce((acc, result) => acc + result.totalPoints, 0) * userMultiplier
+  const actionRequiredPoints = result.filter((result) => result.dueDate !== 0)
+
+  return ResponseOk({
+    body: {
+      address,
+      eligiblePoints,
+      multipliedPoints,
+      allPossiblePoints,
+      actionRequiredPoints,
+    },
+  })
 }
 
 export default handler


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/15387

This commit introduces the multiplier concept and associated tables in the database schema, including 'multiplier', 'position_multiplier', and 'user_multiplier'. Additionally, various column adjustments and type modifications have been made in the database-types file for better data management and enforcement of integrity constraints.

In the rays-db.ts file, the scalingStaging configuration was updated to have an auto pause of 30 minutes, from the previous setting of auto pausing when not in use. The change will ensure more efficient usage and management of the database resources.
The update introduces improved data parsing from the query parameters using zod schema validation. Additionally, there's significant refactoring in the data handling, groupings, and calculations related with point's distribution, eligibility conditions, and multipliers. Also, tsconfig.json in get-rays-function has been updated to allow esnext style of imports and lib.

