### PR TITLE
chore: add eth points bonanza

### DIFF
--- a/background-jobs/update-rays-cron-function/src/point-accrual.ts
+++ b/background-jobs/update-rays-cron-function/src/point-accrual.ts
@@ -83,6 +83,8 @@ export class SummerPointsService {
   private NET_VALUE_CAP = 10000000
   private START_POINTS_TIMESTAMP
 
+  private ETH_TOKEN_BONANZA_END = 1722470399
+
   /**
    * Creates an instance of SummerPointsService.
    * @param clients - An array of clients for fetching data from the summer points subgraph.
@@ -285,6 +287,8 @@ export class SummerPointsService {
         const migrationPoints = this.getMigrationPoints(position.migration)
         const swapPoints = swapMultiplier * this.getSwapPoints(position.recentSwaps)
 
+        const ethTokenMultiplier = this.ethTokenPositionMultiplier(position)
+
         const timeOpenMultiplier = this.getTimeOpenMultiplier(position, endTimestamp)
         const automationProtectionMultiplier = this.getAutomationProtectionMultiplier(position)
         const lazyVaultMultiplier = this.getLazyVaultMultiplier(position)
@@ -292,7 +296,8 @@ export class SummerPointsService {
           protocolBoostMultiplier *
           timeOpenMultiplier *
           automationProtectionMultiplier *
-          lazyVaultMultiplier
+          lazyVaultMultiplier *
+          ethTokenMultiplier
 
         return {
           vaultId: position.account.vaultId,
@@ -441,6 +446,24 @@ export class SummerPointsService {
     }
 
     return migrationPoints
+  }
+
+  ethTokenPositionMultiplier(position: Position): number {
+    let multiplier = 1
+    if (Date.now() / 1000 > this.ETH_TOKEN_BONANZA_END) {
+      return multiplier
+    }
+    if (position.debtToken && position.debtToken.symbol.toLowerCase().includes('eth')) {
+      multiplier = 2
+    } else if (
+      position.collateralToken &&
+      position.collateralToken.symbol.toLowerCase().includes('eth')
+    ) {
+      multiplier = 2
+    } else if (position.supplyToken && position.supplyToken.symbol.toLowerCase().includes('weth')) {
+      multiplier = 2
+    }
+    return multiplier
   }
 
   /**

--- a/packages/summer-events-subgraph/queries/get-points.graphql
+++ b/packages/summer-events-subgraph/queries/get-points.graphql
@@ -11,6 +11,15 @@ query SummerPoints(
     allPositions: positions {
       id
       netValue
+      debtToken {
+        symbol
+      }
+      collateralToken {
+        symbol
+      }
+      supplyToken {
+        symbol
+      }
       triggers(
         where: {
           or: [
@@ -26,6 +35,15 @@ query SummerPoints(
       id
       protocol
       marketId
+      debtToken {
+        symbol
+      }
+      collateralToken {
+        symbol
+      }
+      supplyToken {
+        symbol
+      }
       account {
         id
         vaultId

--- a/packages/summer-events-subgraph/schema.graphql
+++ b/packages/summer-events-subgraph/schema.graphql
@@ -1341,6 +1341,11 @@ type Position {
   protocol: String!
   marketId: String!
   positionType: String
+
+  debtToken: Token
+  collateralToken: Token
+  supplyToken: Token
+
   cumulativeDepositedUSD: BigDecimal!
   cumulativeWithdrawnUSD: BigDecimal!
   cumulativeDeltaUSD: BigDecimal!


### PR DESCRIPTION
adds a `2x` multiplier to all eth positions until  timesatmp = `1722470399`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced points calculation to incorporate Ethereum token dynamics, potentially increasing points earned based on token holdings.
  - Expanded GraphQL query and schema to include new fields (debtToken, collateralToken, supplyToken) for more detailed financial data retrieval.

- **Bug Fixes**
  - Improved accuracy and tracking of token multipliers in points calculations.

- **Chores**
  - Added a commit reference in the contracts repository for better version tracking and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->