### PR TITLE
Update auto-sell validators for MorphoBlue and Spark protocols

### DIFF
--- a/summerfi-api/setup-trigger-function/src/services/against-position-validators/morphoblue-auto-sell-validator.ts
+++ b/summerfi-api/setup-trigger-function/src/services/against-position-validators/morphoblue-auto-sell-validator.ts
@@ -115,7 +115,7 @@ const upsertErrorsValidation = paramsSchema
     ({ triggers, action, triggerData }) => {
       if (action === SupportedActions.Remove || action === SupportedActions.Update)
         return (
-          triggers.triggers[`${ProtocolId.MORPHO_BLUE}-${triggerData.poolId}`].basicBuy !==
+          triggers.triggers[`${ProtocolId.MORPHO_BLUE}-${triggerData.poolId}`].basicSell !==
           undefined
         )
       return true

--- a/summerfi-api/setup-trigger-function/src/services/against-position-validators/spark-auto-sell-validator.ts
+++ b/summerfi-api/setup-trigger-function/src/services/against-position-validators/spark-auto-sell-validator.ts
@@ -110,7 +110,7 @@ const upsertErrorsValidation = paramsSchema
   .refine(
     ({ triggers, action }) => {
       if (action === SupportedActions.Remove || action === SupportedActions.Update)
-        return triggers.triggers[ProtocolId.SPARK].basicBuy !== undefined
+        return triggers.triggers[ProtocolId.SPARK].basicSell !== undefined
       return true
     },
     {


### PR DESCRIPTION
This pull request updates the auto-sell validators for the MorphoBlue and Spark protocols. The changes ensure that the basicSell property is checked instead of the basicBuy property in the upsertErrorsValidation function. This ensures that the correct validation is applied when removing or updating triggers.