### PR TITLE
fix: skip send action with correct flags

### DIFF
--- a/sdk/protocol-plugins/src/plugins/morphoblue/builders/MorphoDepositBorrowActionBuilder.ts
+++ b/sdk/protocol-plugins/src/plugins/morphoblue/builders/MorphoDepositBorrowActionBuilder.ts
@@ -77,8 +77,8 @@ export class MorphoDepositBorrowActionBuilder extends BaseActionBuilder<steps.De
       skip: borrowAmount.toBN().isZero(),
     })
 
-    const isBorrowTargetOperationExecutor =
-      step.inputs.borrowTargetType !== TokenTransferTargetType.PositionsManager
+    const isBorrowTargetPositionsManager =
+      step.inputs.borrowTargetType === TokenTransferTargetType.PositionsManager
 
     const operationExecutorAddress = await this._getContractAddress({
       addressBookManager,
@@ -97,7 +97,7 @@ export class MorphoDepositBorrowActionBuilder extends BaseActionBuilder<steps.De
         borrowAmount: 'amount',
       },
       connectedOutputs: {},
-      skip: borrowAmount.toBN().isZero() && isBorrowTargetOperationExecutor,
+      skip: borrowAmount.toBN().isZero() || isBorrowTargetPositionsManager,
     })
   }
 }


### PR DESCRIPTION
Fixes the flags used to send the borrowed amount for Morpho to the operation executor. The flags were wrong and the send happened twice when it didn't need to