### PR TITLE
Add Icon component color prop

### DIFF
--- a/apps/rays-dashboard/components/molecules/CriteriaList/CriteriaList.tsx
+++ b/apps/rays-dashboard/components/molecules/CriteriaList/CriteriaList.tsx
@@ -100,7 +100,7 @@ export const CriteriaList = ({ userRays }: CriteriaListProps) => {
                     style={{ color: 'var(--color-primary-60' }}
                     tooltipWrapperStyles={{ minWidth: '300px' }}
                   >
-                    <Icon iconName="tooltip" size={17} />
+                    <Icon iconName="tooltip" size={17} color="gray" />
                   </Tooltip>
                 </div>
                 <Text

--- a/packages/app-ui/src/components/atoms/Icon/Icon.tsx
+++ b/packages/app-ui/src/components/atoms/Icon/Icon.tsx
@@ -16,6 +16,7 @@ export interface IconPropsBase {
   tokenName?: TokenSymbolsList
   style?: React.CSSProperties
   proxyStyle?: React.CSSProperties
+  color?: string
 }
 
 export interface IconPropsWithIconName extends IconPropsBase {
@@ -71,6 +72,7 @@ export const Icon: FC<IconPropsWithIconName | IconPropsWithTokenName> = ({
   size,
   style,
   proxyStyle,
+  color,
 }) => {
   const [errorLoading, setErrorLoading] = useState(false)
   const finalSize =
@@ -90,6 +92,8 @@ export const Icon: FC<IconPropsWithIconName | IconPropsWithTokenName> = ({
 
   const LazyIconComponent = iconProxies[iconName]
 
+  const colorSet = color ?? style?.stroke
+
   return (
     <LazyIconComponent
       fallback={
@@ -104,7 +108,7 @@ export const Icon: FC<IconPropsWithIconName | IconPropsWithTokenName> = ({
       {({ default: iconData }: { default: string }) =>
         iconData && !errorLoading ? (
           <Image
-            src={iconData}
+            src={colorSet ? iconData.replaceAll('currentColor', colorSet) : iconData}
             color="inherit"
             alt={iconName}
             role={role}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `color` prop for the `Icon` component, allowing users to customize the icon's color dynamically.
	- Updated the `CriteriaList` component to use the new `color` prop in its `Icon` representation for enhanced visual consistency.

- **Bug Fixes**
	- Improved icon rendering to correctly apply specified colors, ensuring better alignment with design requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->