### PR TITLE
fix: use flashloan amount for borrowing

### DIFF
--- a/sdk/simulator-service/src/strategies/refinanceLendingToLending/RefinanceLendingToLendingAnyPair.ts
+++ b/sdk/simulator-service/src/strategies/refinanceLendingToLending/RefinanceLendingToLendingAnyPair.ts
@@ -113,7 +113,7 @@ export async function refinanceLendingToLending(
           ? position.collateralAmount
           : ctx.getReference(['SwapCollateralFromSourcePosition', 'received']),
         borrowAmount: isDebtSwapSkipped
-          ? position.debtAmount
+          ? flashloanAmount
           : await estimateSwapFromAmount({
               receiveAtLeast: flashloanAmount,
               fromToken: targetPool.debtToken,


### PR DESCRIPTION
Fixing a bug in which the borrowed amount was not the flashloan amount, so the flashloan could not be properly repaid