### PR TITLE
chore: refactor

### DIFF
--- a/packages/morpho-blue-external-api-client/queries/meta-morho-details.graphql
+++ b/packages/morpho-blue-external-api-client/queries/meta-morho-details.graphql
@@ -1,58 +1,51 @@
 query metaMorphoDetails($metaMorphoAddresses: [String!]) {
-    vaults (where: { address_in: $metaMorphoAddresses }) {
-        items {
-            name
-            monthlyApy
-            weeklyApy
-            dailyApy
-            symbol
-            address
-            asset {
-                address
-                symbol
-                decimals
-                priceUsd
-            }
-            chain {
-                id
-                network
-            }
-            state {
-                totalAssets
-                totalAssetsUsd
-                apy
-                fee
-                allocation {
-                    id
-                    market {
-                        uniqueKey
-                        id
-                    }
-                    supplyAssets
-                }
-            }
-        }
-    }
-    markets {
-        items {
-            id
+  vaults(where: { address_in: $metaMorphoAddresses }) {
+    items {
+      name
+      monthlyApy
+      weeklyApy
+      dailyApy
+      symbol
+      address
+      asset {
+        address
+        symbol
+        decimals
+        priceUsd
+      }
+      chain {
+        id
+        network
+      }
+      state {
+        totalAssets
+        totalAssetsUsd
+        apy
+        fee
+        allocation {
+          id
+          market {
             uniqueKey
+            id
             collateralAsset {
-                id
-                address
-                symbol
-                priceUsd
-                decimals
-
+              id
+              address
+              symbol
+              priceUsd
+              decimals
             }
             lltv
             loanAsset {
-                id
-                address
-                symbol
-                priceUsd
-                decimals
+              id
+              address
+              symbol
+              priceUsd
+              decimals
             }
+          }
+          supplyAssets
         }
+      }
     }
+  }
 }

--- a/packages/morpho-blue-external-api-client/src/index.ts
+++ b/packages/morpho-blue-external-api-client/src/index.ts
@@ -69,13 +69,6 @@ const getVaultAllocations = async (
     return []
   }
 
-  const markets = result.markets.items
-
-  if (markets == null) {
-    logger?.warn('No markets found for the given vaults')
-    return []
-  }
-
   return vaults
     .map((vault) => {
       return {
@@ -99,10 +92,7 @@ const getVaultAllocations = async (
           ? vault.state.allocation
               .filter((allocation) => allocation.supplyAssets > 0)
               .map((allocation) => {
-                const market = markets.find((m) => m.id === allocation.market.id)
-                if (market == null) {
-                  throw new Error(`No market found for allocation ${allocation.id}`)
-                }
+                const market = allocation.market
 
                 logger?.debug('Found allocation', {
                   market: market.uniqueKey,


### PR DESCRIPTION
- don't fetch markets separately - but embed them in vault response
- reposne is now much samller and less prone to errors