### PR TITLE
Add tooltips to MigrateProductCardPositionInfo and MigrateProductCardTitle components

### DIFF
--- a/apps/rays-dashboard/components/molecules/MigrateProductCard/MigrateProductCardPositionInfo.tsx
+++ b/apps/rays-dashboard/components/molecules/MigrateProductCard/MigrateProductCardPositionInfo.tsx
@@ -1,5 +1,6 @@
 import { type PortfolioMigrations, type TokenSymbolsList } from '@summerfi/app-types'
-import { Text, TokensGroup } from '@summerfi/app-ui'
+import { Text, TokensGroup, Tooltip } from '@summerfi/app-ui'
+import { IconHelpCircle } from '@tabler/icons-react'
 import BigNumber from 'bignumber.js'
 
 import { formatAsShorthandNumbers } from '@/helpers/formatters'
@@ -31,9 +32,24 @@ export const MigrateProductCardPositionInfo = ({
       <TokensGroup tokens={[tokens[0]]} />
     </div>
     <div>
-      <Text variant="p4semi" className={migrateProductCardStyles.heading}>
-        Balance of Supplied
-      </Text>
+      <Tooltip
+        tooltip={
+          <Text as="span" variant="p4">
+            The total amount of your supplied asset(s), expressed in{' '}
+            {migration.collateralAsset.symbol}.
+          </Text>
+        }
+        tooltipWrapperStyles={{ minWidth: '200px' }}
+      >
+        <Text variant="p4semi" className={migrateProductCardStyles.heading}>
+          Balance of Supplied
+        </Text>
+        <IconHelpCircle
+          size={14}
+          strokeWidth={2}
+          style={{ marginTop: '3px', marginLeft: '5px', stroke: 'var(--color-neutral-80)' }}
+        />
+      </Tooltip>
       <Text variant="p1semi">{getMigrationTokenValue(migration.collateralAsset)}</Text>
     </div>
     <div>
@@ -43,9 +59,23 @@ export const MigrateProductCardPositionInfo = ({
       <TokensGroup tokens={[tokens[1]]} />
     </div>
     <div>
-      <Text variant="p4semi" className={migrateProductCardStyles.heading}>
-        Balance of Borrowed
-      </Text>
+      <Tooltip
+        tooltip={
+          <Text as="span" variant="p4">
+            The total amount of your borrowed asset(s), expressed in {migration.debtAsset.symbol}.
+          </Text>
+        }
+        tooltipWrapperStyles={{ minWidth: '200px' }}
+      >
+        <Text variant="p4semi" className={migrateProductCardStyles.heading}>
+          Balance of Borrowed
+        </Text>
+        <IconHelpCircle
+          size={14}
+          strokeWidth={2}
+          style={{ marginTop: '3px', marginLeft: '5px', stroke: 'var(--color-neutral-80)' }}
+        />
+      </Tooltip>
       <Text variant="p1semi">{getMigrationTokenValue(migration.debtAsset)}</Text>
     </div>
   </div>

--- a/apps/rays-dashboard/components/molecules/MigrateProductCard/MigrationProductCardTitle.tsx
+++ b/apps/rays-dashboard/components/molecules/MigrateProductCard/MigrationProductCardTitle.tsx
@@ -59,6 +59,7 @@ export const MigrateProductCardTitle = ({
               </Text>
             </div>
           }
+          tooltipWrapperStyles={{ minWidth: '130px' }}
         >
           <BlockLabel label={`${formatRaysPoints(totalPoints)} RAYS`} variant="colorful" />
         </Tooltip>

--- a/packages/app-ui/src/components/molecules/Tooltip/Tooltip.module.scss
+++ b/packages/app-ui/src/components/molecules/Tooltip/Tooltip.module.scss
@@ -14,7 +14,8 @@
   font-size: 12px;
   font-weight: 500;
   border-radius: var(--radius-12);
-  white-space: nowrap;
+  width: 100px;
+  max-width: 400px;
 }
 
 .tooltip {


### PR DESCRIPTION
This pull request adds tooltips to the `MigrateProductCardPositionInfo` and `MigrateProductCardTitle` components. The tooltips provide additional information about the balance of supplied and borrowed assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added tooltips to the balance headings in the Migration Product Card for better context on supplied and borrowed assets.
	- Introduced a new prop for the tooltip styling to improve layout consistency.

- **Style Enhancements**
	- Updated tooltip styles to manage width and allow text wrapping for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->