### PR TITLE
Fix FE communication issue in getLendingPool input schema

### DIFF
--- a/sdk/sdk-server/src/handlers/getLendingPool.ts
+++ b/sdk/sdk-server/src/handlers/getLendingPool.ts
@@ -1,9 +1,13 @@
 import { publicProcedure } from '../TRPC'
-import { PoolIdSchema } from '@summerfi/sdk-common/protocols'
+import { LendingPoolIdSchema } from '@summerfi/sdk-common/protocols'
 import { z } from 'zod'
 
 export const getLendingPool = publicProcedure
-  .input(z.object({ poolId: PoolIdSchema.passthrough() }))
+  .input(
+    z.object({
+      poolId: LendingPoolIdSchema.catchall(z.any()),
+    }),
+  )
   .query(async (opts) => {
     return await opts.ctx.protocolManager.getLendingPool(opts.input.poolId)
   })

--- a/sdk/sdk-server/src/handlers/getLendingPool.ts
+++ b/sdk/sdk-server/src/handlers/getLendingPool.ts
@@ -3,7 +3,7 @@ import { PoolIdSchema } from '@summerfi/sdk-common/protocols'
 import { z } from 'zod'
 
 export const getLendingPool = publicProcedure
-  .input(z.object({ poolId: PoolIdSchema }))
+  .input(z.object({ poolId: PoolIdSchema.passthrough() }))
   .query(async (opts) => {
     return await opts.ctx.protocolManager.getLendingPool(opts.input.poolId)
   })


### PR DESCRIPTION
This pull request updates the `getLendingPool` input schema to use passthrough for `poolId`, fixing a communication issue with the front-end.