### PR TITLE
feat: [sc-15556] Cleanup & Load AuroraDB

### DIFF
--- a/packages/rays-db/src/database-types.ts
+++ b/packages/rays-db/src/database-types.ts
@@ -19,6 +19,8 @@ export type JsonPrimitive = boolean | number | string | null
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive
 
+export type Numeric = ColumnType<string, number | string, number | string>
+
 export type PositionType = 'Lend' | 'Supply'
 
 export type Protocol = 'AAVE_v2' | 'AAVE_v3' | 'Ajna' | 'ERC_4626' | 'MorphoBlue' | 'Spark'
@@ -58,7 +60,7 @@ export interface PointsDistribution {
   description: string
   eligibilityConditionId: number | null
   id: Generated<number>
-  points: Generated<number>
+  points: Generated<Numeric>
   positionId: number | null
   type: string
   updatedAt: Generated<Timestamp>

--- a/packages/rays-db/src/migrations/001_init.mts
+++ b/packages/rays-db/src/migrations/001_init.mts
@@ -134,7 +134,7 @@ export async function up(db: Kysely<never>) {
   await db.schema
     .createTable('points_distribution')
     .addColumn('id', 'serial', (col) => col.primaryKey())
-    .addColumn('points', 'integer', (col) => col.notNull().defaultTo(0))
+    .addColumn('points', 'decimal(20, 10)', (col) => col.notNull().defaultTo(0))
     .addColumn('description', 'varchar', (col) => col.notNull())
     .addColumn('type', 'varchar(100)', (col) => col.notNull())
     .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`NOW

--- a/stacks/apy.ts
+++ b/stacks/apy.ts
@@ -28,7 +28,9 @@ export function addApyConfig({ stack, api, vpc, cache }: SummerStackContext) {
         runtime: 'nodejs20.x',
         environment,
         vpc: vpc.vpc,
-        vpcSubnets: vpc.vpcSubnets,
+        vpcSubnets: {
+          subnets: [...vpc.vpc.privateSubnets],
+        },
         securityGroups: [vpc.securityGroup],
       }
     : {

--- a/stacks/local-env/docker-compose.yaml
+++ b/stacks/local-env/docker-compose.yaml
@@ -2,7 +2,7 @@ name: summerfi-api-local
 
 services:
   rays-db:
-    image: postgres:16.1
+    image: postgres:13.9
     environment:
       POSTGRES_DB: rays
       POSTGRES_USER: user
@@ -17,7 +17,7 @@ services:
     ports:
       - "5500:5432"
     volumes:
-      - rays-db-data:/var/lib/postgresql/data
+      - rays-db-pg-v13-9-data:/var/lib/postgresql/data
   redis-cache:
     image: redis:7.2.4
     restart: always
@@ -30,9 +30,9 @@ services:
     ports:
       - "5501:6379"
     volumes:
-      - redis-cache-data:/data
+      - redis-cache-v7-data:/data
 volumes:
-  rays-db-data:
+  rays-db-pg-v13-9-data:
     driver: local
-  redis-cache-data:
+  redis-cache-v7-data:
     driver: local

--- a/stacks/rays-db.ts
+++ b/stacks/rays-db.ts
@@ -54,7 +54,9 @@ export function addRaysDb({
     cdk: {
       cluster: {
         vpc: vpc.vpc,
-        vpcSubnets: vpc.vpcSubnets,
+        vpcSubnets: {
+          subnets: [...vpc.vpc.privateSubnets, ...vpc.vpc.publicSubnets],
+        },
       },
     },
   })

--- a/stacks/rays.ts
+++ b/stacks/rays.ts
@@ -11,7 +11,9 @@ export function addRaysConfig({ stack, api, db, vpc }: SummerStackContext & { db
           POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',
         },
         vpc: vpc.vpc,
-        vpcSubnets: vpc.vpcSubnets,
+        vpcSubnets: {
+          subnets: [...vpc.vpc.privateSubnets],
+        },
       })
     : new Function(stack, 'get-rays-function', {
         handler: 'summerfi-api/get-rays-function/src/index.handler',

--- a/stacks/redis.ts
+++ b/stacks/redis.ts
@@ -23,7 +23,7 @@ export function addRedis({
     serverlessCacheName: `${stack.stage}-redis-cache`,
     majorEngineVersion: '7',
     securityGroupIds: [vpc.securityGroup.securityGroupId],
-    subnetIds: vpc.vpc.selectSubnets(vpc.vpcSubnets).subnetIds,
+    subnetIds: vpc.vpc.privateSubnets.map((subnet) => subnet.subnetId),
   })
 
   redis.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN)

--- a/stacks/summer-stack-context.ts
+++ b/stacks/summer-stack-context.ts
@@ -12,7 +12,6 @@ export type CacheContext = {
 export interface VPCContext {
   vpc: ec2.IVpc
   securityGroup: ec2.ISecurityGroup
-  vpcSubnets: ec2.SubnetSelection
 }
 
 export type SummerStackContext = StackContext & {

--- a/stacks/vpc.ts
+++ b/stacks/vpc.ts
@@ -20,14 +20,10 @@ export function attachVPC({ stack, isDev }: StackContext & { isDev: boolean }): 
     }
   }
 
-  const vpcSubnets = {
-    subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-  }
-
   const vpc = ec2.Vpc.fromLookup(stack, 'VPC', {
     vpcId: VPC_ID,
   })
 
   const securityGroup = ec2.SecurityGroup.fromSecurityGroupId(stack, 'SG', SECURITY_GROUP_ID!)
-  return { vpc, vpcSubnets, securityGroup }
+  return { vpc, securityGroup }
 }

--- a/summerfi-api/get-rays-function/src/index.ts
+++ b/summerfi-api/get-rays-function/src/index.ts
@@ -101,7 +101,7 @@ export const handler = async (
   )
 
   const result = Object.entries(byDueDate).map(([dueDate, points]) => {
-    const total = points.reduce((acc, result) => acc + result.points, 0)
+    const total = points.reduce((acc, result) => acc + Number(result.points), 0)
     const [timestamp, type] = dueDate.split('-')
     return {
       dueDate: Number(timestamp) === 0 ? null : new Date(Number(timestamp)),
@@ -111,7 +111,7 @@ export const handler = async (
   })
 
   const eligiblePoints = result.find((result) => result.dueDate === null)?.points ?? 0
-  const allPossiblePoints = result.reduce((acc, result) => acc + result.points, 0)
+  const allPossiblePoints = result.reduce((acc, result) => acc + Number(result.points), 0)
   const actionRequiredPoints = result.filter((result) => result.dueDate !== null)
 
   return ResponseOk({


### PR DESCRIPTION
Story details: https://app.shortcut.com/oazo-apps/story/15556

The PostgreSQL version in the local docker configuration has been downgraded from 16.1 to 13.9. Adjustments have also been made to the VPC subnet settings in various files, changing from using a predefined vpcSubnets variable to directly using private or both private and public subnets from the vpc object. Additionally, the 'points' column type in the 'points_distribution' table has been changed to decimal to accommodate non-integer values.
