### PR TITLE
chore: change point accrual function timeout to 300 seconds

### DIFF
--- a/stacks/rays.ts
+++ b/stacks/rays.ts
@@ -50,6 +50,7 @@ export function addRaysConfig({ stack, api, vpc, app }: SummerStackContext) {
   const updateRaysCronFunctionProps: FunctionProps = {
     handler: 'background-jobs/update-rays-cron-function/src/index.handler',
     runtime: 'nodejs20.x',
+    timeout: '300 seconds',
     environment: {
       POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',
       RAYS_DB_CONNECTION_STRING: RAYS_DB_WRITE_CONNECTION_STRING,


### PR DESCRIPTION
- the default `10` seconds is not enough to process all the points and insert them to the database