### PR TITLE
Add prod workflow

### DIFF
--- a/.github/workflows/deploy-rays-dashboard-production.yaml
+++ b/.github/workflows/deploy-rays-dashboard-production.yaml
@@ -1,0 +1,147 @@
+name: Deploy Rays Dashboard Production
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and deploy Rays Dashboard
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      AWS_REGION: eu-central-1
+      ENVIRONMENT_TAG: prod
+      SERVICE_NAME: summer-fi-rays-prod
+      CLUSTER_NAME: summer-fi-rays-prod
+      CONFIG_URL: ${{ secrets.CONFIG_URL }}
+      CONFIG_URL_RAYS: ${{ secrets.CONFIG_URL_RAYS }}
+      FUNCTIONS_API_URL: ${{ secrets.FUNCTIONS_API_URL }}
+      BORROW_DB_READ_CONNECTION_STRING: ${{ secrets.BORROW_DB_READ_CONNECTION_STRING }}
+      CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+      CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
+      CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 8.14.1
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Establish VPN connection
+        run: |
+          sudo apt update
+          sudo apt install -y openvpn openvpn-systemd-resolved
+          echo 'Configuring the VPN...'
+          echo "${{ secrets.VPN_CONFIG }}" > vpn-config.ovpn
+          echo "${{ secrets.VPN_USERNAME }}" > vpn-credentials.txt
+          echo "${{ secrets.VPN_PASSWORD }}" >> vpn-credentials.txt
+          echo 'Connecting to the VPN...'
+          sudo openvpn --config vpn-config.ovpn --auth-user-pass vpn-credentials.txt --daemon
+          sleep 5
+
+      - name: Check VPN connection
+        env:
+          BORROW_DB_READ_DB: ${{ secrets.BORROW_DB_READ_DB }}
+          BORROW_DB_READ_HOST: ${{ secrets.BORROW_DB_READ_HOST }}
+          BORROW_DB_READ_USER: ${{ secrets.BORROW_DB_READ_USER }}
+          BORROW_DB_READ_PASSWORD: ${{ secrets.BORROW_DB_READ_PASSWORD }}
+          PGCONNECT_TIMEOUT: 5
+        run: |
+          echo 'Checking the VPN connection...'
+          sudo systemctl start postgresql.service
+          PGPASSWORD=$BORROW_DB_READ_PASSWORD /usr/bin/psql -d $BORROW_DB_READ_DB -U $BORROW_DB_READ_USER -h $BORROW_DB_READ_HOST -c 'SELECT 1;' > /dev/null
+          STATUS_CODE=$?
+          if ! [[ "$STATUS_CODE" = 0 ]]; then
+            echo 'VPN connection failed'
+            exit 1
+          fi
+          echo 'VPN connected!'
+
+      - name: Extract commit hash
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Prebuild
+        run: pnpm prebuild
+
+      - name: Build
+        env:
+          CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+          CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
+          CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+        run: pnpm build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build docker image, copy build output and push to ECR
+        id: build-image
+        env:
+          LATEST_TAG: latest
+          ECR_REPO_NAME: summer-fi-rays-prod
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SHA_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build -f apps/rays-dashboard/docker/Dockerfile \
+                       --build-arg BORROW_DB_READ_CONNECTION_STRING=${{ secrets.BORROW_DB_READ_CONNECTION_STRING }} \
+                       --build-arg CONTENTFUL_SPACE_ID=${{ secrets.CONTENTFUL_SPACE_ID }} \
+                       --build-arg CONTENTFUL_ACCESS_TOKEN=${{ secrets.CONTENTFUL_ACCESS_TOKEN }} \
+                       --build-arg CONTENTFUL_PREVIEW_ACCESS_TOKEN=${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }} \
+                       --build-arg CONFIG_URL=${{ secrets.CONFIG_URL }} \
+                       --build-arg CONFIG_URL_RAYS=${{ secrets.CONFIG_URL_RAYS }} \
+                       --build-arg FUNCTIONS_API_URL=${{ secrets.FUNCTIONS_API_URL }} \
+                       --cache-from=$ECR_REGISTRY/$ECR_REPO_NAME:$LATEST_TAG \
+                       -t $ECR_REGISTRY/$ECR_REPO_NAME:$SHA_TAG \
+                       -t $ECR_REGISTRY/$ECR_REPO_NAME:$LATEST_TAG \
+                       -t $ECR_REGISTRY/$ECR_REPO_NAME:$ENVIRONMENT_TAG \
+                       ./apps/rays-dashboard
+          docker push $ECR_REGISTRY/$ECR_REPO_NAME --all-tags
+
+      - name: Update ECS service with latest Docker image
+        id: service-update
+        run: |
+          aws ecs update-service --cluster $CLUSTER_NAME --service ${{ env.SERVICE_NAME }} --force-new-deployment --region $AWS_REGION
+
+      - name: Wait for all services to become stable
+        uses: oryanmoshe/ecs-wait-action@v1.3
+        with:
+          ecs-cluster: ${{ env.CLUSTER_NAME }}
+          ecs-services: '["${{ env.SERVICE_NAME }}"]'
+
+      - name: Invalidate CloudFront
+        env:
+          CF_DIST_ID: ${{ secrets.CF_DIST_ID }}
+        run: |
+          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.CF_DIST_ID }} --paths "/*"


### PR DESCRIPTION
This pull request adds a production workflow for deploying the Rays Dashboard. The workflow includes steps for checking out the code, caching the turbo build setup, setting up the Node.js environment, establishing a VPN connection, installing dependencies, prebuilding, building, configuring AWS credentials, logging in to Amazon ECR, building a Docker image, pushing the image to ECR, updating the ECS service with the latest Docker image, waiting for all services to become stable, and invalidating CloudFront. This workflow will enable the deployment of the Rays Dashboard to the production environment.