### PR TITLE
Fix for sending E2E test results to correct trigger repository

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -94,5 +94,5 @@ jobs:
             -H "Authorization: Bearer ${{ env.E2E_TESTS_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml/dispatches \
-            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\"}}"
+            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\", \"repository\":\"${{ github.repository }}\"}}"
           echo 'See test results in https://github.com/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml --> Job with RUN_ID ${{ github.run_id }} in the logs.'


### PR DESCRIPTION
## Description
Fix for sending E2E test results to correct trigger repository

## Changes
Sending repository name with dispatch event


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the payload in the deployment workflow to include repository context for enhanced end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->