### PR TITLE
Add getRaysDailyChallengeData function and integrate it into fetchRays

### DIFF
--- a/apps/rays-dashboard/helpers/get-rays-daily-challenge-data.ts
+++ b/apps/rays-dashboard/helpers/get-rays-daily-challenge-data.ts
@@ -1,0 +1,72 @@
+import dayjs from 'dayjs'
+
+export const dailyRaysAmount = 10
+export const bonusRaysAmount = 30
+
+export const getRaysDailyChallengeDateFormat = () => dayjs().format('YYYY-MM-DD')
+
+// this function is taken from oasis-borrow, if you make changes here you should also update it there
+export const getRaysDailyChallengeData = (claimedDates?: string[]) => {
+  if (!claimedDates) {
+    return {
+      dailyChallengeRays: 0,
+      streakRays: 0,
+      allBonusRays: 0,
+      currentStreak: 0,
+      streaks: 0,
+    }
+  }
+  // every day the user claims the daily challenge, they get 100 points
+  // every 7 consecutive days, the user gets a 500 points bonus
+  const dailyChallengeRays = claimedDates.length * dailyRaysAmount
+
+  const consecutiveDaysMap = claimedDates
+    .sort((a, b) => {
+      return dayjs(a).isBefore(dayjs(b)) ? -1 : 1
+    })
+    .reduce((acc, date, index, array) => {
+      // if it is the first date, we will always have a streak of 1
+      if (index === 0) {
+        return acc.set(date, 1)
+      }
+      // if the difference between the current date and the previous date is 1 day
+      // we will increment the streak by 1
+      if (dayjs(date).diff(dayjs(array[index - 1]), 'day') === 1) {
+        if (acc.get(array[index - 1]) === 7) {
+          // if the previous streak was 7, we will not increment the streak
+          return acc.set(date, 1)
+        }
+
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        return acc.set(date, (acc.get(array[index - 1]) || 0) + 1)
+      }
+
+      // if the difference between the current date and the previous date is not 1 day
+      // we will start a new streak of 1
+      return acc.set(date, 1)
+    }, new Map<string, number>())
+
+  // all we need is to filter the values that are equal to 7
+  const streaks = Array.from(consecutiveDaysMap.values()).filter((streak) => streak === 7).length
+
+  // and we can reuse the consecutiveDaysMap for the current streak
+  // returning the last value of the map for today or yesterday (the case if not claimed today)
+  const currentStreak =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    consecutiveDaysMap.get(getRaysDailyChallengeDateFormat()) ||
+    consecutiveDaysMap.get(
+      dayjs(getRaysDailyChallengeDateFormat()).subtract(1, 'day').format('YYYY-MM-DD'),
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    ) ||
+    0
+
+  const streakRays = streaks * bonusRaysAmount
+
+  return {
+    dailyChallengeRays,
+    streakRays,
+    allBonusRays: dailyChallengeRays + streakRays,
+    currentStreak,
+    streaks,
+  }
+}

--- a/apps/rays-dashboard/server-handlers/rays/index.ts
+++ b/apps/rays-dashboard/server-handlers/rays/index.ts
@@ -1,14 +1,27 @@
 import { type RaysApiResponse } from '@summerfi/app-types'
 
+import { getRaysDailyChallengeData } from '@/helpers/get-rays-daily-challenge-data'
+import { prisma } from '@/helpers/prisma-client'
+
 export const fetchRays = async (query: { [key: string]: string } | string) => {
   try {
     const urlParams = new URLSearchParams(query)
+    const address = urlParams.get('address')
 
-    if (urlParams.get('address') === null) {
+    if (address === null) {
       return {
         error: 'No address provided',
       }
     }
+
+    const dailyChallengeData = await prisma.raysDailyChallenge.findUnique({
+      where: {
+        address: address.toLocaleLowerCase(),
+      },
+    })
+
+    const calculatedData = getRaysDailyChallengeData(dailyChallengeData?.claimed_dates)
+
     const rays = (await fetch(`${process.env.FUNCTIONS_API_URL}/api/rays?${urlParams.toString()}`, {
       method: 'GET',
       next: { revalidate: 60, tags: [urlParams.toString()] },
@@ -17,7 +30,12 @@ export const fetchRays = async (query: { [key: string]: string } | string) => {
       },
     }).then((resp) => resp.json())) as RaysApiResponse
 
-    return { rays }
+    return {
+      rays: {
+        ...rays,
+        allPossiblePoints: rays.allPossiblePoints + calculatedData.allBonusRays,
+      },
+    }
   } catch (e) {
     return {
       error: e,

--- a/packages/app-db/prisma/schema.prisma
+++ b/packages/app-db/prisma/schema.prisma
@@ -351,3 +351,11 @@ enum AjnaRewardsPositionType {
 
   @@map("ajna_rewards_position_type")
 }
+
+model RaysDailyChallenge {
+  id             Int               @id @default(autoincrement())
+  address        String            @unique
+  claimed_dates  String[]
+
+  @@map("rays_daily_challenge")
+}

--- a/summerfi-api/get-rays-leaderboard-function/src/index.ts
+++ b/summerfi-api/get-rays-leaderboard-function/src/index.ts
@@ -33,7 +33,6 @@ export const handler = async (
   if (!RAYS_DB_CONNECTION_STRING) {
     throw new Error('RAYS_DB_CONNECTION_STRING is not set')
   }
-  console.log(RAYS_DB_CONNECTION_STRING)
   logger.addContext(context)
 
   const parsedResult = queryParamsSchema.safeParse(event.queryStringParameters || {})


### PR DESCRIPTION
This pull request adds a new function called `getRaysDailyChallengeData` that calculates the daily challenge points. It also integrates this function into the `fetchRays` function, updating the `rays` response object with the calculated data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to calculate rewards for user participation in daily challenges, including streak tracking.
  - Enhanced the fetchRays function to incorporate daily challenge data and calculate possible points.
  - Added a new database model to track daily challenges associated with user addresses.

- **Bug Fixes**
  - Improved readability and functionality of the fetchRays function by refining address handling.

- **Chores**
  - Removed sensitive information logging to enhance security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->