### PR TITLE
Update sst build commands for prebuild and build steps

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -34,7 +34,7 @@ const checkForUncommittedOrUntrackedChanges = async () => {
 const runInstallAndChecks = async () => {
   try {
     await $`pnpm install`
-    await $`pnpm run cicheck`
+    await $`pnpm run cicheck --filter=./packages/*`
   } catch (error) {
     echo(`cicheck failed: ${error.message}`)
     return false


### PR DESCRIPTION
This pull request updates the build commands for the prebuild and build steps in the sst project. The changes ensure that the cicheck script is only run for files in the packages directory.