### PR TITLE
Add validation for Mixpanel event types

### DIFF
--- a/apps/rays-dashboard/app/api/t/route.ts
+++ b/apps/rays-dashboard/app/api/t/route.ts
@@ -2,12 +2,20 @@ import { snakeCase } from 'lodash'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { trackEventHandler } from '@/server-handlers/mixpanel'
+import { MixpanelEventProduct, MixpanelEventTypes } from '@/types/mixpanel'
 
 export const revalidate = 0
 
 export async function POST(request: NextRequest) {
   try {
     const { distinctId, eventBody, eventName, ...rest } = await request.json()
+
+    if (
+      ![...Object.values(MixpanelEventTypes)].includes(eventName) ||
+      ![...Object.values(MixpanelEventProduct)].includes(eventBody.product)
+    ) {
+      return NextResponse.json({ status: 400 })
+    }
 
     trackEventHandler(`${eventName}`, {
       // eslint-disable-next-line camelcase


### PR DESCRIPTION
This pull request adds validation for Mixpanel event types and event products. If the event type or event product is not valid, a 400 response is returned. This helps ensure that only valid events are tracked in Mixpanel.