### PR TITLE
Disable no-magic-numbers rule in eslint config

### DIFF
--- a/apps/rays-dashboard/.eslintrc.cjs
+++ b/apps/rays-dashboard/.eslintrc.cjs
@@ -8,4 +8,7 @@ module.exports = {
     sourceType: 'module',
     tsconfigRootDir: __dirname,
   },
+  rules: {
+    'no-magic-numbers': 'off',
+  },
 }

--- a/apps/rays-dashboard/app/claimed/page.tsx
+++ b/apps/rays-dashboard/app/claimed/page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers */
-
 import { formatAddress, Text } from '@summerfi/app-ui'
 import Image from 'next/image'
 

--- a/apps/rays-dashboard/components/molecules/CriteriaList/CriteriaList.tsx
+++ b/apps/rays-dashboard/components/molecules/CriteriaList/CriteriaList.tsx
@@ -1,5 +1,4 @@
 'use client'
-/* eslint-disable no-magic-numbers */
 import { useEffect, useState } from 'react'
 import { Card, Icon, SkeletonLine, Text, Tooltip } from '@summerfi/app-ui'
 import Link from 'next/link'

--- a/apps/rays-dashboard/components/molecules/WalletButton/WalletButton.tsx
+++ b/apps/rays-dashboard/components/molecules/WalletButton/WalletButton.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import { useLayoutEffect, useRef, useState } from 'react'
 import { Button, Divider, Text, WithArrow } from '@summerfi/app-ui'
 import { IconLogout, IconSettings } from '@tabler/icons-react'

--- a/apps/rays-dashboard/components/molecules/WalletButton/WalletButtonFallback.tsx
+++ b/apps/rays-dashboard/components/molecules/WalletButton/WalletButtonFallback.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import { Button, LoadingSpinner } from '@summerfi/app-ui'
 
 export const WalletButtonFallback = () => {

--- a/apps/rays-dashboard/components/organisms/Leaderboard/Leaderboard.tsx
+++ b/apps/rays-dashboard/components/organisms/Leaderboard/Leaderboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 'use client'
 
 import { ChangeEvent, FC, useEffect, useState } from 'react'

--- a/apps/rays-dashboard/components/organisms/Leaderboard/columns.tsx
+++ b/apps/rays-dashboard/components/organisms/Leaderboard/columns.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers */
-
 import { Button, Text } from '@summerfi/app-ui'
 import Link from 'next/link'
 

--- a/apps/rays-dashboard/constants/networks-list-ssr.ts
+++ b/apps/rays-dashboard/constants/networks-list-ssr.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-/* eslint-disable no-magic-numbers */
 import { keyBy } from 'lodash'
 
 import { NetworkConfig, NetworkHexIds, NetworkIds, NetworkNames } from '@/constants/networks-list'

--- a/apps/rays-dashboard/constants/networks-list.ts
+++ b/apps/rays-dashboard/constants/networks-list.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-/* eslint-disable no-magic-numbers */
 import { keyBy } from 'lodash'
 
 import { clientId } from '@/helpers/client-id'

--- a/apps/rays-dashboard/helpers/client-id.ts
+++ b/apps/rays-dashboard/helpers/client-id.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable no-bitwise */
-/* eslint-disable no-magic-numbers */
 
 export function getRandomString() {
   let randomString = ''

--- a/apps/rays-dashboard/helpers/formatters.ts
+++ b/apps/rays-dashboard/helpers/formatters.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers */
-
 import BigNumber from 'bignumber.js'
 
 export const minusOne = new BigNumber('-1')

--- a/apps/rays-dashboard/server-handlers/system-config/parsers/filter-featured-products.ts
+++ b/apps/rays-dashboard/server-handlers/system-config/parsers/filter-featured-products.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import { ProductHubFeaturedProducts, ProductHubItem } from '@/types/product-hub'
 
 interface FilterFeaturedProductsParams {

--- a/apps/rays-dashboard/server-handlers/system-config/parsers/map-navigation-link-item.ts
+++ b/apps/rays-dashboard/server-handlers/system-config/parsers/map-navigation-link-item.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers */
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { TokenSymbolsList } from '@summerfi/app-ui'
 
 import { lendingProtocolsByName } from '@/helpers/lending-protocols-configs'
@@ -48,6 +46,7 @@ export function mapNavigationLinkItem({
           ...(link && { url: link }),
           ...(featureFlag && { featureFlag }),
           ...('nestedLinks' in item &&
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             item.nestedLinks && {
               list: {
                 ...(item.nestedLinks.displayTitle && {

--- a/apps/rays-dashboard/server-handlers/system-config/parsers/map-top-borrow-product.ts
+++ b/apps/rays-dashboard/server-handlers/system-config/parsers/map-top-borrow-product.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import { TokenSymbolsList } from '@summerfi/app-ui'
 import BigNumber from 'bignumber.js'
 import { capitalize } from 'lodash'

--- a/apps/rays-dashboard/server-handlers/system-config/parsers/map-top-tokens.ts
+++ b/apps/rays-dashboard/server-handlers/system-config/parsers/map-top-tokens.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-/* eslint-disable no-magic-numbers */
 import { INTERNAL_LINKS } from '@summerfi/app-ui'
 import BigNumber from 'bignumber.js'
 


### PR DESCRIPTION
This pull request disables the `no-magic-numbers` rule in the eslint config. This rule is disabled to allow the use of magic numbers in the code. Magic numbers are hardcoded numeric values that are not assigned to a named constant. Disabling this rule can improve code readability and maintainability (?).