### PR TITLE
feat: Add server rendered leaderboard

### DIFF
--- a/apps/rays-dashboard/app/page.tsx
+++ b/apps/rays-dashboard/app/page.tsx
@@ -16,12 +16,20 @@ import { Leaderboard } from '@/components/organisms/Leaderboard/Leaderboard'
 import { NetworkNames, networksByName } from '@/constants/networks-list'
 import { LendingProtocol } from '@/helpers/lending-protocol'
 import { lendingProtocolsByName } from '@/helpers/lending-protocols-configs'
+import { fetchLeaderboard } from '@/server-handlers/leaderboard'
+import { LeaderboardResponse } from '@/types/leaderboard'
 
-export default function HomePage() {
+export default async function HomePage() {
   const aaveV3Config = lendingProtocolsByName[LendingProtocol.AaveV3]
+  const serverLeaderboardResponse = await fetchLeaderboard('?page=1&limit=5')
 
   return (
     <div style={{ display: 'flex', gap: '8px', flexDirection: 'column', alignItems: 'flex-start' }}>
+      <Leaderboard
+        serverLeaderboardResponse={
+          serverLeaderboardResponse.leaderboard as LeaderboardResponse['leaderboard']
+        }
+      />
       <Icon tokenName="ADAI" />
       <Icon iconName="arb" />
       <TokensGroup tokens={['CRV', 'AETHCBETH', 'CUSDCV3', 'XETH', 'DETH', 'GUNIV3DAIUSDC2']} />
@@ -79,7 +87,6 @@ export default function HomePage() {
       />
       <BoostCards />
       <Dial value={280} max={400} subtext="Eligible" icon="rays" iconSize={48} />
-      <Leaderboard />
     </div>
   )
 }

--- a/apps/rays-dashboard/components/organisms/Leaderboard/Leaderboard.tsx
+++ b/apps/rays-dashboard/components/organisms/Leaderboard/Leaderboard.tsx
@@ -62,7 +62,7 @@ export const Leaderboard: FC<LeaderboardProps> = ({
   const [debouncedInput, setDebouncedInput] = useState('')
 
   useEffect(() => {
-    if (page === 1 && !debouncedInput) {
+    if (page === 1) {
       return
     }
     setIsLoading(true)
@@ -87,7 +87,7 @@ export const Leaderboard: FC<LeaderboardProps> = ({
         setIsLoading(false)
         setFreshStart(false)
       })
-  }, [page, freshStart, pagination.limit, debouncedInput])
+  }, [page, pagination.limit])
 
   useEffect(() => {
     if (!debouncedInput) {

--- a/apps/rays-dashboard/components/organisms/Leaderboard/Leaderboard.tsx
+++ b/apps/rays-dashboard/components/organisms/Leaderboard/Leaderboard.tsx
@@ -62,7 +62,6 @@ export const Leaderboard: FC<LeaderboardProps> = ({
   const [debouncedInput, setDebouncedInput] = useState('')
 
   useEffect(() => {
-    console.log('page', page)
     if (page === 1 && !debouncedInput) {
       return
     }


### PR DESCRIPTION
This commit adds the server leaderboard to the homepage of the Rays Dashboard app. It fetches the leaderboard data from the server using the `fetchLeaderboard` function and displays it in the `Leaderboard` component. The leaderboard data is limited to the top 5 entries.