### PR TITLE
fix: relax token amount checks

### DIFF
--- a/sdk/sdk-common/src/common/implementation/TokenAmount.ts
+++ b/sdk/sdk-common/src/common/implementation/TokenAmount.ts
@@ -142,7 +142,9 @@ export class TokenAmount implements ITokenAmount {
 
   /** PRIVATE */
   private _validateSameToken(tokenAmount: ITokenAmount): void {
-    if (tokenAmount.token.symbol !== this.token.symbol) {
+    // TODO: relaxed check by using only lowercase due to Portfolio and Product Hub not being
+    // TODO: integrated in the SDK and using different symbols cases
+    if (tokenAmount.token.symbol.toLowerCase() !== this.token.symbol.toLowerCase()) {
       throw new Error(
         `Token symbols do not match: ${tokenAmount.token.symbol} !== ${this.token.symbol}`,
       )


### PR DESCRIPTION
Due to product hub and portfolio not being integrated in the SDK, there are some token symbols casing that is not matching the SDK expection. The fix relaxes this check by converting it to lowercase for the time being.