### PR TITLE
chore: Update protocol-plugins reexport

### DIFF
--- a/sdk/sdk-client/src/protocol-plugins-reexport.ts
+++ b/sdk/sdk-client/src/protocol-plugins-reexport.ts
@@ -1,31 +1,7 @@
 // WORKAROUND: re-exporting protocol-plugins to give FE access to protocol plugins types
 
-export {
-  AaveV3LendingPoolId,
-  AaveV3LendingPosition,
-  AaveV3LendingPositionId,
-  isAaveV3LendingPoolId,
-  type IAaveV3LendingPoolId,
-} from '@summerfi/protocol-plugins/plugins/aave-v3'
+export * from '@summerfi/protocol-plugins/plugins/aave-v3'
 export { EmodeType } from '@summerfi/protocol-plugins/plugins/common'
-export {
-  MakerLendingPoolId,
-  MakerLendingPosition,
-  MakerLendingPositionId,
-  isMakerLendingPoolId,
-  type IMakerLendingPoolId,
-} from '@summerfi/protocol-plugins/plugins/maker'
-export {
-  MorphoLendingPoolId,
-  MorphoLendingPosition,
-  MorphoLendingPositionId,
-  isMorphoLendingPoolId,
-  type IMorphoLendingPoolId,
-} from '@summerfi/protocol-plugins/plugins/morphoblue'
-export {
-  SparkLendingPoolId,
-  SparkLendingPosition,
-  SparkLendingPositionId,
-  isSparkLendingPoolId,
-  type ISparkLendingPoolId,
-} from '@summerfi/protocol-plugins/plugins/spark'
+export * from '@summerfi/protocol-plugins/plugins/maker'
+export * from '@summerfi/protocol-plugins/plugins/morphoblue'
+export * from '@summerfi/protocol-plugins/plugins/spark'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined export process for protocol plugin types, enhancing maintainability and reducing redundancy.
	- Improved organization of exports for Aave, Maker, Morpho, and Spark protocols.
  
- **Bug Fixes**
	- Resolved inconsistencies in export declarations, ensuring smoother integration and functionality across protocol plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->