### PR TITLE
"Fix liq price calculations for short position"

### DIFF
--- a/sdk/sdk-client/bundle/package.json
+++ b/sdk/sdk-client/bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@summer_fi/summerfi-sdk-client",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "packageManager": "yarn@1.22.21",

--- a/sdk/sdk-client/src/utils/PositionUtils.ts
+++ b/sdk/sdk-client/src/utils/PositionUtils.ts
@@ -34,7 +34,7 @@ export class PositionUtils {
     position: Position
     // TODO: it is not defined in Position yet, we should use Pool in the future
     liquidationThreshold: Percentage
-    debtPriceInUsd: string,
+    debtPriceInUsd: string
   }): string {
     // Determine the Collateral Value:
     const collateralAmount = new BigNumber(position.collateralAmount.amount)

--- a/sdk/sdk-client/src/utils/PositionUtils.ts
+++ b/sdk/sdk-client/src/utils/PositionUtils.ts
@@ -1,6 +1,9 @@
 import { IPercentage, ITokenAmount, Percentage, type Position } from '@summerfi/sdk-common/common'
 import { BigNumber } from 'bignumber.js'
 
+// TODO: refactor BigNumbers to use the SDK's TokenAmount operations
+// TODO: refactor priceInUsd to use the SDK's Price class when FE have Position from the SDK
+
 export class PositionUtils {
   static getLTV({
     collateralTokenAmount,

--- a/sdk/sdk-client/src/utils/PositionUtils.ts
+++ b/sdk/sdk-client/src/utils/PositionUtils.ts
@@ -34,7 +34,7 @@ export class PositionUtils {
     position: Position
     // TODO: it is not defined in Position yet, we should use Pool in the future
     liquidationThreshold: Percentage
-    debtPriceInUsd: string
+    debtPriceInUsd: string,
   }): string {
     // Determine the Collateral Value:
     const collateralAmount = new BigNumber(position.collateralAmount.amount)
@@ -49,6 +49,6 @@ export class PositionUtils {
     const liquidationPrice = debtValue.div(
       collateralAmount.times(liquidationThreshold.toProportion()),
     )
-    return liquidationPrice.toString()
+    return liquidationPrice.times(debtPriceInUsd).toString()
   }
 }

--- a/sdk/sdk-client/src/utils/PositionUtils.ts
+++ b/sdk/sdk-client/src/utils/PositionUtils.ts
@@ -37,7 +37,7 @@ export class PositionUtils {
     position: Position
     // TODO: it is not defined in Position yet, we should use Pool in the future
     liquidationThreshold: Percentage
-    debtPriceInUsd: string,
+    debtPriceInUsd: string
   }): string {
     // Determine the Collateral Value:
     const collateralAmount = new BigNumber(position.collateralAmount.amount)

--- a/sdk/sdk-client/tests/PositionUtils.spec.ts
+++ b/sdk/sdk-client/tests/PositionUtils.spec.ts
@@ -105,8 +105,8 @@ describe('PositionUtils', () => {
 
       const liquidationPrice = PositionUtils.getLiquidationPriceInUsd({
         position: {
-          collateralAmount: TokenAmount.createFrom({ amount: '2000', token: DAI } ),
-          debtAmount: TokenAmount.createFrom({amount: '1.5', token: WETH }),
+          collateralAmount: TokenAmount.createFrom({ amount: '2000', token: DAI }),
+          debtAmount: TokenAmount.createFrom({ amount: '1.5', token: WETH }),
         } as Position,
         liquidationThreshold,
         debtPriceInUsd: ethPriceInUsd,

--- a/sdk/sdk-client/tests/PositionUtils.spec.ts
+++ b/sdk/sdk-client/tests/PositionUtils.spec.ts
@@ -66,28 +66,28 @@ describe('PositionUtils', () => {
   })
 
   describe('getLiquidationPrice', () => {
-    it('should correctly calculate liquidation price when debt amount is not 0', () => {
+    it('should correctly calculate liquidation price for long position', () => {
       const liquidationThreshold = Percentage.createFrom({ value: 80 })
 
       const liquidationPrice = PositionUtils.getLiquidationPriceInUsd({
         position: {
           collateralAmount: TokenAmount.createFrom({ amount: '2', token: WETH }),
-          debtAmount: TokenAmount.createFrom({ amount: '5000', token: DAI }),
+          debtAmount: TokenAmount.createFrom({ amount: '1500', token: DAI }),
         } as Position,
         liquidationThreshold,
         debtPriceInUsd: daiPriceInUsd,
       })
-      expect(liquidationPrice).toEqual('3125')
+      expect(liquidationPrice).toEqual('937.5')
 
       const liquidationPrice2 = PositionUtils.getLiquidationPriceInUsd({
         position: {
           collateralAmount: TokenAmount.createFrom({ amount: '2', token: WETH }),
-          debtAmount: TokenAmount.createFrom({ amount: '6000', token: DAI }),
+          debtAmount: TokenAmount.createFrom({ amount: '1600', token: DAI }),
         } as Position,
         liquidationThreshold,
         debtPriceInUsd: daiPriceInUsd,
       })
-      expect(liquidationPrice2).toEqual('3750')
+      expect(liquidationPrice2).toEqual('1000')
 
       const liquidationPrice3 = PositionUtils.getLiquidationPriceInUsd({
         position: {
@@ -96,6 +96,40 @@ describe('PositionUtils', () => {
         } as Position,
         liquidationThreshold,
         debtPriceInUsd: daiPriceInUsd,
+      })
+      expect(liquidationPrice3).toEqual('0.625')
+    })
+
+    it('should correctly calculate liquidation price for short position', () => {
+      const liquidationThreshold = Percentage.createFrom({ value: 80 })
+
+      const liquidationPrice = PositionUtils.getLiquidationPriceInUsd({
+        position: {
+          collateralAmount: TokenAmount.createFrom({ amount: '2000', token: DAI } ),
+          debtAmount: TokenAmount.createFrom({amount: '1.5', token: WETH }),
+        } as Position,
+        liquidationThreshold,
+        debtPriceInUsd: ethPriceInUsd,
+      })
+      expect(liquidationPrice).toEqual('937.5')
+
+      const liquidationPrice2 = PositionUtils.getLiquidationPriceInUsd({
+        position: {
+          collateralAmount: TokenAmount.createFrom({ amount: '2000', token: DAI }),
+          debtAmount: TokenAmount.createFrom({ amount: '1.6', token: WETH }),
+        } as Position,
+        liquidationThreshold,
+        debtPriceInUsd: ethPriceInUsd,
+      })
+      expect(liquidationPrice2).toEqual('1000')
+
+      const liquidationPrice3 = PositionUtils.getLiquidationPriceInUsd({
+        position: {
+          collateralAmount: TokenAmount.createFrom({ amount: '2000', token: DAI }),
+          debtAmount: TokenAmount.createFrom({ amount: '0.001', token: WETH }),
+        } as Position,
+        liquidationThreshold,
+        debtPriceInUsd: ethPriceInUsd,
       })
       expect(liquidationPrice3).toEqual('0.625')
     })


### PR DESCRIPTION
This pull request fixes the liquidation price calculations for short positions. Previously, the liquidation price was not being calculated correctly for short positions. This PR updates the `getLiquidationPrice` function in the `PositionUtils` class to correctly calculate the liquidation price for both long and short positions. The changes include updating the debt price calculation and adding tests for short positions.