### PR TITLE
Refactor getMorphoBluePosition to safely retrieve token symbols

### DIFF
--- a/packages/triggers-calculations/src/get-morphoblue-position.ts
+++ b/packages/triggers-calculations/src/get-morphoblue-position.ts
@@ -22,6 +22,25 @@ export const MB_ORACLE_DECIMALS = 36
 const VIRTUAL_SHARES = TEN ** 6n
 const VIRTUAL_ASSETS = 1n
 
+async function safeSymbolCall(token: Address, publicClient: PublicClient): Promise<string> {
+  // MKR is not regular ERC20 and the symbol is in bytes32
+  // so we need to hardcode it
+  if (token.toLowerCase() === '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2') {
+    return 'MKR'
+  }
+  const symbol = await publicClient.multicall({
+    contracts: [
+      {
+        abi: erc20Abi,
+        address: token,
+        functionName: 'symbol',
+      },
+    ],
+    allowFailure: false,
+  })
+  return symbol[0]
+}
+
 function mulDivDown(x: bigint, y: bigint, d: bigint): bigint {
   return (x * y) / d
 }
@@ -120,9 +139,7 @@ export async function getMorphoBluePosition(
     [, , totalBorrowAssets, totalBorrowShares],
     [, borrowShares, collateralAmount],
     collateralDecimals,
-    collateralSymbol,
     debtDecimals,
-    debtSymbol,
   ] = await publicClient.multicall({
     contracts: [
       {
@@ -150,22 +167,14 @@ export async function getMorphoBluePosition(
       },
       {
         abi: erc20Abi,
-        address: collateral,
-        functionName: 'symbol',
-      },
-      {
-        abi: erc20Abi,
         address: debt,
         functionName: 'decimals',
-      },
-      {
-        abi: erc20Abi,
-        address: debt,
-        functionName: 'symbol',
       },
     ],
     allowFailure: false,
   })
+  const collateralSymbol = await safeSymbolCall(collateral, publicClient)
+  const debtSymbol = await safeSymbolCall(debt, publicClient)
   const [oraclePrice] = await publicClient.multicall({
     contracts: [
       {


### PR DESCRIPTION
This pull request refactors the `getMorphoBluePosition` function to safely retrieve token symbols. Previously, there was no hardcoded check for the MKR token, but now the function uses the `safeSymbolCall` function to retrieve the symbol for any token. This ensures that the function works correctly for all ERC20/nonERC20 tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous function for improved token symbol retrieval, enhancing error handling for the MKR token.
	- Simplified the process of obtaining collateral and debt token symbols in the position calculation.

- **Bug Fixes**
	- Improved handling of token symbol retrieval to prevent potential errors with non-standard tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->