### PR TITLE
Triggering e2e tests when deploying to staging

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -84,3 +84,15 @@ jobs:
       - name: Deploy app
         run: |
           pnpm run sst:deploy:staging
+      - name: Trigger e2e tests in e2e-tests repository
+        env:
+          E2E_TESTS_PAT: ${{ secrets.E2E_TESTS_PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.E2E_TESTS_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml/dispatches \
+            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\"}}"
+          echo 'See test results in https://github.com/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml --> Job with RUN_ID ${{ github.run_id }} in the logs.'

--- a/.github/workflows/e2e-tests-result.yaml
+++ b/.github/workflows/e2e-tests-result.yaml
@@ -1,0 +1,29 @@
+name: Staging E2E tests result
+
+on: 
+  workflow_dispatch:
+    inputs:
+      tests_run_id:
+        description: 'E2E tests run_id'
+        type: string
+        required: true
+      tests_result:
+        description: 'E2E tests result -- failure | success'
+        type: string
+        required: true
+
+jobs:
+  e2e-tests-result:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Link to tests run -> https://github.com/OasisDEX/e2e-tests/actions/runs/${{ inputs.tests_run_id }}
+        run: echo 'See tests results in https://github.com/OasisDEX/e2e-tests/actions/runs/${{ inputs.tests_run_id }}'
+      - name: E2E tests failed
+        if: ${{ inputs.tests_result == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('E2E tests failed - Link to tests run https://github.com/OasisDEX/e2e-tests/actions/runs/${{ inputs.tests_run_id }}')
+      - name: E2E tests passed
+        if: ${{ inputs.tests_result == 'success' }}
+        run: echo 'E2E tests passed'


### PR DESCRIPTION
## Description
Triggering e2e tests when deploying to staging, and getting test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job step in the deployment workflow to trigger end-to-end (e2e) tests after application deployment.
	- Added a new workflow for reporting e2e test results, allowing manual triggering and input for test run ID and results.

- **Bug Fixes**
	- Enhanced error handling and reporting for e2e test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->