### PR TITLE
fix: small positions refinance

### DIFF
--- a/sdk/protocol-plugins/src/plugins/common/builders/SwapActionBuilder.ts
+++ b/sdk/protocol-plugins/src/plugins/common/builders/SwapActionBuilder.ts
@@ -16,7 +16,6 @@ export class SwapActionBuilder extends BaseActionBuilder<steps.SwapStep> {
     })
 
     const swapData = await swapManager.getSwapDataExactInput({
-      chainInfo: params.user.chainInfo,
       fromAmount: step.inputs.inputAmountAfterFee,
       toToken: step.inputs.minimumReceivedAmount.token,
       recipient: swapContractAddress,

--- a/sdk/protocol-plugins/src/plugins/common/helpers/aaveV3Like/AAVEv3LikeProtocolDataBuilder.ts
+++ b/sdk/protocol-plugins/src/plugins/common/helpers/aaveV3Like/AAVEv3LikeProtocolDataBuilder.ts
@@ -118,7 +118,7 @@ export class AaveV3LikeProtocolDataBuilder<
         })
         if (!token) {
           console.error(
-            `Token not found for address ${reservesToken.tokenAddress} while processing AaveLike protocol data`,
+            `Protocol token not found in SDK token list for address ${reservesToken.tokenAddress} while processing AaveLike protocol data`,
           )
         }
         return token
@@ -474,4 +474,11 @@ export function filterAssetsListByEMode<T extends { emode: EmodeCategory }>(
   }
 
   return assetsList.filter((asset) => Number(asset.emode) === emode)
+}
+
+export function filterAssetsListByToken<T extends { token: Token }>(
+  assetsList: T[],
+  token: Token,
+): T[] {
+  return assetsList.filter((asset) => asset.token.equals(token))
 }

--- a/sdk/protocol-plugins/tests/unit/builders/SwapActionBuilder.spec.ts
+++ b/sdk/protocol-plugins/tests/unit/builders/SwapActionBuilder.spec.ts
@@ -131,7 +131,6 @@ describe('Swap Action Builder', () => {
 
     expect(builderParams.swapManager.lastGetSwapDataExactInputParams).toBeDefined()
     expect(builderParams.swapManager.lastGetSwapDataExactInputParams).toEqual({
-      chainInfo: chainInfo,
       fromAmount: inputAmountAfterFee,
       toToken: toAmount.token,
       recipient: Address.createFromEthereum({ value: SwapContractAddress }),

--- a/sdk/sdk-common/src/common/implementation/Percentage.ts
+++ b/sdk/sdk-common/src/common/implementation/Percentage.ts
@@ -7,6 +7,10 @@ import { IPercentage, IPercentageData, isPercentage } from '../interfaces/IPerce
  * @see IPercentage
  */
 export class Percentage implements IPercentage {
+  public static Percent100: Percentage = new Percentage({
+    value: 100.0,
+  })
+
   readonly value: number
 
   /** FACTORY */
@@ -54,6 +58,11 @@ export class Percentage implements IPercentage {
   /** @see IPercentage.toProportion */
   toProportion(): number {
     return this.value / 100
+  }
+
+  /** @see IPercentage.toComplement */
+  toComplement(): IPercentage {
+    return Percentage.createFrom({ value: 100 - this.value })
   }
 
   /** @see IPercentage.toBaseUnit */

--- a/sdk/sdk-common/src/common/implementation/Price.ts
+++ b/sdk/sdk-common/src/common/implementation/Price.ts
@@ -44,10 +44,13 @@ export class Price implements IPrice {
   }
 
   /**
-   * Create a price from the ratio of two token amounts
+   * Creates a price from the ratio of two token amounts
+   *
    * @param numerator the token amount in the numerator
    * @param denominator the token amount in the denominator
-   * @returns the price calculated from the amounts ratio
+   * @returns the price calculated from the amounts ratio of numerator divided by denominator
+   *
+   * @dev The denominator becomes the base of the price and the numerator becomes the quote
    */
   static createFromAmountsRatio(params: {
     numerator: ITokenAmount

--- a/sdk/sdk-common/src/common/interfaces/IPercentage.ts
+++ b/sdk/sdk-common/src/common/interfaces/IPercentage.ts
@@ -45,6 +45,14 @@ export interface IPercentage extends IPercentageData {
   toProportion(): number
 
   /**
+   * @name toComplement
+   * @returns The complement of the percentage
+   *
+   * The complement is the difference between 100% and the percentage
+   */
+  toComplement(): IPercentage
+
+  /**
    * @name toBaseUnit
    * @param decimals The number of decimals to use for the conversion
    * @returns The percentage as a string in base unit

--- a/sdk/sdk-common/src/common/interfaces/IPrice.ts
+++ b/sdk/sdk-common/src/common/interfaces/IPrice.ts
@@ -3,6 +3,7 @@ import { Denomination, DenominationDataSchema } from '../aliases/Denomination'
 import { IPrintable } from './IPrintable'
 import { type ITokenAmount } from './ITokenAmount'
 import { type IFiatCurrencyAmount } from './IFiatCurrencyAmount'
+import { type IPercentage } from './IPercentage'
 import { z } from 'zod'
 
 /**
@@ -10,7 +11,13 @@ import { z } from 'zod'
  *
  * This helps callers to know what to expect from the result of the operation
  */
-export type PriceMulParamType = string | number | IPrice | ITokenAmount | IFiatCurrencyAmount
+export type PriceMulParamType =
+  | string
+  | number
+  | IPrice
+  | ITokenAmount
+  | IFiatCurrencyAmount
+  | IPercentage
 export type PriceMulReturnType<T> = T extends ITokenAmount
   ? ITokenAmount | IFiatCurrencyAmount
   : T extends IFiatCurrencyAmount
@@ -133,6 +140,42 @@ export interface IPrice extends IPriceData, IPrintable {
    * @description Converts the price to a string
    */
   toString(): string
+
+  /**
+   * @name isLessThan
+   * @description Checks if the price is less than another price
+   */
+  isLessThan(otherPrice: IPrice): boolean
+
+  /**
+   * @name isLessThanOrEqual
+   * @description Checks if the price is less than or equal to another price
+   */
+  isLessThanOrEqual(otherPrice: IPrice): boolean
+
+  /**
+   * @name isGreaterThan
+   * @description Checks if the price is greater than another price
+   */
+  isGreaterThan(otherPrice: IPrice): boolean
+
+  /**
+   * @name isGreaterThanOrEqual
+   * @description Checks if the price is greater than or equal to another price
+   */
+  isGreaterThanOrEqual(otherPrice: IPrice): boolean
+
+  /**
+   * @name isZero
+   * @description Checks if the price is zero
+   */
+  isZero(): boolean
+
+  /**
+   * @name isEqual
+   * @description Checks if the price is equal to another price
+   */
+  isEqual(otherPrice: IPrice): boolean
 }
 
 /**

--- a/sdk/sdk-common/src/common/utils/PriceUtils.ts
+++ b/sdk/sdk-common/src/common/utils/PriceUtils.ts
@@ -8,6 +8,7 @@ import {
   type IFiatCurrencyAmountData,
 } from '../interfaces/IFiatCurrencyAmount'
 import { FiatCurrency, isFiatCurrency } from '../enums/FiatCurrency'
+import { IPercentage } from '../interfaces'
 
 /**
  * Multiply a token amount by a price
@@ -120,6 +121,34 @@ export function dividePriceByPrice(price: IPrice, otherPrice: IPrice): IPriceDat
       base: price.base,
       quote: otherPrice.base,
     }
+  }
+}
+
+/**
+ * Multiplies a price by a percentage
+ * @param price The price to multiply
+ * @param percentage The percentage to multiply by
+ * @returns The resulting price
+ */
+export function multiplyPriceByPercentage(price: IPrice, percentage: IPercentage): IPriceData {
+  return {
+    value: price.toBN().times(percentage.toProportion()).toString(),
+    base: price.base,
+    quote: price.quote,
+  }
+}
+
+/**
+ * Divides a price by a percentage
+ * @param price The price to divide
+ * @param percentage The percentage to divide by
+ * @returns The resulting price
+ */
+export function dividePriceByPercentage(price: IPrice, percentage: IPercentage): IPriceData {
+  return {
+    value: price.toBN().dividedBy(percentage.toProportion()).toString(),
+    base: price.base,
+    quote: price.quote,
   }
 }
 

--- a/sdk/sdk-common/tests/Percentage.spec.ts
+++ b/sdk/sdk-common/tests/Percentage.spec.ts
@@ -148,4 +148,16 @@ describe('SDK Common | Percentage', () => {
       expect(percentage.toString()).toEqual('20%')
     })
   })
+
+  describe('#toComplement()', () => {
+    it('should return the complement (100-x) of the percentage', () => {
+      const percentage = Percentage.createFrom({
+        value: 20,
+      })
+
+      const complementPercentage = percentage.toComplement()
+
+      expect(complementPercentage.value).toEqual(80)
+    })
+  })
 })

--- a/sdk/sdk-common/tests/Price.spec.ts
+++ b/sdk/sdk-common/tests/Price.spec.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import {
   IToken,
   Price,
@@ -763,6 +764,287 @@ describe('SDK Common | Price', () => {
       })
 
       expect(price.toString()).toEqual('108.54 DAI/USDC')
+    })
+  })
+
+  describe('#isLessThan()', () => {
+    it('should not accept a different base/quote', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: DAI,
+        quote: FiatCurrency.USD,
+      })
+
+      expect(() => price.isLessThan(otherPrice)).toThrow()
+    })
+
+    it('should compare another price for less than', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(otherPrice.isLessThan(price)).toBeTruthy()
+      expect(price.isLessThan(otherPrice)).toBeFalsy()
+    })
+  })
+
+  describe('#isLessThanOrEqual()', () => {
+    it('should not accept a different base/quote', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: DAI,
+        quote: FiatCurrency.USD,
+      })
+
+      expect(() => price.isLessThanOrEqual(otherPrice)).toThrow()
+    })
+
+    it('should compare another price for less than', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(otherPrice.isLessThanOrEqual(price)).toBeTruthy()
+      expect(price.isLessThanOrEqual(otherPrice)).toBeFalsy()
+    })
+
+    it('should compare another price for equality', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(otherPrice.isLessThanOrEqual(price)).toBeTruthy()
+      expect(price.isLessThanOrEqual(otherPrice)).toBeTruthy()
+    })
+  })
+
+  describe('#isGreaterThan()', () => {
+    it('should not accept a different base/quote', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: DAI,
+        quote: FiatCurrency.USD,
+      })
+
+      expect(() => price.isGreaterThan(otherPrice)).toThrow()
+    })
+
+    it('should compare another price for greater than', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(otherPrice.isGreaterThan(price)).toBeFalsy()
+      expect(price.isGreaterThan(otherPrice)).toBeTruthy()
+    })
+  })
+
+  describe('#isGreaterThanOrEqual()', () => {
+    it('should not accept a different base/quote', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: DAI,
+        quote: FiatCurrency.USD,
+      })
+
+      expect(() => price.isGreaterThanOrEqual(otherPrice)).toThrow()
+    })
+
+    it('should compare another price for greater than', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(otherPrice.isGreaterThanOrEqual(price)).toBeFalsy()
+      expect(price.isGreaterThanOrEqual(otherPrice)).toBeTruthy()
+    })
+
+    it('should compare another price for equality', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(otherPrice.isGreaterThanOrEqual(price)).toBeTruthy()
+      expect(price.isGreaterThanOrEqual(otherPrice)).toBeTruthy()
+    })
+  })
+
+  describe('#isZero()', () => {
+    it('should return true when price is 0', () => {
+      const price = Price.createFrom({
+        value: '0.000',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(price.isZero()).toBeTruthy()
+    })
+
+    it('should return false when price is not 0', () => {
+      const price = Price.createFrom({
+        value: '0.1',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(price.isZero()).toBeFalsy()
+    })
+
+    it('should return false when price is very small and close to 0', () => {
+      const price = Price.createFrom({
+        value: '0.0000000000000000001',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(price.isZero()).toBeFalsy()
+    })
+  })
+
+  describe('#isEqual()', () => {
+    it('should not accept a different base/quote', () => {
+      const price = Price.createFrom({
+        value: '108.54',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '20.5',
+        base: DAI,
+        quote: FiatCurrency.USD,
+      })
+
+      expect(() => price.isEqual(otherPrice)).toThrow()
+    })
+
+    it('should return true when prices are equal', () => {
+      const price = Price.createFrom({
+        value: '123.45',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '123.45',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(price.isEqual(otherPrice)).toBeTruthy()
+    })
+
+    it('should return false when prices are not equal', () => {
+      const price = Price.createFrom({
+        value: '123.45',
+        base: USDC,
+        quote: DAI,
+      })
+
+      const otherPrice = Price.createFrom({
+        value: '123.46',
+        base: USDC,
+        quote: DAI,
+      })
+
+      expect(price.isEqual(otherPrice)).toBeFalsy()
+    })
+  })
+
+  describe('#createFromAmountsRatio()', () => {
+    it('should create a price from token amounts', () => {
+      const daiAmount = TokenAmount.createFrom({
+        token: DAI,
+        amount: '100',
+      })
+
+      const usdcAmount = TokenAmount.createFrom({
+        token: USDC,
+        amount: '10854',
+      })
+
+      const price = Price.createFromAmountsRatio({
+        numerator: usdcAmount,
+        denominator: daiAmount,
+      })
+
+      expect(price.value).toEqual('108.54')
+      assert(isToken(price.base), 'Price base is not a token')
+      expect(price.base.equals(DAI)).toBeTruthy()
+      assert(isToken(price.quote), 'Price quote is not a token')
+      expect(price.quote.equals(USDC)).toBeTruthy()
     })
   })
 })

--- a/sdk/sdk-e2e/tests/refinanceMakerAaveV3AnyPair.test.ts
+++ b/sdk/sdk-e2e/tests/refinanceMakerAaveV3AnyPair.test.ts
@@ -1,0 +1,272 @@
+import {
+  Percentage,
+  TokenAmount,
+  Address,
+  type Maybe,
+  ChainFamilyMap,
+  PositionType,
+} from '@summerfi/sdk-common/common'
+
+import { ProtocolName, isLendingPool } from '@summerfi/sdk-common/protocols'
+import { ProtocolClient, makeSDK, type Chain, type User } from '@summerfi/sdk-client'
+import {
+  PositionsManager,
+  Order,
+  RefinanceParameters,
+  ExternalPositionType,
+} from '@summerfi/sdk-common/orders'
+import { ISimulation, SimulationType } from '@summerfi/sdk-common/simulation'
+import { TransactionUtils } from './utils/TransactionUtils'
+
+import { Hex } from 'viem'
+import assert from 'assert'
+import { EmodeType } from '@summerfi/protocol-plugins/plugins/common'
+import { AddressValue, CommonTokenSymbols, IToken, Token } from '@summerfi/sdk-common'
+import {
+  ILKType,
+  MakerLendingPoolId,
+  MakerPosition,
+  MakerPositionId,
+  isMakerLendingPool,
+  isMakerProtocol,
+} from '@summerfi/protocol-plugins/plugins/maker'
+import {
+  AaveV3LendingPoolId,
+  isAaveV3LendingPoolId,
+  isAaveV3Protocol,
+} from '@summerfi/protocol-plugins'
+
+jest.setTimeout(300000)
+
+/** TEST CONFIG */
+const config = {
+  SDKAPiUrl: 'https://72dytt1e93.execute-api.us-east-1.amazonaws.com/api/sdk',
+  TenderlyForkUrl: 'https://virtual.mainnet.rpc.tenderly.co/c5113732-6db6-400d-ad7c-8706e0857239',
+  makerVaultId: '31722',
+  DPMAddress: '0x7126E8E9C26832B441a560f4283e09f9c51AB605',
+  walletAddress: '0xDDc68f9dE415ba2fE2FD84bc62Be2d2CFF1098dA',
+  source: {
+    collateralTokenSymbol: CommonTokenSymbols.WETH,
+    collateralAmount: '2.5',
+    debtTokenSymbol: CommonTokenSymbols.DAI,
+    debtAmount: '3509.8',
+    ilkType: ILKType.ETH_C,
+  },
+  target: {
+    collateralTokenSymbol: CommonTokenSymbols.sDAI,
+    debtTokenSymbol: CommonTokenSymbols.LUSD,
+    emodeType: EmodeType.Stablecoins,
+  },
+  sendTransaction: false,
+}
+
+describe.skip('Refinance Maker -> Spark | SDK', () => {
+  it('should allow refinance Maker -> Spark with same pair', async () => {
+    // SDK
+    const sdk = makeSDK({ apiURL: config.SDKAPiUrl })
+
+    // Chain
+    const chain: Maybe<Chain> = await sdk.chains.getChain({
+      chainInfo: ChainFamilyMap.Ethereum.Mainnet,
+    })
+
+    assert(chain, 'Chain not found')
+
+    // User
+    const walletAddress = Address.createFromEthereum({
+      value: config.walletAddress as AddressValue,
+    })
+    const user: User = await sdk.users.getUser({
+      chainInfo: chain.chainInfo,
+      walletAddress: walletAddress,
+    })
+    expect(user).toBeDefined()
+    expect(user.wallet.address).toEqual(walletAddress)
+    expect(user.chainInfo).toEqual(chain.chainInfo)
+
+    // Positions Manager
+    const positionsManager = PositionsManager.createFrom({
+      address: Address.createFromEthereum({
+        value: config.DPMAddress as AddressValue,
+      }),
+    })
+
+    // Tokens
+    const sourceDebtToken: Maybe<IToken> = await chain.tokens.getTokenBySymbol({
+      symbol: config.source.debtTokenSymbol,
+    })
+    assert(sourceDebtToken, `${config.source.debtTokenSymbol} not found`)
+
+    const sourceCollateralToken: Maybe<IToken> = await chain.tokens.getTokenBySymbol({
+      symbol: config.source.collateralTokenSymbol,
+    })
+    assert(sourceCollateralToken, `${config.source.collateralTokenSymbol} not found`)
+
+    const targetDebtToken: Maybe<IToken> = await chain.tokens.getTokenBySymbol({
+      symbol: config.target.debtTokenSymbol,
+    })
+    assert(targetDebtToken, `${config.target.debtTokenSymbol} not found`)
+
+    const targetCollateralToken = Token.createFrom({
+      address: Address.createFromEthereum({
+        value: '0x83F20F44975D03b1b09e64809B757c47f942BEeA',
+      }),
+      chainInfo: ChainFamilyMap.Ethereum.Mainnet,
+      decimals: 18,
+      name: 'SDAI Test',
+      symbol: 'SDAI',
+    })
+
+    // Source position
+    const maker = await chain.protocols.getProtocol({ name: ProtocolName.Maker })
+    assert(maker, 'Maker protocol not found')
+
+    if (!isMakerProtocol(maker)) {
+      assert(false, 'Maker protocol type is not lending')
+    }
+
+    const makerPoolId = MakerLendingPoolId.createFrom({
+      protocol: maker,
+      debtToken: sourceDebtToken,
+      collateralToken: sourceCollateralToken,
+      ilkType: config.source.ilkType,
+    })
+
+    const makerPool = await maker.getLendingPool({
+      poolId: makerPoolId,
+    })
+    assert(makerPool, 'Maker pool not found')
+
+    if (!isMakerLendingPool(makerPool)) {
+      assert(false, 'Maker pool type is not lending')
+    }
+
+    // Source position
+    const makerPosition: MakerPosition = MakerPosition.createFrom({
+      type: PositionType.Multiply,
+      id: MakerPositionId.createFrom({ id: config.makerVaultId, vaultId: config.makerVaultId }),
+      debtAmount: TokenAmount.createFrom({
+        token: sourceDebtToken,
+        amount: config.source.debtAmount,
+      }),
+      collateralAmount: TokenAmount.createFrom({
+        token: sourceCollateralToken,
+        amount: config.source.collateralAmount,
+      }),
+      pool: makerPool,
+    })
+
+    // Target protocol
+    const aaveV3: Maybe<ProtocolClient> = await chain.protocols.getProtocol({
+      name: ProtocolName.AaveV3,
+    })
+    assert(aaveV3, 'AaveV3 not found')
+
+    if (!isAaveV3Protocol(aaveV3)) {
+      assert(false, 'Protocol type is not AaveV3')
+    }
+
+    const targetPoolId = AaveV3LendingPoolId.createFrom({
+      protocol: aaveV3,
+      collateralToken: targetCollateralToken,
+      debtToken: targetDebtToken,
+      emodeType: config.target.emodeType,
+    })
+
+    const targetPool = await aaveV3.getLendingPool({
+      poolId: targetPoolId,
+    })
+
+    assert(targetPool, 'Pool not found')
+
+    if (!isAaveV3LendingPoolId(targetPool.id)) {
+      assert(false, 'Pool ID is not a AaveV3 one')
+    }
+
+    if (!isLendingPool(targetPool)) {
+      assert(false, 'Spark pool type is not lending')
+    }
+
+    const poolInfo = await aaveV3.getLendingPoolInfo({ poolId: targetPoolId })
+    console.log('Pool Info:', JSON.stringify(poolInfo, null, 2))
+
+    //
+    // IMPORT SIMULATION
+    //
+    const importSimulation: ISimulation<SimulationType.ImportPosition> =
+      await sdk.simulator.importing.simulateImportPosition({
+        externalPosition: {
+          externalId: {
+            address: Address.createFromEthereum({
+              value: '0x517775d01FA1D41c8906848e88831b6dA49AB8E7',
+            }),
+            type: ExternalPositionType.DS_PROXY,
+          },
+          position: makerPosition,
+        },
+      })
+
+    //
+    // REFINANCE SIMULATION
+    //
+    const refinanceParameters = RefinanceParameters.createFrom({
+      sourcePosition: makerPosition,
+      targetPool: targetPool,
+      slippage: Percentage.createFrom({ value: 0.2 }),
+    })
+
+    const refinanceSimulation: ISimulation<SimulationType.Refinance> =
+      await sdk.simulator.refinance.simulateRefinancePosition(refinanceParameters)
+
+    expect(refinanceSimulation).toBeDefined()
+
+    expect(refinanceSimulation.sourcePosition?.id).toEqual(makerPosition.id)
+    expect(refinanceSimulation.targetPosition.pool.id).toEqual(targetPool.id)
+
+    console.log('Refinance Simulation:', JSON.stringify(refinanceSimulation, null, 2))
+    //
+    // IMPORT ORDER
+    //
+    const importOrder: Maybe<Order> = await user.newOrder({
+      positionsManager,
+      simulation: importSimulation,
+    })
+
+    assert(importOrder, 'Order not found')
+
+    //
+    // REFINANCE ORDER
+    //
+    const refinanceOrder: Maybe<Order> = await user.newOrder({
+      positionsManager,
+      simulation: refinanceSimulation,
+    })
+
+    assert(refinanceOrder, 'Order not found')
+
+    if (config.sendTransaction) {
+      // Send transaction
+      console.log('Sending transaction...')
+
+      const privateKey = process.env.DEPLOYER_PRIVATE_KEY as Hex
+      const transactionUtils = new TransactionUtils({
+        rpcUrl: config.TenderlyForkUrl,
+        walletPrivateKey: privateKey,
+      })
+
+      const importTxHash = await transactionUtils.sendTransaction({
+        transaction: importOrder.transactions[0].transaction,
+        waitForConfirmation: true,
+      })
+
+      console.log('Import Transaction Sent:', importTxHash)
+
+      const refinanceTxHash = await transactionUtils.sendTransaction({
+        transaction: refinanceOrder.transactions[0].transaction,
+        waitForConfirmation: true,
+      })
+
+      console.log('Refinance Transaction Sent:', refinanceTxHash)
+    }
+  })
+})

--- a/sdk/sdk-e2e/tests/refinanceSparkMorphoAnyPair.test.ts
+++ b/sdk/sdk-e2e/tests/refinanceSparkMorphoAnyPair.test.ts
@@ -1,0 +1,202 @@
+import { makeSDK } from '@summerfi/sdk-client'
+import { ProtocolName, isLendingPool } from '@summerfi/sdk-common/protocols'
+import { EmodeType } from '@summerfi/protocol-plugins/plugins/common'
+import {
+  AddressValue,
+  CommonTokenSymbols,
+  ISimulation,
+  Percentage,
+  TokenAmount,
+  Address,
+  ChainFamilyMap,
+  PositionType,
+  SimulationType,
+} from '@summerfi/sdk-common'
+import { PositionsManager, RefinanceParameters } from '@summerfi/sdk-common/orders'
+import {
+  SparkLendingPoolId,
+  SparkPosition,
+  SparkPositionId,
+  isSparkLendingPool,
+  isSparkProtocol,
+} from '@summerfi/protocol-plugins/plugins/spark'
+import {
+  MorphoLendingPoolId,
+  isMorphoLendingPoolId,
+  isMorphoProtocol,
+} from '@summerfi/protocol-plugins/plugins/morphoblue'
+
+import assert from 'assert'
+import { TransactionUtils } from './utils/TransactionUtils'
+import { Hex } from 'viem'
+
+jest.setTimeout(300000)
+
+/** TEST CONFIG */
+const config = {
+  SDKAPiUrl: 'https://72dytt1e93.execute-api.us-east-1.amazonaws.com/api/sdk',
+  TenderlyForkUrl: 'https://virtual.mainnet.rpc.tenderly.co/f127b873-ff67-4490-ae0d-e17742db7725',
+  DPMAddress: '0x7126E8E9C26832B441a560f4283e09f9c51AB605',
+  walletAddress: '0xDDc68f9dE415ba2fE2FD84bc62Be2d2CFF1098dA',
+  chainInfo: ChainFamilyMap.Ethereum.Mainnet,
+  source: {
+    collateralTokenSymbol: CommonTokenSymbols.WBTC,
+    collateralAmount: '0.00005',
+    debtTokenSymbol: CommonTokenSymbols.DAI,
+    debtAmount: '1.0005',
+    emodeType: EmodeType.None,
+  },
+  target: {
+    // WBTC/USDC
+    marketId: '0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49' as const,
+  },
+  sendTransactionEnabled: true,
+}
+
+describe.skip('Refinance Morpho Spark | SDK', () => {
+  it('should allow refinance Maker -> Spark with same pair', async () => {
+    // SDK
+    const sdk = makeSDK({ apiURL: config.SDKAPiUrl })
+
+    // Chain
+    const chain = await sdk.chains.getChain({
+      chainInfo: config.chainInfo,
+    })
+    assert(chain, 'Chain not found')
+
+    // User
+    const walletAddress = Address.createFromEthereum({
+      value: config.walletAddress as AddressValue,
+    })
+    const user = await sdk.users.getUser({
+      chainInfo: chain.chainInfo,
+      walletAddress: walletAddress,
+    })
+
+    // Positions Manager
+    const positionsManager = PositionsManager.createFrom({
+      address: Address.createFromEthereum({
+        value: config.DPMAddress as AddressValue,
+      }),
+    })
+
+    // Tokens
+    const debtToken = await chain.tokens.getTokenBySymbol({
+      symbol: config.source.debtTokenSymbol,
+    })
+    const collateralToken = await chain.tokens.getTokenBySymbol({
+      symbol: config.source.collateralTokenSymbol,
+    })
+
+    if (!debtToken || !collateralToken) {
+      assert(false, 'Tokens not found')
+    }
+
+    const sourceProtocol = await chain.protocols.getProtocol({ name: ProtocolName.Spark })
+    assert(sourceProtocol, 'Source protocol not found')
+
+    if (!isSparkProtocol(sourceProtocol)) {
+      assert(false, 'Spark protocol type is not lending')
+    }
+
+    const sourcePoolId = SparkLendingPoolId.createFrom({
+      protocol: sourceProtocol,
+      collateralToken: collateralToken,
+      debtToken: debtToken,
+      emodeType: config.source.emodeType,
+    })
+
+    const sourcePool = await sourceProtocol.getLendingPool({
+      poolId: sourcePoolId,
+    })
+    assert(sourcePool, 'Spark pool not found')
+
+    if (!isSparkLendingPool(sourcePool)) {
+      assert(false, 'Spark pool type is not lending')
+    }
+
+    // Source position
+    const sourcePosition = SparkPosition.createFrom({
+      type: PositionType.Multiply,
+      id: SparkPositionId.createFrom({
+        id: 'SparkPosition',
+      }),
+      debtAmount: TokenAmount.createFrom({
+        token: debtToken,
+        amount: config.source.debtAmount,
+      }),
+      collateralAmount: TokenAmount.createFrom({
+        token: collateralToken,
+        amount: config.source.collateralAmount,
+      }),
+      pool: sourcePool,
+    })
+
+    // Target protocol
+    const targetProtocol = await chain.protocols.getProtocol({
+      name: ProtocolName.MorphoBlue,
+    })
+    assert(targetProtocol, 'Morpho not found')
+
+    if (!isMorphoProtocol(targetProtocol)) {
+      assert(false, 'Protocol type is not Morpho')
+    }
+
+    const targetPoolId = MorphoLendingPoolId.createFrom({
+      protocol: targetProtocol,
+      marketId: config.target.marketId,
+    })
+
+    const targetPool = await sourceProtocol.getLendingPool({
+      poolId: targetPoolId,
+    })
+
+    assert(targetPool, 'Pool not found')
+
+    if (!isMorphoLendingPoolId(targetPool.id)) {
+      assert(false, 'Pool ID is not a Spark one')
+    }
+
+    if (!isLendingPool(sourcePool)) {
+      assert(false, 'Spark pool type is not lending')
+    }
+
+    const refinanceParameters = RefinanceParameters.createFrom({
+      sourcePosition: sourcePosition,
+      targetPool: targetPool,
+      slippage: Percentage.createFrom({ value: 0.2 }),
+    })
+
+    const refinanceSimulation: ISimulation<SimulationType.Refinance> =
+      await sdk.simulator.refinance.simulateRefinancePosition(refinanceParameters)
+
+    expect(refinanceSimulation).toBeDefined()
+
+    expect(refinanceSimulation.sourcePosition?.id).toEqual(sourcePosition.id)
+    expect(refinanceSimulation.targetPosition.pool.id).toEqual(targetPool.id)
+
+    const refinanceOrder = await user.newOrder({
+      positionsManager,
+      simulation: refinanceSimulation,
+    })
+
+    assert(refinanceOrder, 'Order not found')
+
+    if (config.sendTransactionEnabled) {
+      // Send transaction
+      console.log('Sending transaction...')
+
+      const privateKey = process.env.DEPLOYER_PRIVATE_KEY as Hex
+      const transactionUtils = new TransactionUtils({
+        rpcUrl: config.TenderlyForkUrl,
+        walletPrivateKey: privateKey,
+      })
+
+      const receipt = await transactionUtils.sendTransaction({
+        transaction: refinanceOrder.transactions[0].transaction,
+      })
+
+      console.log('Transaction sent:', receipt)
+    }
+  })
+})

--- a/sdk/sdk-server/src/handlers/getSwapData.ts
+++ b/sdk/sdk-server/src/handlers/getSwapData.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod'
-import { ChainInfo, Token, TokenAmount, Address, Percentage } from '@summerfi/sdk-common/common'
+import { Token, TokenAmount, Address, Percentage } from '@summerfi/sdk-common/common'
 import { SwapData } from '@summerfi/sdk-common/swap'
 import { publicProcedure } from '../TRPC'
 
 export const getSwapDataExactInput = publicProcedure
   .input(
     z.object({
-      chainInfo: z.custom<ChainInfo>((chainInfo) => chainInfo !== undefined),
       fromAmount: z.custom<TokenAmount>((tokenAmount) => tokenAmount !== undefined),
       toToken: z.custom<Token>((token) => token !== undefined),
       recipient: z.custom<Address>((recipient) => recipient !== undefined),
@@ -15,7 +14,6 @@ export const getSwapDataExactInput = publicProcedure
   )
   .query(async (opts): Promise<SwapData> => {
     return await opts.ctx.swapManager.getSwapDataExactInput({
-      chainInfo: opts.input.chainInfo,
       fromAmount: opts.input.fromAmount,
       toToken: opts.input.toToken,
       recipient: opts.input.recipient,

--- a/sdk/sdk-server/src/handlers/getSwapQuote.ts
+++ b/sdk/sdk-server/src/handlers/getSwapQuote.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ChainInfo, Token, TokenAmount } from '@summerfi/sdk-common/common'
+import { Token, TokenAmount } from '@summerfi/sdk-common/common'
 import { QuoteData } from '@summerfi/sdk-common/swap'
 import { publicProcedure } from '../TRPC'
 import { Percentage } from '@summerfi/sdk-common'
@@ -7,7 +7,6 @@ import { Percentage } from '@summerfi/sdk-common'
 export const getSwapQuoteExactInput = publicProcedure
   .input(
     z.object({
-      chainInfo: z.custom<ChainInfo>((chainInfo) => chainInfo !== undefined),
       fromAmount: z.custom<TokenAmount>((tokenAmount) => tokenAmount !== undefined),
       toToken: z.custom<Token>((token) => token !== undefined),
       slippage: z.custom<Percentage>((tokenAmount) => tokenAmount !== undefined),
@@ -15,7 +14,6 @@ export const getSwapQuoteExactInput = publicProcedure
   )
   .query(async (opts): Promise<QuoteData> => {
     return await opts.ctx.swapManager.getSwapQuoteExactInput({
-      chainInfo: opts.input.chainInfo,
       fromAmount: opts.input.fromAmount,
       toToken: opts.input.toToken,
     })

--- a/sdk/simulator-service/src/implementation/utils/EstimateSwapFromAmount.ts
+++ b/sdk/simulator-service/src/implementation/utils/EstimateSwapFromAmount.ts
@@ -1,7 +1,8 @@
 import { TokenAmount, ITokenAmount, IToken, IPercentage } from '@summerfi/sdk-common/common'
 import { ISwapManager } from '@summerfi/swap-common/interfaces'
-import { BigNumber } from 'bignumber.js'
 import { IOracleManager } from '@summerfi/oracle-common'
+import { Percentage, Price, isTokenAmount } from '@summerfi/sdk-common'
+import assert from 'assert'
 
 /**
  * EstimateTokenAmountAfterSwap
@@ -30,30 +31,56 @@ export async function estimateSwapFromAmount(params: {
     })
   }
 
-  const spotPrice = (
+  const spotPriceSourceToken = (
     await params.oracleManager.getSpotPrice({
-      baseToken: receiveAtLeast.token,
-      quoteToken: params.fromToken,
+      baseToken: params.fromToken,
+      quoteToken: receiveAtLeast.token,
     })
   ).price
+
+  const swapQuoteTargetToSource = await params.swapManager.getSwapQuoteExactInput({
+    fromAmount: receiveAtLeast,
+    toToken: params.fromToken,
+  })
+
+  const offerPriceTargetToken = Price.createFromAmountsRatio({
+    numerator: swapQuoteTargetToSource.toTokenAmount,
+    denominator: swapQuoteTargetToSource.fromTokenAmount,
+  })
+
+  const estimatedSourceTokenAmount = receiveAtLeast.multiply(offerPriceTargetToken)
+  assert(
+    isTokenAmount(estimatedSourceTokenAmount),
+    'Estimated token amount cannot be a fiat denomination',
+  )
+
+  const swapQuoteSourceToTarget = await params.swapManager.getSwapQuoteExactInput({
+    fromAmount: estimatedSourceTokenAmount,
+    toToken: params.receiveAtLeast.token,
+  })
+
+  const offerPriceSourceToken = Price.createFromAmountsRatio({
+    numerator: swapQuoteSourceToTarget.toTokenAmount,
+    denominator: swapQuoteSourceToTarget.fromTokenAmount,
+  })
+
+  const worstPriceSourceToken = spotPriceSourceToken.isLessThanOrEqual(offerPriceSourceToken)
+    ? spotPriceSourceToken
+    : offerPriceSourceToken
 
   const summerFee = await params.swapManager.getSummerFee({
     from: { token: receiveAtLeast.token },
     to: { token: params.fromToken },
   })
 
-  const ONE = new BigNumber(1)
-  /*
-  TargetAmt = SourceAmt * (1 - SummerFee) / (SpotPrice * (1 + Slippage))
-  SourceAmt = TargetAmt * SpotPrice * (1 + Slippage) / (1 - SummerFee)
-  */
-  const sourceAmount = receiveAtLeast
-    .toBN()
-    .multipliedBy(spotPrice.toBN().times(ONE.plus(slippage.toProportion())))
-    .div(ONE.minus(summerFee.toProportion()))
+  /**
+   * TargetAmount = SourceAmount * (1 - Slippage) / (1 + SummerFee) / PriceTargetInSource
+   * SourceAmount = TargetAmount * PriceTargetInSource * (1 + SummerFee) / (1 - Slippage)
+   */
+  const onePlusSummerFee = Percentage.Percent100.add(summerFee)
 
-  return TokenAmount.createFrom({
-    amount: sourceAmount.toString(),
-    token: params.fromToken,
-  })
+  return receiveAtLeast
+    .multiply(onePlusSummerFee)
+    .divide(worstPriceSourceToken)
+    .divide(slippage.toComplement())
 }

--- a/sdk/simulator-service/src/implementation/utils/GetSwapStepData.ts
+++ b/sdk/simulator-service/src/implementation/utils/GetSwapStepData.ts
@@ -49,7 +49,7 @@ export async function getSwapStepData(params: {
     quote: params.fromAmount.token,
   })
 
-  const minimumReceivedAmount = quote.toTokenAmount.multiply(1.0 - params.slippage.toProportion())
+  const minimumReceivedAmount = quote.toTokenAmount.multiply(params.slippage.toComplement())
 
   return {
     provider: quote.provider,

--- a/sdk/simulator-service/src/implementation/utils/GetSwapStepData.ts
+++ b/sdk/simulator-service/src/implementation/utils/GetSwapStepData.ts
@@ -33,7 +33,6 @@ export async function getSwapStepData(params: {
 
   const [quote, spotPrice] = await Promise.all([
     params.swapManager.getSwapQuoteExactInput({
-      chainInfo: params.chainInfo,
       fromAmount: amountAfterSummerFee,
       toToken: params.toToken,
     }),

--- a/sdk/simulator-service/tests/mocks/contextMock.ts
+++ b/sdk/simulator-service/tests/mocks/contextMock.ts
@@ -1,12 +1,4 @@
-import {
-  Address,
-  ChainInfo,
-  Percentage,
-  Token,
-  TokenAmount,
-  Price,
-  Maybe,
-} from '@summerfi/sdk-common/common'
+import { Address, Percentage, Token, TokenAmount, Price, Maybe } from '@summerfi/sdk-common/common'
 import { ILendingPool } from '@summerfi/sdk-common/protocols'
 import {
   testTargetLendingPool,
@@ -28,7 +20,6 @@ import { IUser } from '@summerfi/sdk-common/user'
 import { IExternalPosition, IPositionsManager, TransactionInfo } from '@summerfi/sdk-common/orders'
 
 async function getSwapDataExactInput(params: {
-  chainInfo: ChainInfo
   fromAmount: TokenAmount
   toToken: Token
   recipient: Address
@@ -45,11 +36,7 @@ async function getSwapDataExactInput(params: {
   }
 }
 
-async function getSwapQuoteExactInput(params: {
-  chainInfo: ChainInfo
-  fromAmount: TokenAmount
-  toToken: Token
-}) {
+async function getSwapQuoteExactInput(params: { fromAmount: TokenAmount; toToken: Token }) {
   return {
     provider: SwapProviderType.OneInch,
     fromTokenAmount: params.fromAmount,
@@ -70,7 +57,7 @@ async function getSpotPrice(params: {
     price: Price.createFrom({
       value: MOCK_PRICE.toString(),
       base: params.baseToken,
-      quote: MOCK_QUOTE_CURRENCY,
+      quote: params.quoteToken || MOCK_QUOTE_CURRENCY,
     }),
   }
 }

--- a/sdk/swap-common/src/interfaces/ISwapManager.ts
+++ b/sdk/swap-common/src/interfaces/ISwapManager.ts
@@ -1,10 +1,4 @@
-import type {
-  IPercentage,
-  IAddress,
-  IToken,
-  ITokenAmount,
-  IChainInfo,
-} from '@summerfi/sdk-common/common'
+import type { IPercentage, IAddress, IToken, ITokenAmount } from '@summerfi/sdk-common/common'
 import type { QuoteData, SwapData, SwapProviderType } from '@summerfi/sdk-common/swap'
 import { IManagerWithProviders } from '@summerfi/sdk-server-common'
 import { ISwapProvider } from './ISwapProvider'
@@ -19,13 +13,11 @@ export interface ISwapManager extends IManagerWithProviders<SwapProviderType, IS
    * @name getSwapDataExactInput
    * @description Returns the data needed to perform a swap between two tokens, by providing the
    *              exact amount of input tokens to swap
-   * @param chainInfo The chain information
    * @param fromAmount The amount of tokens to swap
    * @param recipient The address that will receive the tokens
    * @param slippage The maximum slippage allowed
    */
   getSwapDataExactInput(params: {
-    chainInfo: IChainInfo
     fromAmount: ITokenAmount
     toToken: IToken
     recipient: IAddress
@@ -36,15 +28,10 @@ export interface ISwapManager extends IManagerWithProviders<SwapProviderType, IS
    * @name getSwapQuoteExactInput
    * @description Returns a quote for the swap between two tokens, by providing the exact amount
    *              of input tokens to swap. It does not return the data needed to perform the swap, only the quote
-   * @param chainInfo The chain information
    * @param fromAmount The amount of tokens to swap
    * @param toToken The token to swap to
    */
-  getSwapQuoteExactInput(params: {
-    chainInfo: IChainInfo
-    fromAmount: ITokenAmount
-    toToken: IToken
-  }): Promise<QuoteData>
+  getSwapQuoteExactInput(params: { fromAmount: ITokenAmount; toToken: IToken }): Promise<QuoteData>
 
   /**
    * @name getSummerFee

--- a/sdk/swap-common/src/interfaces/ISwapProvider.ts
+++ b/sdk/swap-common/src/interfaces/ISwapProvider.ts
@@ -1,10 +1,4 @@
-import {
-  IAddress,
-  IChainInfo,
-  IPercentage,
-  IToken,
-  ITokenAmount,
-} from '@summerfi/sdk-common/common'
+import { IAddress, IPercentage, IToken, ITokenAmount } from '@summerfi/sdk-common/common'
 import type { QuoteData, SwapData, SwapProviderType } from '@summerfi/sdk-common/swap'
 import { IManagerProvider } from '@summerfi/sdk-server-common'
 /**
@@ -16,14 +10,12 @@ export interface ISwapProvider extends IManagerProvider<SwapProviderType> {
    * @name getSwapData
    * @description Returns the data needed to perform a swap between two tokens, by providing the
    *              exact amount of input tokens to swap
-   * @param chainInfo The chain information
    * @param fromAmount The amount of tokens to swap
    * @param toToken The token to swap to
    * @param recipient The address that will receive the tokens
    * @param slippage The maximum slippage allowed
    */
   getSwapDataExactInput(params: {
-    chainInfo: IChainInfo
     fromAmount: ITokenAmount
     toToken: IToken
     recipient: IAddress
@@ -34,13 +26,8 @@ export interface ISwapProvider extends IManagerProvider<SwapProviderType> {
    * @name getSwapQuote
    * @description Returns a quote for the swap between two tokens, by providing the exact amount
    *              of input tokens to swap. It does not return the data needed to perform the swap, only the quote
-   * @param chainInfo The chain information
    * @param fromAmount The amount of tokens to swap
    * @param toToken The token to swap to
    */
-  getSwapQuoteExactInput(params: {
-    chainInfo: IChainInfo
-    fromAmount: ITokenAmount
-    toToken: IToken
-  }): Promise<QuoteData>
+  getSwapQuoteExactInput(params: { fromAmount: ITokenAmount; toToken: IToken }): Promise<QuoteData>
 }

--- a/sdk/swap-service/e2e/oneinch.spec.ts
+++ b/sdk/swap-service/e2e/oneinch.spec.ts
@@ -55,7 +55,6 @@ describe('OneInch | SwapManager | Integration', () => {
     const swapManager = SwapManagerFactory.newSwapManager({ configProvider })
 
     const swapData: SwapData = await swapManager.getSwapDataExactInput({
-      chainInfo,
       fromAmount,
       toToken: DAI,
       recipient: recipient,
@@ -83,7 +82,6 @@ describe('OneInch | SwapManager | Integration', () => {
     const swapManager = SwapManagerFactory.newSwapManager({ configProvider })
 
     const quoteData: QuoteData = await swapManager.getSwapQuoteExactInput({
-      chainInfo,
       fromAmount,
       toToken: DAI,
     })

--- a/sdk/swap-service/src/implementation/SwapManager.ts
+++ b/sdk/swap-service/src/implementation/SwapManager.ts
@@ -1,11 +1,5 @@
 import type { Maybe } from '@summerfi/sdk-common/common/aliases'
-import type {
-  IChainInfo,
-  IPercentage,
-  IAddress,
-  IToken,
-  ITokenAmount,
-} from '@summerfi/sdk-common/common'
+import type { IPercentage, IAddress, IToken, ITokenAmount } from '@summerfi/sdk-common/common'
 import { ChainId, Percentage } from '@summerfi/sdk-common/common'
 import { ISwapProvider, ISwapManager } from '@summerfi/swap-common/interfaces'
 import type { QuoteData, SwapData, SwapProviderType } from '@summerfi/sdk-common/swap'
@@ -38,14 +32,16 @@ export class SwapManager
 
   /** @see ISwapManager.getSwapDataExactInput */
   async getSwapDataExactInput(params: {
-    chainInfo: IChainInfo
     fromAmount: ITokenAmount
     toToken: IToken
     recipient: IAddress
     slippage: IPercentage
     forceUseProvider?: SwapProviderType
   }): Promise<SwapData> {
-    const provider: Maybe<ISwapProvider> = this._getBestProvider(params)
+    const provider: Maybe<ISwapProvider> = this._getBestProvider({
+      chainInfo: params.fromAmount.token.chainInfo,
+      forceUseProvider: params.forceUseProvider,
+    })
     if (!provider) {
       throw new Error('No swap provider available')
     }
@@ -55,12 +51,14 @@ export class SwapManager
 
   /** @see ISwapManager.getSwapQuoteExactInput */
   async getSwapQuoteExactInput(params: {
-    chainInfo: IChainInfo
     fromAmount: ITokenAmount
     toToken: IToken
     forceUseProvider?: SwapProviderType
   }): Promise<QuoteData> {
-    const provider: Maybe<ISwapProvider> = this._getBestProvider(params)
+    const provider: Maybe<ISwapProvider> = this._getBestProvider({
+      chainInfo: params.fromAmount.token.chainInfo,
+      forceUseProvider: params.forceUseProvider,
+    })
     if (!provider) {
       throw new Error('No swap provider available')
     }

--- a/sdk/swap-service/src/implementation/oneinch/OneInchSwapProvider.ts
+++ b/sdk/swap-service/src/implementation/oneinch/OneInchSwapProvider.ts
@@ -64,14 +64,13 @@ export class OneInchSwapProvider
 
   /** @see ISwapProvider.getSwapDataExactInput */
   async getSwapDataExactInput(params: {
-    chainInfo: IChainInfo
     fromAmount: ITokenAmount
     toToken: IToken
     recipient: IAddress
     slippage: IPercentage
   }): Promise<SwapData> {
     const swapUrl = this._formatOneInchSwapUrl({
-      chainInfo: params.chainInfo,
+      chainInfo: params.fromAmount.token.chainInfo,
       fromTokenAmount: params.fromAmount,
       toToken: params.toToken,
       recipient: params.recipient,
@@ -106,12 +105,11 @@ export class OneInchSwapProvider
 
   /** @see ISwapProvider.getSwapQuoteExactInput */
   async getSwapQuoteExactInput(params: {
-    chainInfo: IChainInfo
     fromAmount: ITokenAmount
     toToken: IToken
   }): Promise<QuoteData> {
     const swapUrl = this._formatOneInchQuoteUrl({
-      chainInfo: params.chainInfo,
+      chainInfo: params.fromAmount.token.chainInfo,
       fromTokenAmount: params.fromAmount,
       toToken: params.toToken,
     })

--- a/sdk/testing-utils/src/mocks/managers/SwapManagerMock.ts
+++ b/sdk/testing-utils/src/mocks/managers/SwapManagerMock.ts
@@ -1,4 +1,4 @@
-import { Address, ChainInfo, Percentage, Token, TokenAmount } from '@summerfi/sdk-common/common'
+import { Address, Percentage, Token, TokenAmount } from '@summerfi/sdk-common/common'
 import { SwapData, QuoteData, SwapProviderType } from '@summerfi/sdk-common/swap'
 import { ISwapManager, ISwapProvider } from '@summerfi/swap-common/interfaces'
 import { ManagerWithProvidersBase } from '@summerfi/sdk-server-common'
@@ -12,7 +12,6 @@ export class SwapManagerMock
 
   private _lastGetSwapDataExactInputParams:
     | {
-        chainInfo: ChainInfo
         fromAmount: TokenAmount
         toToken: Token
         recipient: Address
@@ -22,7 +21,6 @@ export class SwapManagerMock
 
   private _lastGetSwapQuoteExactInputParams:
     | {
-        chainInfo: ChainInfo
         fromAmount: TokenAmount
         toToken: Token
       }
@@ -51,7 +49,6 @@ export class SwapManagerMock
   }
 
   async getSwapDataExactInput(params: {
-    chainInfo: ChainInfo
     fromAmount: TokenAmount
     toToken: Token
     recipient: Address
@@ -62,7 +59,6 @@ export class SwapManagerMock
   }
 
   async getSwapQuoteExactInput(params: {
-    chainInfo: ChainInfo
     fromAmount: TokenAmount
     toToken: Token
   }): Promise<QuoteData> {
@@ -80,7 +76,6 @@ export class SwapManagerMock
 
   get lastGetSwapDataExactInputParams():
     | {
-        chainInfo: ChainInfo
         fromAmount: TokenAmount
         toToken: Token
         recipient: Address
@@ -92,7 +87,6 @@ export class SwapManagerMock
 
   get lastGetSwapQuoteExactInputParams():
     | {
-        chainInfo: ChainInfo
         fromAmount: TokenAmount
         toToken: Token
       }


### PR DESCRIPTION
- Convenience functions:
  - Price
    - Comparators with other price (`lessThan`, `isEqual`, etc...)
    - Static constructor to create a price from the ratio between 2 token amounts
  - Percentage
    - `toComplement` which yields the complementary percentage (100% - x)
- Fixed estimate swap calculations to use the worst price possible (worst case scenario) and to try to estimate an offer price that is as close to the real one as possible
- Improved error messages when a token or its emode is not found in AaveLike protocols