### PR TITLE
feat: add global coverage report

### DIFF
--- a/.github/workflows/build-integration-test.yaml
+++ b/.github/workflows/build-integration-test.yaml
@@ -53,3 +53,6 @@ jobs:
           ONE_INCH_ALLOWED_SWAP_PROTOCOLS: ${{ secrets.ONE_INCH_ALLOWED_SWAP_PROTOCOLS }}
           ONE_INCH_SWAP_CHAIN_IDS: ${{ secrets.ONE_INCH_SWAP_CHAIN_IDS }}
           MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+
+      - name: Coverage
+        run: pnpm coverage:total

--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -58,3 +58,6 @@ jobs:
 
       - name: Format
         run: pnpm format
+
+      - name: Coverage
+        run: pnpm coverage:total

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "turbo run test --cache-dir=.turbo",
     "test:integration": "turbo run test:integration --cache-dir=.turbo",
     "check-circular": "turbo run check-circular --cache-dir=.turbo",
-    "cicheck": "turbo run cicheck --cache-dir=.turbo",
+    "cicheck": "turbo run cicheck --cache-dir=.turbo && pnpm run coverage:total",
     "sst:dev": "sst dev",
     "sst:build": "sst build",
     "sst:deploy:dev": "sst deploy",
@@ -19,7 +19,8 @@
     "console": "sst console",
     "graph": "pnpm dlx nx graph",
     "format": "prettier --check \"./**/*.{ts,tsx,js,jsx,json}\"",
-    "format:fix": "prettier --write \"./**/*.{ts,tsx,js,jsx,json}\""
+    "format:fix": "prettier --write \"./**/*.{ts,tsx,js,jsx,json}\"",
+    "coverage:total": "node scripts/coverage-report/GenerateCoverageReport.js"
   },
   "devDependencies": {
     "@graphql-codegen/add": "^5.0.2",

--- a/packages/jest-config/jest.base.js
+++ b/packages/jest-config/jest.base.js
@@ -14,6 +14,7 @@ module.exports = (pkgCompilerOptions = {}) => {
     testTimeout: 10000,
     testEnvironment: 'node',
     moduleNameMapper: mappings,
+    coverageReporters: ['json-summary', 'text', 'lcov'],
     transformIgnorePatterns: ['<rootDir>/node_modules', 'node_modules'],
     transform: {
       '^.+\\.(ts|tsx)$': [

--- a/scripts/coverage-report/GenerateCoverageReport.js
+++ b/scripts/coverage-report/GenerateCoverageReport.js
@@ -1,3 +1,6 @@
+/**
+ * Code based on https://dev.to/musatov/improving-code-coverage-reporting-in-monorepos-115e
+ */
 const {
   getAllPathsForPackagesSummaries,
   readSummaryPerPackageAndCreateJoinedSummaryReportWithTotal,

--- a/scripts/coverage-report/GenerateCoverageReport.js
+++ b/scripts/coverage-report/GenerateCoverageReport.js
@@ -1,0 +1,17 @@
+const {
+  getAllPathsForPackagesSummaries,
+  readSummaryPerPackageAndCreateJoinedSummaryReportWithTotal,
+  createCoverageReportForVisualRepresentation,
+} = require('./Utils')
+
+// Execution Stages
+// 1. Read all coverage-total.json files
+const packagesSummaryPaths = getAllPathsForPackagesSummaries()
+// 2. Generate consolidated report
+const currCoverageReport =
+  readSummaryPerPackageAndCreateJoinedSummaryReportWithTotal(packagesSummaryPaths)
+// 3. Reformat the report for visual representation
+const coverageReportForVisualRepresentation =
+  createCoverageReportForVisualRepresentation(currCoverageReport)
+// 4. Print the report
+console.table(coverageReportForVisualRepresentation)

--- a/scripts/coverage-report/Utils.js
+++ b/scripts/coverage-report/Utils.js
@@ -74,6 +74,13 @@ function createCoverageReportForVisualRepresentation(coverageReport) {
   }
 
   return Object.keys(coverageReport).reduce((report, packageName) => {
+    if (
+      coverageReport[packageName] === undefined ||
+      Object.keys(coverageReport[packageName]).length === 0
+    ) {
+      return report
+    }
+
     const { lines, statements, functions, branches } = coverageReport[packageName]
 
     if (packageName === 'total') {

--- a/scripts/coverage-report/Utils.js
+++ b/scripts/coverage-report/Utils.js
@@ -1,0 +1,105 @@
+const fs = require('fs')
+const path = require('path')
+
+function getAllPathsForPackagesSummaries() {
+  const getDirectories = (source) =>
+    fs
+      .readdirSync(source, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name)
+
+  const appsPath = 'sdk'
+  const appsNames = getDirectories(appsPath)
+
+  const appsSummaries = appsNames.reduce((summary, appName) => {
+    return {
+      ...summary,
+      [appName]: path.join(appsPath, appName, 'coverage', 'coverage-summary.json'),
+    }
+  }, {})
+
+  const packagesPath = 'packages'
+  const packageNames = getDirectories(packagesPath)
+
+  const packagesSummaries = packageNames.reduce((summary, packageName) => {
+    return {
+      ...summary,
+      [packageName]: path.join(packagesPath, packageName, 'coverage', 'coverage-summary.json'),
+    }
+  }, {})
+
+  return { ...appsSummaries, ...packagesSummaries }
+}
+
+function readSummaryPerPackageAndCreateJoinedSummaryReportWithTotal(packagesSummaryPaths) {
+  return Object.keys(packagesSummaryPaths).reduce(
+    (summary, packageName) => {
+      const reportPath = packagesSummaryPaths[packageName]
+      if (fs.existsSync(reportPath)) {
+        const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+
+        const { total } = summary
+
+        Object.keys(report.total).forEach((key) => {
+          if (total[key]) {
+            total[key].total += report.total[key].total
+            total[key].covered += report.total[key].covered
+            total[key].skipped += report.total[key].skipped
+            total[key].pct = Number(((total[key].covered / total[key].total) * 100).toFixed(2))
+          } else {
+            total[key] = { ...report.total[key] }
+          }
+        })
+
+        return { [packageName]: report.total, ...summary, total }
+      }
+
+      return summary
+    },
+    { total: {} },
+  )
+}
+
+function createCoverageReportForVisualRepresentation(coverageReport) {
+  const separator = {
+    ['-------------']: {
+      'lines (%)': '-----',
+      'statements (%)': '-----',
+      'functions (%)': '-----',
+      'branches (%)': '-----',
+    },
+  }
+
+  return Object.keys(coverageReport).reduce((report, packageName) => {
+    const { lines, statements, functions, branches } = coverageReport[packageName]
+
+    if (packageName === 'total') {
+      return {
+        ...report,
+        ...separator,
+        ['TOTAL']: {
+          'lines (%)': lines.pct,
+          'statements (%)': statements.pct,
+          'functions (%)': functions.pct,
+          'branches (%)': branches.pct,
+        },
+      }
+    }
+
+    return {
+      ...report,
+      [packageName]: {
+        'lines (%)': lines.pct,
+        'statements (%)': statements.pct,
+        'functions (%)': functions.pct,
+        'branches (%)': branches.pct,
+      },
+    }
+  }, {})
+}
+
+module.exports = {
+  getAllPathsForPackagesSummaries,
+  readSummaryPerPackageAndCreateJoinedSummaryReportWithTotal,
+  createCoverageReportForVisualRepresentation,
+}

--- a/scripts/coverage-report/Utils.js
+++ b/scripts/coverage-report/Utils.js
@@ -1,3 +1,6 @@
+/**
+ * Code based on https://dev.to/musatov/improving-code-coverage-reporting-in-monorepos-115e
+ */
 const fs = require('fs')
 const path = require('path')
 

--- a/sdk/protocol-manager-common/package.json
+++ b/sdk/protocol-manager-common/package.json
@@ -12,8 +12,6 @@
   "scripts": {
     "tsc": "tsc",
     "watch": "tsc -w",
-    "test": "jest --coverage=true --passWithNoTests",
-    "testw": "jest --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "tsc -b -v tsconfig.build.json",

--- a/turbo.json
+++ b/turbo.json
@@ -80,11 +80,15 @@
         "test:integration",
         "lint",
         "check-circular",
-        "format"
+        "format",
+        "coverage:total"
       ]
     },
     "deploy:staging": {
       "dependsOn": ["cicheck", "^deploy:staging"]
+    },
+    "coverage:total": {
+      "dependsOn": ["test", "test:integration", "^coverage:total"]
     }
   }
 }


### PR DESCRIPTION
Added a script to show global coverage from Jest when cicheck is run. This is an intermediate step to enable showing the coverage on the PR itself. For now it is shown in the command line for the developer to be aware of it