### PR TITLE
Update build commands for prebuild and build steps

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -71,10 +71,10 @@ jobs:
         run: pnpm install
 
       - name: Prebuild
-        run: pnpm prebuild
+        run: pnpm prebuild --filter=./packages/*
 
       - name: Build
-        run: pnpm build
+        run: pnpm build --filter=./packages/*
 
       - name: Deploy app
         run: |

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -73,10 +73,10 @@ jobs:
         run: pnpm install
 
       - name: Prebuild
-        run: pnpm prebuild
+        run: pnpm prebuild --filter=./packages/*
 
       - name: Build
-        run: pnpm build
+        run: pnpm build --filter=./packages/*
 
       - name: Deploy app
         run: |


### PR DESCRIPTION
This pull request updates the build commands for the prebuild and build steps. The `pnpm prebuild` and `pnpm build` commands now include a `--filter=./packages/*` flag to only build the files in the `packages` directory. This ensures that only the necessary files are built, improving the build process efficiency.