### PR TITLE
Fix logging flag condition for SDK logging

### DIFF
--- a/sdk/sdk-server/src/SDKTRPC.ts
+++ b/sdk/sdk-server/src/SDKTRPC.ts
@@ -12,7 +12,7 @@ export const createCallerFactory = t.createCallerFactory
 
 export const publicProcedure = t.procedure.use(async (opts) => {
   const { getRawInput, path, type } = opts
-  if (process.env.SDK_LOGGING_ENABLED) {
+  if (process.env.SDK_LOGGING_ENABLED === 'true') {
     console.log('- path => ', path)
     console.log('- type => ', type)
     console.log('- rawInput => ', await getRawInput())


### PR DESCRIPTION
This PR updates the condition for the SDK logging flag to ensure that logging only occurs when the environment variable `SDK_LOGGING_ENABLED` is explicitly set to 'true'. This change improves the clarity and reliability of the logging functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging conditions to ensure accurate logging based on environment settings.
  
- **Chores**
	- Refined internal logic for better clarity and functionality without altering public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->