### PR TITLE
Adding E2E tests trigger to SDK and Rays - Deploying to staging

### DIFF
--- a/.github/workflows/deploy-rays-dashboard-staging.yaml
+++ b/.github/workflows/deploy-rays-dashboard-staging.yaml
@@ -172,3 +172,15 @@ jobs:
           CF_DIST_ID: ${{ secrets.CF_DIST_ID }}
         run: |
           AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ env.CF_DIST_ID }} --paths "/*"
+      - name: Trigger e2e tests in e2e-tests repository
+        env:
+          E2E_TESTS_PAT: ${{ secrets.E2E_TESTS_PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.E2E_TESTS_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml/dispatches \
+            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\", \"repository\":\"${{ github.repository }}\"}}"
+          echo 'See test results in https://github.com/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml --> Job with RUN_ID ${{ github.run_id }} in the logs.'

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -76,3 +76,15 @@ jobs:
       - name: Deploy app
         run: |
           pnpm run sst:deploy:sdk:staging
+      - name: Trigger e2e tests in e2e-tests repository
+        env:
+          E2E_TESTS_PAT: ${{ secrets.E2E_TESTS_PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.E2E_TESTS_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml/dispatches \
+            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\", \"repository\":\"${{ github.repository }}\"}}"
+          echo 'See test results in https://github.com/OasisDEX/e2e-tests/actions/workflows/ci_e2e_tests.yml --> Job with RUN_ID ${{ github.run_id }} in the logs.'


### PR DESCRIPTION
## Description
Adding E2E tests trigger to SDK and Rays - Deploying to staging



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automated end-to-end (e2e) testing steps for the Rays Dashboard and SDK deployments to the staging environment.
	- Enhanced deployment workflows to trigger e2e tests in a separate repository post-deployment, improving testing efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->