### PR TITLE
fix: oracle spot price interface

### DIFF
--- a/sdk/oracle-common/src/interfaces/IOracleManager.ts
+++ b/sdk/oracle-common/src/interfaces/IOracleManager.ts
@@ -1,4 +1,4 @@
-import type { IToken, Denomination, Maybe } from '@summerfi/sdk-common/common'
+import type { IToken, Denomination } from '@summerfi/sdk-common/common'
 import type { OracleProviderType, SpotPriceInfo } from '@summerfi/sdk-common/oracle'
 import { IOracleProvider } from './IOracleProvider'
 import { IManagerWithProviders } from '@summerfi/sdk-server-common'
@@ -14,8 +14,5 @@ export interface IOracleManager extends IManagerWithProviders<OracleProviderType
    * @param baseToken A price request for baseToken
    * @param quoteToken A price request - QuoteToken is optional with a USD default.
    */
-  getSpotPrice(params: {
-    baseToken: IToken
-    quoteToken: Maybe<Denomination>
-  }): Promise<SpotPriceInfo>
+  getSpotPrice(params: { baseToken: IToken; quoteToken?: Denomination }): Promise<SpotPriceInfo>
 }

--- a/sdk/oracle-common/src/interfaces/IOracleProvider.ts
+++ b/sdk/oracle-common/src/interfaces/IOracleProvider.ts
@@ -1,4 +1,4 @@
-import { Denomination, IToken, Maybe } from '@summerfi/sdk-common/common'
+import { Denomination, IToken } from '@summerfi/sdk-common/common'
 import { OracleProviderType, SpotPriceInfo } from '@summerfi/sdk-common/oracle'
 import { IManagerProvider } from '@summerfi/sdk-server-common'
 
@@ -14,8 +14,5 @@ export interface IOracleProvider extends IManagerProvider<OracleProviderType> {
    * @param baseToken A price request for baseToken
    * @param quoteToken A price request - QuoteToken is optional with a USD default.
    */
-  getSpotPrice(params: {
-    baseToken: IToken
-    quoteToken: Maybe<Denomination>
-  }): Promise<SpotPriceInfo>
+  getSpotPrice(params: { baseToken: IToken; quoteToken?: Denomination }): Promise<SpotPriceInfo>
 }

--- a/sdk/oracle-service/src/implementation/OracleManager.ts
+++ b/sdk/oracle-service/src/implementation/OracleManager.ts
@@ -26,7 +26,7 @@ export class OracleManager
   /** @see IOracleManager.getSpotPrice */
   async getSpotPrice(params: {
     baseToken: IToken
-    quoteToken: Maybe<Denomination>
+    quoteToken?: Denomination
     forceUseProvider?: OracleProviderType
   }): Promise<SpotPriceInfo> {
     if (

--- a/sdk/oracle-service/src/implementation/oneinch/OneInchOracleProvider.ts
+++ b/sdk/oracle-service/src/implementation/oneinch/OneInchOracleProvider.ts
@@ -18,7 +18,7 @@ import {
 } from '@summerfi/sdk-common/common'
 import { OracleProviderType, SpotPriceInfo } from '@summerfi/sdk-common/oracle'
 import { IOracleProvider } from '@summerfi/oracle-common'
-import { FiatCurrency, IToken, Maybe, isTokenAmount } from '@summerfi/sdk-common'
+import { FiatCurrency, IToken, isTokenAmount } from '@summerfi/sdk-common'
 import { ManagerProviderBase } from '@summerfi/sdk-server-common'
 import { IConfigurationProvider } from '@summerfi/configuration-provider'
 
@@ -54,7 +54,7 @@ export class OneInchOracleProvider
   /** @see IOracleProvider.getSpotPrice */
   async getSpotPrice(params: {
     baseToken: IToken
-    quoteToken: Maybe<Denomination>
+    quoteToken?: Denomination
   }): Promise<SpotPriceInfo> {
     const authHeader = this._getOneInchSpotAuthHeader()
 


### PR DESCRIPTION
- Oracle manager interface was not matching the oracle provider. This was due to a property being optional inside the function parameters object. For some reason the linter does not detect this case. Fixed by using `Maybe` to make the parameter optional instead

EDIT: in the end the Maybe was forcing to pass `undefined` as the value, which is not the intention. We need to figure out a better way to make properties optional while making sure the interfaces are properly fulfilled 