### PR TITLE
feat: Group and chunk user points for efficient processing

### DIFF
--- a/background-jobs/update-rays-cron-function/src/point-accrual.ts
+++ b/background-jobs/update-rays-cron-function/src/point-accrual.ts
@@ -9,7 +9,27 @@ import {
   UsersData,
 } from '@summerfi/summer-events-subgraph'
 import { Logger } from '@aws-lambda-powertools/logger'
-
+export type PositionPointsItem = {
+  positionId: string
+  vaultId: number
+  user: string
+  protocol: string
+  marketId: string
+  positionCreated: number
+  points: {
+    openPositionsPoints: number
+    migrationPoints: number
+    swapPoints: number
+  }
+  netValue: number
+  multipliers: {
+    protocolBoostMultiplier: number
+    swapMultiplier: number
+    timeOpenMultiplier: number
+    automationProtectionMultiplier: number
+    lazyVaultMultiplier: number
+  }
+}
 export type PositionPoints = {
   positionId: string
   vaultId: number


### PR DESCRIPTION
This Pull Request introduces an enhancement to the way we handle user points in our system. Previously, we processed user points individually, which was not efficient when dealing with large volumes of data. 

In this PR, we have implemented a new approach where we first group the points by user. This ensures that all points for a specific user are processed together, improving the coherence of our data handling. 

Furthermore, we have introduced a chunking mechanism. The chunking mechanism divides the grouped points into chunks of 30 or more. The key aspect of this chunking mechanism is that it ensures all points for a user are in the same chunk. This means that the chunk size doesn't have to be strictly 30 but the first possible size above 30 that can accommodate all points for the last processed user.

This new approach not only improves the efficiency of our data processing but also ensures that all points for a specific user are handled together, thereby maintaining user-specific context.

Changes include:
- Grouping points by user before processing
- Dividing grouped points into chunks of size 30 or more
- Ensuring all points for a user are in the same chunk
- Adjusting chunk size to accommodate all points for the last processed user

This PR is expected to significantly improve the efficiency and reliability of our user points handling process.