### PR TITLE
Remove quote and collateral decimals from trigger encoders

### DIFF
--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-auto-buy.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-auto-buy.ts
@@ -7,7 +7,7 @@ import {
 } from 'viem'
 import { automationBotAbi } from '@summerfi/abis'
 import { MorphoBlueAutoBuyTriggerData } from '~types'
-import { maxUnit256, PositionLike, CurrentTriggerLike } from '@summerfi/triggers-shared'
+import { CurrentTriggerLike, maxUnit256, PositionLike } from '@summerfi/triggers-shared'
 
 import { DEFAULT_DEVIATION } from './defaults'
 import { TriggerTransactions } from './types'
@@ -29,8 +29,8 @@ export const encodeMorphoBlueAutoBuy = (
       'bytes32 operationName, ' +
       // Trigger specific data
       'bytes32 poolId, ' +
-      'uint8 quoteDecimals, ' +
-      'uint8 collateralDecimals, ' +
+      'uint8 quoteDecimals, ' + // The field is not used. It's here because the trigger wasn't redeployed.
+      'uint8 collateralDecimals, ' + // The field is not used. It's here because the trigger wasn't redeployed.
       'uint256 executionLtv, ' +
       'uint256 targetLTV, ' +
       'uint256 maxBuyPrice, ' +

--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-auto-sell.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-auto-sell.ts
@@ -10,7 +10,7 @@ import { OPERATION_NAMES } from '@oasisdex/dma-library'
 import { DEFAULT_DEVIATION } from './defaults'
 import { automationBotAbi } from '@summerfi/abis'
 import { MorphoBlueAutoSellTriggerData } from '~types'
-import { PositionLike, CurrentTriggerLike } from '@summerfi/triggers-shared'
+import { CurrentTriggerLike, PositionLike } from '@summerfi/triggers-shared'
 
 import { getMaxCoverage } from './get-max-coverage'
 
@@ -29,8 +29,6 @@ export const encodeMorphoBlueAutoSell = (
       'bytes32 operationName, ' +
       // Trigger specific data
       'bytes32 poolId, ' +
-      'uint8 quoteDecimals, ' +
-      'uint8 collateralDecimals, ' +
       'uint256 executionLtv, ' +
       'uint256 targetLTV, ' +
       'uint256 minSellPrice, ' +
@@ -53,8 +51,6 @@ export const encodeMorphoBlueAutoSell = (
     operationNameInBytes,
     // Trigger specific data
     triggerData.poolId,
-    position.debt.token.decimals,
-    position.collateral.token.decimals,
     triggerData.executionLTV,
     triggerData.targetLTV,
     triggerData.minSellPrice ?? 0n,

--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-partial-take-profit.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-partial-take-profit.ts
@@ -1,6 +1,6 @@
 import { bytesToHex, encodeAbiParameters, parseAbiParameters, stringToBytes } from 'viem'
 import { MorphoBluePartialTakeProfitTriggerData } from '~types'
-import { PositionLike, CurrentTriggerLike } from '@summerfi/triggers-shared'
+import { CurrentTriggerLike, PositionLike } from '@summerfi/triggers-shared'
 import { DEFAULT_DEVIATION } from './defaults'
 import { EncodedTriggers } from './types'
 import { OPERATION_NAMES } from '@oasisdex/dma-library'
@@ -22,8 +22,6 @@ export const encodeMorphoBluePartialTakeProfit = (
       'bytes32 operationName, ' +
       // Trigger specific data
       'bytes32 poolId, ' +
-      'uint8 quoteDecimals, ' +
-      'uint8 collateralDecimals, ' +
       'uint256 executionLtv, ' +
       'uint256 targetLtv, ' +
       'uint256 excutionPrice, ' +
@@ -50,8 +48,6 @@ export const encodeMorphoBluePartialTakeProfit = (
     operationNameInBytes,
     // Trigger specific data
     triggerData.poolId,
-    position.debt.token.decimals,
-    position.collateral.token.decimals,
     triggerData.executionLTV,
     triggerData.executionLTV + triggerData.withdrawStep,
     triggerData.executionPrice,

--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-stop-loss.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-stop-loss.ts
@@ -8,7 +8,7 @@ import {
 } from 'viem'
 import { automationBotAbi } from '@summerfi/abis'
 import { DmaMorphoBlueStopLossTriggerData } from '~types'
-import { PositionLike, CurrentTriggerLike } from '@summerfi/triggers-shared'
+import { CurrentTriggerLike, PositionLike } from '@summerfi/triggers-shared'
 
 import { getMaxCoverage } from './get-max-coverage'
 import { OPERATION_NAMES } from '@oasisdex/dma-library'
@@ -29,8 +29,6 @@ export const encodeMorphoBlueStopLoss = (
       'bytes32 operationName, ' +
       // Trigger specific data
       'bytes32 poolId, ' +
-      'uint8 quoteDecimals, ' +
-      'uint8 collateralDecimals, ' +
       'uint256 executionLtv, ' +
       'bool closeToCollateral',
   )
@@ -58,8 +56,6 @@ export const encodeMorphoBlueStopLoss = (
     operationNameInBytes,
     // Trigger specific data
     triggerData.poolId,
-    position.debt.token.decimals,
-    position.collateral.token.decimals,
     triggerData.executionLTV,
     triggerData.token === position.collateral.token.address,
   ])

--- a/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-trailing-stop-loss.ts
+++ b/summerfi-api/setup-trigger-function/src/services/trigger-encoders/encode-morphoblue-trailing-stop-loss.ts
@@ -8,7 +8,7 @@ import {
 } from 'viem'
 import { automationBotAbi } from '@summerfi/abis'
 import { DmaMorphoBlueTrailingStopLossTriggerData } from '~types'
-import { PositionLike, CurrentTriggerLike } from '@summerfi/triggers-shared'
+import { CurrentTriggerLike, PositionLike } from '@summerfi/triggers-shared'
 
 import { DerivedPrices } from '@summerfi/prices-subgraph'
 import { getMaxCoverage } from './get-max-coverage'
@@ -31,8 +31,6 @@ export const encodeMorphoBlueTrailingStopLoss = (
       'bytes32 operationName, ' +
       // Trigger specific data
       'bytes32 poolId, ' +
-      'uint8 quoteDecimals, ' +
-      'uint8 collateralDecimals, ' +
       'address collateralOracle, ' +
       'uint80 collateralAddedRoundId, ' +
       'address debtOracle, ' +
@@ -60,8 +58,6 @@ export const encodeMorphoBlueTrailingStopLoss = (
     operationNameInBytes,
     // Trigger specific data
     triggerData.poolId,
-    position.debt.token.decimals,
-    position.collateral.token.decimals,
     latestPrice.token.oraclesToken[0].address ?? '0x0',
     latestPrice.tokenRoundId,
     latestPrice.denomination.oraclesToken[0].address ?? '0x0',


### PR DESCRIPTION
The quote and collateral decimal values were removed from the trigger encoders for morphoblue stop loss, auto-sell, trailing stop loss, and partial take profit. This cleanup effort is a part of code optimization and to reduce redundancy, as these values are now calculated and handled elsewhere.