### PR TITLE
Rays calculator + Top climbers + visual polish

### DIFF
--- a/apps/rays-dashboard/app/page.tsx
+++ b/apps/rays-dashboard/app/page.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@summerfi/app-ui'
 import Link from 'next/link'
 
+import { TopClimbersWrapper } from '@/components/molecules/TopClimbers/TopClimbersWrapper'
 import ClaimRays from '@/components/organisms/ClaimRays/ClaimRays'
 import { HomepageHandler } from '@/components/organisms/HomepageHandler/HomepageHandler'
 import { mapLeaderboardColumns } from '@/components/organisms/Leaderboard/columns'
@@ -8,7 +9,11 @@ import { LeaderboardBanner } from '@/components/organisms/Leaderboard/components
 import { Leaderboard } from '@/components/organisms/Leaderboard/Leaderboard'
 import { LeaderboardSearchBoxAndResults } from '@/components/organisms/Leaderboard/LeaderboardSearchBoxAndResults'
 import { PageViewHandler } from '@/components/organisms/PageViewHandler/PageViewHandler'
-import { leaderboardDefaults, userLeaderboardDefaults } from '@/constants/leaderboard'
+import {
+  climbersCount,
+  leaderboardDefaults,
+  userLeaderboardDefaults,
+} from '@/constants/leaderboard'
 import { parseServerResponse } from '@/helpers/parse-server-response'
 import { fetchLeaderboard } from '@/server-handlers/leaderboard'
 import { fetchRays, RaysApiResponse } from '@/server-handlers/rays'
@@ -66,6 +71,12 @@ export default async function LeaderboardPage({
     page: '/',
   })
 
+  const topClimbers = await fetchLeaderboard({
+    page: '1',
+    limit: climbersCount.toString(),
+    sortMethod: 'top_gainers',
+  })
+
   return (
     <div style={{ display: 'flex', gap: '8px', flexDirection: 'column', alignItems: 'center' }}>
       <ClaimRays
@@ -101,6 +112,7 @@ export default async function LeaderboardPage({
           <LeaderboardBanner userWalletAddress={searchParams.userAddress} page="/" />
         </div>
       </div>
+      <TopClimbersWrapper topClimbers={topClimbers} />
       {/**
        * The HomepageHandler component handles the redirection after wallet is connected.
        * Now mixpanel tracking as well

--- a/apps/rays-dashboard/components/molecules/AnimatedNumber/AnimatedNumber.tsx
+++ b/apps/rays-dashboard/components/molecules/AnimatedNumber/AnimatedNumber.tsx
@@ -1,0 +1,33 @@
+import NumberComponent, {
+  AnimatedNumberProps as OriginalAnimatedNumberProps,
+} from 'react-awesome-animated-number'
+
+import 'react-awesome-animated-number/dist/index.css'
+
+type AnimatedNumberProps = {
+  number: number
+  size?: number
+  style?: React.CSSProperties
+  className?: string
+} & Omit<OriginalAnimatedNumberProps, 'value'>
+
+export const AnimatedNumber = ({
+  number,
+  size = 20,
+  style,
+  className,
+  duration,
+  ...rest
+}: AnimatedNumberProps) => {
+  return (
+    <NumberComponent
+      {...rest}
+      value={number}
+      hasComma
+      size={size}
+      duration={duration ?? 500}
+      style={style}
+      className={className}
+    />
+  )
+}

--- a/apps/rays-dashboard/components/molecules/ClaimRaysTitle/ClaimRaysTitle.tsx
+++ b/apps/rays-dashboard/components/molecules/ClaimRaysTitle/ClaimRaysTitle.tsx
@@ -34,9 +34,9 @@ export const ClaimRaysTitle = ({
 
   return (
     <>
-      <Text as="h2" variant="h2">
-        Wallet {formatAddress(userAddress)} is eligible for{' '}
-        {userRays.rays.allPossiblePoints > 0 ? `up to` : ''}{' '}
+      <Text as="h1" variant="h1" style={{ textAlign: 'center' }}>
+        Wallet {formatAddress(userAddress)} is eligible <br />
+        for {userRays.rays.allPossiblePoints > 0 ? `up to` : ''}{' '}
         {formatCryptoBalance(new BigNumber(userRays.rays.allPossiblePoints))} $RAYS
       </Text>
       {!!pointsEarnedPerYear && (

--- a/apps/rays-dashboard/components/molecules/Modal/ModalButton.module.scss
+++ b/apps/rays-dashboard/components/molecules/Modal/ModalButton.module.scss
@@ -1,0 +1,80 @@
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes overlayFadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes modalAppear {
+  from {
+    transform: translate(-50%, -50%) scale(0.9);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+@keyframes modalDisappear {
+  from {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translate(-50%, -50%) scale(0.9);
+    opacity: 0;
+  }
+}
+
+.modalWrapper {
+  position: fixed;
+  //centered on screen
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1001;
+  background-color: var(--color-neutral-10);
+  border-radius: var(--radius-16);
+  box-shadow: var(--shadow-depth-1);
+  max-height: 625px;
+  max-width: 455px;
+  width: 100%;
+  height: 100%;
+  padding: var(--space-xl);
+  animation: modalAppear 0.2s ease-in-out;
+  &.isModalWrapperClosing {
+    animation: modalDisappear 0.2s ease-in-out;
+  }
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.6);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  animation: overlayFadeIn 0.2s ease-in-out;
+  &.isOverlayClosing {
+    animation: overlayFadeOut 0.2s ease-in-out;
+  }
+}
+
+.closeButton {
+  position: absolute;
+  top: var(--space-s);
+  right: var(--space-s);
+  padding: var(--space-s);
+  cursor: pointer;
+}

--- a/apps/rays-dashboard/components/molecules/Modal/ModalButton.tsx
+++ b/apps/rays-dashboard/components/molecules/Modal/ModalButton.tsx
@@ -12,7 +12,7 @@ type ModalProps = {
 }
 
 export const ModalButton = ({ Button, ModalContent }: ModalProps) => {
-  const [isOpen, toggleModal] = useToggle(true)
+  const [isOpen, toggleModal] = useToggle(false)
   const [closing, setClosing] = useState(false)
 
   const handleModalClose = () => {

--- a/apps/rays-dashboard/components/molecules/Modal/ModalButton.tsx
+++ b/apps/rays-dashboard/components/molecules/Modal/ModalButton.tsx
@@ -1,0 +1,49 @@
+import { PropsWithChildren, useState } from 'react'
+import { IconX } from '@tabler/icons-react'
+import { useToggle } from 'usehooks-ts'
+
+import modalButtonStyles from './ModalButton.module.scss'
+
+export type ModalButtonProps = { onClick: () => void }
+
+type ModalProps = {
+  Button: React.ComponentType<PropsWithChildren<ModalButtonProps>>
+  ModalContent: React.ComponentType
+}
+
+export const ModalButton = ({ Button, ModalContent }: ModalProps) => {
+  const [isOpen, toggleModal] = useToggle(true)
+  const [closing, setClosing] = useState(false)
+
+  const handleModalClose = () => {
+    setClosing(true)
+    setTimeout(() => {
+      setTimeout(() => {
+        setClosing(false)
+      }, 100) // for a good measure = no flicker
+      toggleModal()
+    }, 200)
+  }
+
+  return (
+    <>
+      <Button onClick={toggleModal} />
+      {isOpen && (
+        <>
+          <div
+            className={`${modalButtonStyles.overlay} ${closing ? modalButtonStyles.isOverlayClosing : ''}`}
+            onClick={handleModalClose}
+          />
+          <div
+            className={`${modalButtonStyles.modalWrapper} ${closing ? modalButtonStyles.isModalWrapperClosing : ''}`}
+          >
+            <ModalContent />
+            <div className={modalButtonStyles.closeButton} onClick={handleModalClose}>
+              <IconX stroke={2} />
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  )
+}

--- a/apps/rays-dashboard/components/molecules/TopClimbers/TopClimbers.module.scss
+++ b/apps/rays-dashboard/components/molecules/TopClimbers/TopClimbers.module.scss
@@ -1,0 +1,82 @@
+.wrapper {
+  position: fixed;
+  bottom: var(--space-xxl);
+  right: var(--space-xxl);
+  box-shadow: var(--shadow-depth-1);
+  border-radius: var(--radius-16);
+  user-select: none;
+  background-color: var(--color-neutral-10);
+  transition: box-shadow 0.2s ease-in-out;
+  max-height: 80vh;
+  &:hover {
+    box-shadow: var(--shadow-depth-2);
+  }
+}
+
+.clickableHeader {
+  cursor: pointer;
+  padding: var(--space-l);
+}
+
+.flexRowCenter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.wrapperTitle {
+  margin-right: var(--space-xxxl)
+}
+
+.wrapperTime {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-xxs);
+  padding: var(--space-xs) var(--space-m);
+  background-color: var(--color-neutral-30);
+  border-radius: var(--radius-32);
+  color: var(--color-primary-60);
+  margin-right: var(--space-xxs);
+}
+
+.topClimbersListWrapper {
+  overflow-y: hidden;
+  transition: max-height 0.2s ease-in-out;
+}
+
+.topClimbersListRankRow {
+  padding-left: var(--space-l);
+  padding-right: var(--space-l);
+  margin-bottom: var(--space-l);
+  &:hover {
+    span.rankChangeInfo {
+      opacity: 0.5;
+    }
+  }
+}
+span.rankChangeInfo {
+  transition: opacity 0.2s ease-in-out;
+  margin-right: var(--space-l);
+}
+.topClimbersListRankRowLink {
+  width: 100%;
+  color: var(--color-neutral-80);
+}
+.topClimbersListRank {
+  width: 15%;
+  justify-content: space-between;
+  margin-right: var(--space-m);
+  color: var(--color-primary-100);
+}
+.topClimbersListRankChangeInfo {
+  word-break: keep-all;
+  white-space: nowrap;
+  opacity: 0;
+  text-align: right;
+}
+
+.topClimbersListRankChange {
+  color: var(--color-success-100);
+  stroke: var(--color-success-100);
+}

--- a/apps/rays-dashboard/components/molecules/TopClimbers/TopClimbers.tsx
+++ b/apps/rays-dashboard/components/molecules/TopClimbers/TopClimbers.tsx
@@ -1,0 +1,91 @@
+import { Text } from '@summerfi/app-ui'
+import { IconArrowRight, IconArrowUpRight, IconTrophyFilled } from '@tabler/icons-react'
+import { useConnectWallet } from '@web3-onboard/react'
+import Link from 'next/link'
+
+import { formatAddress } from '@/helpers/formatters'
+import { LeaderboardResponse } from '@/types/leaderboard'
+
+import topClimbersStyles from './TopClimbers.module.scss'
+
+export const TopClimbers = ({
+  topClimbers,
+  topClimbersOpen,
+  toggleTopClimbers,
+}: {
+  topClimbers?: LeaderboardResponse
+  topClimbersOpen: boolean
+  toggleTopClimbers: () => void
+}) => {
+  const [{ wallet }] = useConnectWallet()
+
+  return (
+    <div
+      className={topClimbersStyles.topClimbersListWrapper}
+      style={{
+        maxHeight: !topClimbersOpen ? 0 : `${(topClimbers?.leaderboard.length ?? 5) * 100}px`,
+      }}
+    >
+      {topClimbers?.leaderboard.map((entry, index) => (
+        <div
+          key={entry.userAddress}
+          className={`${topClimbersStyles.flexRowCenter} ${topClimbersStyles.topClimbersListRankRow}`}
+        >
+          <div
+            className={`${topClimbersStyles.flexRowCenter} ${topClimbersStyles.topClimbersListRank}`}
+          >
+            <Text variant="p2semi">{index + 1}</Text>
+            {[1, 2, 3].includes(index + 1) && (
+              <IconTrophyFilled
+                style={{ marginLeft: '4px' }}
+                color={
+                  {
+                    1: 'gold',
+                    2: 'silver',
+                    3: 'brown',
+                  }[(index + 1) as 1 | 2 | 3]
+                }
+              />
+            )}
+          </div>
+          <Link
+            href={{
+              pathname: '/',
+              query: { userAddress: entry.userAddress },
+            }}
+            onClick={toggleTopClimbers}
+            className={topClimbersStyles.topClimbersListRankRowLink}
+          >
+            <Text
+              variant={
+                wallet?.accounts[0].address.toLocaleLowerCase() ===
+                entry.userAddress.toLocaleLowerCase()
+                  ? 'p2semiColorful'
+                  : 'p2semi'
+              }
+            >
+              {entry.ens ?? formatAddress(entry.userAddress)}
+            </Text>
+          </Link>
+          <div className={topClimbersStyles.flexRowCenter}>
+            <Text
+              variant="p4"
+              className={`${topClimbersStyles.topClimbersListRankChangeInfo} ${topClimbersStyles.rankChangeInfo}`}
+            >
+              {entry.rank22h} <IconArrowRight size={10} style={{ marginBottom: '3px' }} />{' '}
+              {entry.rank}
+            </Text>
+            <IconArrowUpRight
+              size={16}
+              style={{ marginRight: '4px' }}
+              className={topClimbersStyles.topClimbersListRankChange}
+            />
+            <Text variant="p3semi" className={topClimbersStyles.topClimbersListRankChange}>
+              {Number(entry.rank22h) - Number(entry.rank)}
+            </Text>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/rays-dashboard/components/molecules/TopClimbers/TopClimbersWrapper.tsx
+++ b/apps/rays-dashboard/components/molecules/TopClimbers/TopClimbersWrapper.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Text } from '@summerfi/app-ui'
+import { IconChevronDown, IconChevronUp, IconClockHour3 } from '@tabler/icons-react'
+import { useToggle } from 'usehooks-ts'
+
+import { TopClimbers } from '@/components/molecules/TopClimbers/TopClimbers'
+import { climbersCount } from '@/constants/leaderboard'
+import { LeaderboardResponse } from '@/types/leaderboard'
+
+import topClimbersStyles from './TopClimbers.module.scss'
+
+export const TopClimbersWrapper = ({ topClimbers }: { topClimbers?: LeaderboardResponse }) => {
+  const [topClimbersOpen, toggleTopClimbers] = useToggle(false)
+
+  return topClimbers ? (
+    <div className={topClimbersStyles.wrapper}>
+      <div
+        className={`${topClimbersStyles.flexRowCenter} ${topClimbersStyles.clickableHeader}`}
+        onClick={toggleTopClimbers}
+      >
+        <Text as="h5" variant="h5" className={topClimbersStyles.wrapperTitle}>
+          Top {climbersCount} Biggest Climbers
+        </Text>
+        <div className={topClimbersStyles.flexRowCenter}>
+          <div className={topClimbersStyles.wrapperTime}>
+            <IconClockHour3 size={16} style={{ stroke: 'var(--color-primary-60)' }} />
+            <Text variant="p3semi">In last 24h</Text>
+          </div>
+          {topClimbersOpen ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
+        </div>
+      </div>
+      <TopClimbers
+        topClimbers={topClimbers}
+        topClimbersOpen={topClimbersOpen}
+        toggleTopClimbers={toggleTopClimbers}
+      />
+    </div>
+  ) : null
+}

--- a/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.module.scss
+++ b/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.module.scss
@@ -1,0 +1,17 @@
+.valuesWrapper {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  padding: var(--space-l) var(--space-l);
+}
+
+.valueBox {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.amountInput {
+  padding: var(--space-m) var(--space-m) var(--space-m) 50px;
+  width: 100%;
+  border-radius: var(--radius-8);
+}

--- a/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
+++ b/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button, Divider, Input, RadioButton, RadioButtonGroup, Text } from '@summerfi/app-ui'
+import BigNumber from 'bignumber.js'
+import { useToggle } from 'usehooks-ts'
+
+import { AnimatedNumber } from '@/components/molecules/AnimatedNumber/AnimatedNumber'
+import { ModalButton, ModalButtonProps } from '@/components/molecules/Modal/ModalButton'
+import { formatAsShorthandNumbers } from '@/helpers/formatters'
+
+const AmountTooHigh = ({ label }: { label: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
+    <Text as="h5" variant="h5" style={{ color: 'var(--color-primary-30)', marginTop: '8px' }}>
+      [̲̅$̲̅(̲̅ ͡° ͜ʖ ͡°̲̅)̲̅$̲̅]
+    </Text>
+    <Text as="p" variant="p3semi" style={{ color: 'var(--color-neutral-80)' }}>
+      {label}
+    </Text>
+  </div>
+)
+
+const CalculatorModalRaysValue = ({ value, label }: { value: number; label: string }) => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
+      <Text as="h4" variant="h4" style={{ color: 'var(--color-primary-30)' }}>
+        {value > 99999 ? (
+          <>{formatAsShorthandNumbers(new BigNumber(value), 1)}</>
+        ) : (
+          <AnimatedNumber number={Number(value.toPrecision(4))} size={28} hasComma duration={400} />
+        )}
+      </Text>
+      <Text as="p" variant="p3semi" style={{ color: 'var(--color-neutral-80)' }}>
+        {label}
+      </Text>
+    </div>
+  )
+}
+
+const CalculatorModalButton = (props: ModalButtonProps) => {
+  return (
+    <Button variant="secondaryLarge" {...props}>
+      Use $RAYS Calculator
+    </Button>
+  )
+}
+
+const CalculatorModalContent = () => {
+  const [amount, setAmount] = useState(0)
+  const [migration, setMigration] = useState<'true' | 'false'>('true')
+  const [calculatedValues, setCalculatedValues] = useState([0, 0, 0])
+
+  const calculateValues = () => {
+    const safeAmount = amount > 0 ? amount : 0
+    const basePoints = (safeAmount / 10000) * 690
+    const migrationBonus = migration === 'true' ? basePoints * 0.2 : 0
+    const totalPoints = basePoints + migrationBonus
+
+    setCalculatedValues([basePoints, migrationBonus, totalPoints])
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <Text as="h5" variant="h5" style={{ marginTop: '16px' }}>
+        $RAYS Calculator
+      </Text>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          padding: 'var(--space-l) var(--space-l)',
+        }}
+      >
+        {amount > 9999999999999 ? (
+          <>
+            <AmountTooHigh label="Base" />
+            <AmountTooHigh label="Migration" />
+            <AmountTooHigh label="Total" />
+          </>
+        ) : (
+          <>
+            <CalculatorModalRaysValue value={calculatedValues[0]} label="Base" />
+            <CalculatorModalRaysValue value={calculatedValues[1]} label="Migration" />
+            <CalculatorModalRaysValue value={calculatedValues[2]} label="Total" />
+          </>
+        )}
+      </div>
+      <Text as="p" variant="p3semi" style={{ margin: '32px 0 8px 0' }}>
+        Amount
+      </Text>
+      <Input
+        icon={{
+          name: 'dai_circle_color',
+          size: 24,
+        }}
+        value={amount || 0}
+        onChange={(e) => setAmount(parseFloat(e.target.value))}
+        style={{
+          padding: 'var(--space-m) var(--space-m) var(--space-m) 50px',
+          width: '100%',
+        }}
+      />
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <Text as="p" variant="p3semi" style={{ margin: '32px 0 8px 0' }}>
+          Migration
+        </Text>
+        <RadioButtonGroup
+          name="migration"
+          onChange={(nextMigration) => setMigration(nextMigration as 'true' | 'false')}
+          value={migration}
+          options={[
+            {
+              label: 'Yes',
+              value: 'true',
+            },
+            {
+              label: 'No',
+              value: 'false',
+            },
+          ]}
+        />
+      </div>
+      <Divider style={{ margin: '40px 0 20px 0' }} />
+      <Button
+        variant="secondaryLarge"
+        style={{ marginTop: 'var(--space-l)' }}
+        onClick={calculateValues}
+      >
+        Calculate $RAYS
+      </Button>
+    </div>
+  )
+}
+
+export const CalculatorModal = () => {
+  return <ModalButton Button={CalculatorModalButton} ModalContent={CalculatorModalContent} />
+}

--- a/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
+++ b/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { Button, Divider, Input, RadioButton, RadioButtonGroup, Text } from '@summerfi/app-ui'
+import { useState } from 'react'
+import { Button, Divider, Input, RadioButtonGroup, Text } from '@summerfi/app-ui'
 import { IconCurrencyDollar } from '@tabler/icons-react'
 import BigNumber from 'bignumber.js'
-import { useToggle } from 'usehooks-ts'
 
 import { AnimatedNumber } from '@/components/molecules/AnimatedNumber/AnimatedNumber'
 import { ModalButton, ModalButtonProps } from '@/components/molecules/Modal/ModalButton'

--- a/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
+++ b/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
@@ -65,7 +65,16 @@ const CalculatorModalContent = () => {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <form
+      style={{ display: 'flex', flexDirection: 'column' }}
+      onSubmit={calculateValues}
+      onKeyDown={(ev) => {
+        if (ev.key === 'Enter') {
+          ev.preventDefault()
+          calculateValues()
+        }
+      }}
+    >
       <Text as="h5" variant="h5" style={{ marginTop: '16px' }}>
         $RAYS Calculator
       </Text>
@@ -135,7 +144,7 @@ const CalculatorModalContent = () => {
       >
         Calculate $RAYS
       </Button>
-    </div>
+    </form>
   )
 }
 

--- a/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
+++ b/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
@@ -2,12 +2,18 @@
 
 import { useEffect, useState } from 'react'
 import { Button, Divider, Input, RadioButton, RadioButtonGroup, Text } from '@summerfi/app-ui'
+import { IconCurrencyDollar } from '@tabler/icons-react'
 import BigNumber from 'bignumber.js'
 import { useToggle } from 'usehooks-ts'
 
 import { AnimatedNumber } from '@/components/molecules/AnimatedNumber/AnimatedNumber'
 import { ModalButton, ModalButtonProps } from '@/components/molecules/Modal/ModalButton'
 import { formatAsShorthandNumbers } from '@/helpers/formatters'
+
+const amountTooHighValue = 9999999999999
+const amounttooHighLocked = 99999999999999 // same as above but with one more 9
+
+const DollarIconElement = () => <IconCurrencyDollar size={20} />
 
 const AmountTooHigh = ({ label }: { label: string }) => (
   <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
@@ -71,7 +77,7 @@ const CalculatorModalContent = () => {
           padding: 'var(--space-l) var(--space-l)',
         }}
       >
-        {amount > 9999999999999 ? (
+        {amount > amountTooHighValue ? (
           <>
             <AmountTooHigh label="Base" />
             <AmountTooHigh label="Migration" />
@@ -89,15 +95,17 @@ const CalculatorModalContent = () => {
         Amount
       </Text>
       <Input
-        icon={{
-          name: 'dai_circle_color',
-          size: 24,
-        }}
+        CustomIcon={DollarIconElement}
         value={amount || 0}
-        onChange={(e) => setAmount(parseFloat(e.target.value))}
+        onChange={(e) =>
+          setAmount(
+            parseFloat(e.target.value) > amounttooHighLocked ? amount : parseFloat(e.target.value),
+          )
+        }
         style={{
           padding: 'var(--space-m) var(--space-m) var(--space-m) 50px',
           width: '100%',
+          borderRadius: 'var(--radius-8)',
         }}
       />
       <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
+++ b/apps/rays-dashboard/components/organisms/CalculatorModal/CalculatorModal.tsx
@@ -9,15 +9,17 @@ import { AnimatedNumber } from '@/components/molecules/AnimatedNumber/AnimatedNu
 import { ModalButton, ModalButtonProps } from '@/components/molecules/Modal/ModalButton'
 import { formatAsShorthandNumbers } from '@/helpers/formatters'
 
+import calculatorModalStyles from './CalculatorModal.module.scss'
+
 const amountTooHighValue = 9999999999999
 const amounttooHighLocked = 99999999999999 // same as above but with one more 9
 
 const DollarIconElement = () => <IconCurrencyDollar size={20} />
 
 const AmountTooHigh = ({ label }: { label: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
+  <div className={calculatorModalStyles.valueBox}>
     <Text as="h5" variant="h5" style={{ color: 'var(--color-primary-30)', marginTop: '8px' }}>
-      [̲̅$̲̅(̲̅ ͡° ͜ʖ ͡°̲̅)̲̅$̲̅]
+      ( ͡~ ͜ʖ ͡°)
     </Text>
     <Text as="p" variant="p3semi" style={{ color: 'var(--color-neutral-80)' }}>
       {label}
@@ -27,7 +29,7 @@ const AmountTooHigh = ({ label }: { label: string }) => (
 
 const CalculatorModalRaysValue = ({ value, label }: { value: number; label: string }) => {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', textAlign: 'center' }}>
+    <div className={calculatorModalStyles.valueBox}>
       <Text as="h4" variant="h4" style={{ color: 'var(--color-primary-30)' }}>
         {value > 99999 ? (
           <>{formatAsShorthandNumbers(new BigNumber(value), 1)}</>
@@ -78,13 +80,7 @@ const CalculatorModalContent = () => {
       <Text as="h5" variant="h5" style={{ marginTop: '16px' }}>
         $RAYS Calculator
       </Text>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 1fr)',
-          padding: 'var(--space-l) var(--space-l)',
-        }}
-      >
+      <div className={calculatorModalStyles.valuesWrapper}>
         {amount > amountTooHighValue ? (
           <>
             <AmountTooHigh label="Base" />
@@ -110,11 +106,7 @@ const CalculatorModalContent = () => {
             parseFloat(e.target.value) > amounttooHighLocked ? amount : parseFloat(e.target.value),
           )
         }
-        style={{
-          padding: 'var(--space-m) var(--space-m) var(--space-m) 50px',
-          width: '100%',
-          borderRadius: 'var(--radius-8)',
-        }}
+        className={calculatorModalStyles.amountInput}
       />
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <Text as="p" variant="p3semi" style={{ margin: '32px 0 8px 0' }}>

--- a/apps/rays-dashboard/components/organisms/ClaimRays/ClaimRays.tsx
+++ b/apps/rays-dashboard/components/organisms/ClaimRays/ClaimRays.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation'
 
 import { ClaimRaysTitle } from '@/components/molecules/ClaimRaysTitle/ClaimRaysTitle'
 import { CriteriaList } from '@/components/molecules/CriteriaList/CriteriaList'
+import { CalculatorModal } from '@/components/organisms/CalculatorModal/CalculatorModal'
 import { trackButtonClick } from '@/helpers/mixpanel'
 import { useClientSideMount } from '@/helpers/use-client-side-mount'
 import { RaysApiResponse } from '@/server-handlers/rays'
@@ -151,6 +152,7 @@ export default ({ userAddress, userRays, pointsEarnedPerYear }: ClaimRaysPagePro
           Connect wallet
         </Button>
       )}
+      <CalculatorModal />
       <Text
         as="p"
         variant="p1"

--- a/apps/rays-dashboard/components/organisms/ClaimRays/ClaimRays.tsx
+++ b/apps/rays-dashboard/components/organisms/ClaimRays/ClaimRays.tsx
@@ -82,13 +82,6 @@ export default ({ userAddress, userRays, pointsEarnedPerYear }: ClaimRaysPagePro
         userRays={userRays}
         pointsEarnedPerYear={pointsEarnedPerYear}
       />
-      <Text
-        as="p"
-        variant="p1"
-        style={{ color: 'var(--color-neutral-80)', marginBottom: 'var(--space-l)' }}
-      >
-        Over 2 million DeFi users are eligible for Summer.fi Rays.
-      </Text>
       <CriteriaList userRays={userRays} />
 
       {mountedOnClient && typeof userAddress !== 'undefined' && isViewingOwnWallet && (
@@ -158,6 +151,13 @@ export default ({ userAddress, userRays, pointsEarnedPerYear }: ClaimRaysPagePro
           Connect wallet
         </Button>
       )}
+      <Text
+        as="p"
+        variant="p1"
+        style={{ color: 'var(--color-neutral-80)', marginTop: 'var(--space-l)' }}
+      >
+        Over 2 million DeFi users are eligible for Summer.fi Rays.
+      </Text>
     </>
   )
 }

--- a/apps/rays-dashboard/constants/leaderboard.ts
+++ b/apps/rays-dashboard/constants/leaderboard.ts
@@ -21,3 +21,8 @@ export const wholeLeaderboardDefaults = {
   page: '1',
   limit: '100',
 }
+
+/**
+ * Default values for the climbers count
+ */
+export const climbersCount = 5

--- a/apps/rays-dashboard/package.json
+++ b/apps/rays-dashboard/package.json
@@ -37,6 +37,7 @@
     "next-intl": "^3.15.2",
     "pino-pretty": "^11.2.1",
     "react": "^18.3.1",
+    "react-awesome-animated-number": "^1.0.13",
     "react-dom": "^18.3.1",
     "usehooks-ts": "^3.1.0"
   },

--- a/apps/rays-dashboard/server-handlers/leaderboard/index.ts
+++ b/apps/rays-dashboard/server-handlers/leaderboard/index.ts
@@ -1,3 +1,4 @@
+'use server'
 import { LeaderboardResponse } from '@/types/leaderboard'
 
 export const fetchLeaderboard = async (

--- a/packages/app-ui/src/components/atoms/Icon/iconsProxy.tsx
+++ b/packages/app-ui/src/components/atoms/Icon/iconsProxy.tsx
@@ -218,3 +218,7 @@ export const search_icon = lazy.lib(() => import('../../../tokens/icons/search_i
 export const tooltip = lazy.lib(() => import('../../../tokens/icons/tooltip'))
 export const checkmark_colorful = lazy.lib(() => import('../../../tokens/icons/checkmark_colorful'))
 export const close_colorful = lazy.lib(() => import('../../../tokens/icons/close_colorful'))
+export const radio_button = lazy.lib(() => import('../../../tokens/icons/radio_button'))
+export const radio_button_checked = lazy.lib(
+  () => import('../../../tokens/icons/radio_button_checked'),
+)

--- a/packages/app-ui/src/components/atoms/Input/Input.tsx
+++ b/packages/app-ui/src/components/atoms/Input/Input.tsx
@@ -14,13 +14,19 @@ export const Input: FC<
       name: IconNamesList
       size?: number
     }
+    CustomIcon?: FC
   }
-> = ({ variant = 'default', className, icon, ...rest }) => {
+> = ({ variant = 'default', className, CustomIcon, icon, ...rest }) => {
   return (
     <div className={classNames.wrapper}>
       {icon && (
         <div className={classNames.iconWrapper}>
           <Icon iconName={icon.name} size={icon.size} variant="s" />
+        </div>
+      )}
+      {CustomIcon && (
+        <div className={classNames.iconWrapper}>
+          <CustomIcon />
         </div>
       )}
       <input

--- a/packages/app-ui/src/components/atoms/RadioButton/RadioButton.module.scss
+++ b/packages/app-ui/src/components/atoms/RadioButton/RadioButton.module.scss
@@ -1,0 +1,37 @@
+.radioButtonWrapper {
+  display: flex;
+  position: relative;
+  align-items: center;
+  margin-right: 10px;
+  width: 100%;
+  border-radius: var(--radius-12);
+  background-color: var(--color-neutral-10);
+  border: 1px solid #E4EAED;
+  box-shadow: none;
+  transition: border 0.2s, box-shadow 0.2s;
+  padding: var(--space-m) var(--space-xs) var(--space-m) var(--space-m);
+  user-select: none;
+  &:hover {
+    border: 1px solid #afafaf;
+  }
+  &.radioButtonWrapperChecked {
+    border: 1px solid #25273D;
+    box-shadow: var(--shadow-depth-2);
+  }
+}
+
+.radio {
+  display: none;
+}
+
+.label {
+  position:absolute;
+  padding-left: 60px;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/app-ui/src/components/atoms/RadioButton/RadioButton.module.scss.d.ts
+++ b/packages/app-ui/src/components/atoms/RadioButton/RadioButton.module.scss.d.ts
@@ -1,0 +1,12 @@
+export type Styles = {
+  label: string
+  radio: string
+  radioButtonWrapper: string
+  radioButtonWrapperChecked: string
+}
+
+export type ClassNames = keyof Styles
+
+declare const styles: Styles
+
+export default styles

--- a/packages/app-ui/src/components/atoms/RadioButton/RadioButton.tsx
+++ b/packages/app-ui/src/components/atoms/RadioButton/RadioButton.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import React from 'react'
+import classNames from 'classnames'
+
+import { Icon } from '@/components/atoms/Icon/Icon'
+import { Text } from '@/components/atoms/Text/Text'
+
+import radioButtonStyles from './RadioButton.module.scss'
+
+export const RadioButton = ({
+  name,
+  value,
+  checked,
+  onChange,
+  label,
+  className,
+  style,
+}: {
+  name: string
+  value: string
+  checked: boolean
+  onChange: (value: string) => void
+  label: string
+  className?: string
+  style?: React.CSSProperties
+}) => {
+  return (
+    <div
+      className={classNames(radioButtonStyles.radioButtonWrapper, className, {
+        [radioButtonStyles.radioButtonWrapperChecked]: checked,
+      })}
+      style={style}
+    >
+      {checked ? <Icon iconName="radio_button_checked" /> : <Icon iconName="radio_button" />}
+      <input
+        type="radio"
+        id={value}
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={(e) => onChange(e.target.value)}
+        className={radioButtonStyles.radio}
+      />
+      <label htmlFor={value} className={radioButtonStyles.label}>
+        <Text as="p" variant="p3semi">
+          {label}
+        </Text>
+      </label>
+    </div>
+  )
+}

--- a/packages/app-ui/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/app-ui/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import React from 'react'
+
+import { RadioButton } from '@/components/atoms/RadioButton/RadioButton'
+
+export const RadioButtonGroup = ({
+  name,
+  options,
+  value,
+  onChange,
+  vertical = false,
+}: {
+  name: string
+  options: { value: string; label: string }[]
+  value: string
+  onChange: (value: string) => void
+  vertical?: boolean
+}) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: vertical ? 'column' : 'row',
+        justifyContent: 'space-between',
+        width: '100%',
+      }}
+    >
+      {options.map((option) => (
+        <RadioButton
+          key={option.value}
+          name={name}
+          value={option.value}
+          checked={value === option.value}
+          onChange={onChange}
+          label={option.label}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/app-ui/src/index.ts
+++ b/packages/app-ui/src/index.ts
@@ -2,29 +2,31 @@
 export { GlobalStyles } from './GlobalStyles'
 
 export { Button } from './components/atoms/Button/Button'
-export { Text } from './components/atoms/Text/Text'
-export { Icon } from './components/atoms/Icon/Icon'
 export { Card } from './components/atoms/Card/Card'
 export { Divider } from './components/atoms/Divider/Divider'
-export { Pill } from './components/atoms/Pill/Pill'
 export { GenericTokenIcon } from './components/atoms/GenericTokenIcon/GenericTokenIcon'
+export { Icon } from './components/atoms/Icon/Icon'
 export { Input } from './components/atoms/Input/Input'
-export { SkeletonLine } from './components/atoms/SkeletonLine/SkeletonLine'
-export { WithArrow } from './components/atoms/WithArrow/WithArrow'
-export { Select } from './components/atoms/Select/Select'
+export { Pill } from './components/atoms/Pill/Pill'
 export { ProxyLinkComponent } from './components/atoms/ProxyLinkComponent/ProxyLinkComponent'
+export { RadioButton } from './components/atoms/RadioButton/RadioButton'
+export { Select } from './components/atoms/Select/Select'
+export { SkeletonLine } from './components/atoms/SkeletonLine/SkeletonLine'
+export { Text } from './components/atoms/Text/Text'
+export { WithArrow } from './components/atoms/WithArrow/WithArrow'
 
-export { TokensGroup } from './components/molecules/TokensGroup/TokensGroup'
-export { ProtocolLabel } from './components/molecules/ProtocolLabel/ProtocolLabel'
-export { Tooltip } from './components/molecules/Tooltip/Tooltip'
-export { LoadingSpinner } from './components/molecules/Loader/Loader'
 export { AutomationIcon } from './components/molecules/AutomationIcon/AutomationIcon'
 export { BannerCard } from './components/molecules/BannerCard/BannerCard'
 export { Dial } from './components/molecules/Dial/Dial'
+export { LoadingSpinner } from './components/molecules/Loader/Loader'
+export { ProtocolLabel } from './components/molecules/ProtocolLabel/ProtocolLabel'
+export { RadioButtonGroup } from './components/molecules/RadioButtonGroup/RadioButtonGroup'
 export { Table } from './components/molecules/Table/Table'
+export { TokensGroup } from './components/molecules/TokensGroup/TokensGroup'
+export { Tooltip } from './components/molecules/Tooltip/Tooltip'
 
-export { LaunchBanner } from './components/organisms/LaunchBanner/LaunchBanner'
 export { CountDownBanner } from './components/organisms/CountDownBanner/CountDownBanner'
+export { LaunchBanner } from './components/organisms/LaunchBanner/LaunchBanner'
 
 export { Footer } from './components/layout/Footer/Footer'
 
@@ -40,10 +42,10 @@ export { formatAddress } from './helpers/format-address'
 export type { IconNamesList, TokenSymbolsList, TokenConfig } from './tokens/types'
 export { tokenConfigs } from './tokens/config'
 export {
+  getToken,
+  getTokenDisplayName,
+  getTokenGuarded,
+  getTokens,
   tokens,
   tokensBySymbol,
-  getTokenDisplayName,
-  getToken,
-  getTokens,
-  getTokenGuarded,
 } from './tokens/helpers'

--- a/packages/app-ui/src/tokens/icons/radio_button.tsx
+++ b/packages/app-ui/src/tokens/icons/radio_button.tsx
@@ -1,0 +1,14 @@
+export default {
+  path: (
+    <rect
+      x="0.5"
+      y="0.909729"
+      width="25"
+      height="25"
+      rx="12.5"
+      stroke="#CAD6DB"
+      fill="transparent"
+    />
+  ),
+  viewBox: '0 0 26 27',
+}

--- a/packages/app-ui/src/tokens/icons/radio_button_checked.tsx
+++ b/packages/app-ui/src/tokens/icons/radio_button_checked.tsx
@@ -1,0 +1,18 @@
+export default {
+  path: (
+    <g fill="none">
+      <rect x="5.5" y="5.40973" width="16" height="16" rx="8" fill="#1AAB9B" stroke="transparent" />
+      <rect
+        x="1.5"
+        y="1.40973"
+        width="24"
+        height="24"
+        rx="12"
+        stroke="#1AAB9B"
+        fill="transparent"
+        strokeWidth="2"
+      />
+    </g>
+  ),
+  viewBox: '0 0 27 27',
+}

--- a/packages/app-ui/src/tokens/types/index.ts
+++ b/packages/app-ui/src/tokens/types/index.ts
@@ -184,6 +184,8 @@ export type IconNamesList =
   | 'tooltip'
   | 'checkmark_colorful'
   | 'close_colorful'
+  | 'radio_button'
+  | 'radio_button_checked'
 
 export type TokenSymbolsList =
   | 'USDP'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
         version: 2.41.5
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.7)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.4.5)
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -210,6 +210,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-awesome-animated-number:
+        specifier: ^1.0.13
+        version: 1.0.13(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -926,7 +929,7 @@ importers:
         version: 8.57.0
       kysely-codegen:
         specifier: ^0.15.0
-        version: 0.15.0(kysely@0.27.3)
+        version: 0.15.0(kysely@0.27.3)(pg@8.11.5)
       tsx:
         specifier: ^4.9.0
         version: 4.9.3
@@ -23588,46 +23591,6 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /kysely-codegen@0.15.0(kysely@0.27.3):
-    resolution: {integrity: sha512-LPta2nQOyoEPDQ3w/Gsplc+2iyZPAsGvtWoS21VzOB0NDQ0B38Xy1gS8WlbGef542Zdw2eLJHxekud9DzVdNRw==}
-    hasBin: true
-    peerDependencies:
-      '@libsql/kysely-libsql': ^0.3.0
-      '@tediousjs/connection-string': ^0.5.0
-      better-sqlite3: '>=7.6.2'
-      kysely: ^0.27.0
-      kysely-bun-worker: ^0.5.3
-      mysql2: ^2.3.3 || ^3.0.0
-      pg: ^8.8.0
-      tarn: ^3.0.0
-      tedious: ^16.6.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@libsql/kysely-libsql':
-        optional: true
-      '@tediousjs/connection-string':
-        optional: true
-      better-sqlite3:
-        optional: true
-      kysely-bun-worker:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      tarn:
-        optional: true
-      tedious:
-        optional: true
-    dependencies:
-      chalk: 4.1.2
-      dotenv: 16.4.5
-      dotenv-expand: 11.0.6
-      git-diff: 2.0.6
-      kysely: 0.27.3
-      micromatch: 4.0.7
-      minimist: 1.2.8
-    dev: true
-
   /kysely-codegen@0.15.0(kysely@0.27.3)(pg@8.11.5):
     resolution: {integrity: sha512-LPta2nQOyoEPDQ3w/Gsplc+2iyZPAsGvtWoS21VzOB0NDQ0B38Xy1gS8WlbGef542Zdw2eLJHxekud9DzVdNRw==}
     hasBin: true
@@ -26245,6 +26208,17 @@ packages:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  /react-awesome-animated-number@1.0.13(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-Qx/T9MLKMwxkyTGpy7uUO859UqBqH6yy4IIWFPJVo5hdz5e2bWlfZDOgs1P8F+6dvnfAs57JXyRt2UOj+7E+6Q==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@babel/runtime': 7.24.7
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /react-dom@18.3.1(react@18.3.1):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -28506,6 +28480,41 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
+
+  /ts-jest@29.1.2(@babel/core@7.24.4)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.24.4
+      bs-logger: 0.2.6
+      esbuild: 0.20.2
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.12.7)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.2
+      typescript: 5.4.5
+      yargs-parser: 20.2.2
+    dev: true
 
   /ts-jest@29.1.2(@babel/core@7.24.7)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.4.5):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}

--- a/summerfi-api/get-rays-leaderboard-function/src/index.ts
+++ b/summerfi-api/get-rays-leaderboard-function/src/index.ts
@@ -45,7 +45,11 @@ export const handler = async (
     .selectFrom('leaderboard_new')
     .selectAll()
     .where((eb) =>
-      eb.or([eb('userAddress', 'like', `%${userAddress}%`), eb('ens', 'like', `%${userAddress}%`)]),
+      eb.or(
+        sortMethod === 'top_gainers'
+          ? [eb('totalPoints', '>', '2000')]
+          : [eb('userAddress', 'like', `%${userAddress}%`), eb('ens', 'like', `%${userAddress}%`)],
+      ),
     )
     .orderBy(() => {
       if (sortMethod === 'top_gainers') {


### PR DESCRIPTION
This pull request adds a new `sortMethod` parameter to the `get-rays-leaderboard-function`. The function now supports sorting the leaderboard by top gainers. The default sorting is by total points. This change allows for more flexibility in displaying the leaderboard data.

Update leaderboard UI and add top climbers section

Added rays calculator