### PR TITLE
Full turbo

### DIFF
--- a/.github/workflows/build-integration-test.yaml
+++ b/.github/workflows/build-integration-test.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - dev
-      
+
 jobs:
   build:
     name: Build and Integration Test
@@ -21,20 +21,16 @@ jobs:
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
       MIXPANEL_KEY: ${{ secrets.MIXPANEL_KEY }}
       NEXT_PUBLIC_MIXPANEL_KEY: ${{ secrets.NEXT_PUBLIC_MIXPANEL_KEY }}
-      SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}    
+      SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:
@@ -79,11 +75,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Prebuild
-        run: pnpm prebuild
-
-      - name: Build
-        run: pnpm build
+        # there was build and prebuild step here, but it was removed
+        # because integration tests are dependent on the build step
 
       - name: Test
         run: pnpm test:integration
@@ -104,4 +97,4 @@ jobs:
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}        
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-integration-test.yaml
+++ b/.github/workflows/build-integration-test.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Build and Integration Test
 on:
   pull_request:
     types: [opened, synchronize]

--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Build and Unit Test
 on:
   pull_request:
     types: [opened, synchronize]

--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -20,20 +20,15 @@ jobs:
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
       MIXPANEL_KEY: ${{ secrets.MIXPANEL_KEY }}
       NEXT_PUBLIC_MIXPANEL_KEY: ${{ secrets.NEXT_PUBLIC_MIXPANEL_KEY }}
-      SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}    
+      SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:
@@ -78,11 +73,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Prebuild
-        run: pnpm prebuild
-
-      - name: Build
-        run: pnpm build
+        # there was build and prebuild step here, but it was removed
+        # because test/lint/format tasks are dependent on the build step
 
       - name: Test
         run: pnpm test
@@ -108,4 +100,4 @@ jobs:
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}            
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deploy-earn-protocol-landing-page-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-staging.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Cache turbo build setup (alternative)
+      - name: Set up turbo cache
         uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1

--- a/.github/workflows/deploy-earn-protocol-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-staging.yaml
@@ -63,13 +63,8 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -41,17 +41,13 @@ jobs:
       CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
       CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-rays-dashboard-production.yaml
+++ b/.github/workflows/deploy-rays-dashboard-production.yaml
@@ -21,20 +21,15 @@ jobs:
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
       MIXPANEL_KEY: ${{ secrets.MIXPANEL_KEY }}
       NEXT_PUBLIC_MIXPANEL_KEY: ${{ secrets.NEXT_PUBLIC_MIXPANEL_KEY }}
-      SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}    
+      SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-rays-dashboard-staging.yaml
+++ b/.github/workflows/deploy-rays-dashboard-staging.yaml
@@ -48,19 +48,15 @@ jobs:
       NEXT_PUBLIC_MIXPANEL_KEY: ${{ secrets.NEXT_PUBLIC_MIXPANEL_KEY }}
       SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}
       SDK_API_URL: ${{ secrets.SDK_API_URL }}
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-sdk-production.yaml
+++ b/.github/workflows/deploy-sdk-production.yaml
@@ -39,13 +39,8 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@v3
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -39,13 +39,8 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@v3
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -42,17 +42,13 @@ jobs:
       CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
       CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.5
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/packages/app-earn-ui/src/components/atoms/Box/Box.module.scss
+++ b/packages/app-earn-ui/src/components/atoms/Box/Box.module.scss
@@ -1,8 +1,8 @@
 .box {
   display: flex;
   background-color: var(--color-surface-subtle);
-  border-radius: var(--radius-roundish);
   padding: var(--general-space-24);
+  border-radius: var(--radius-roundish);
   &.light {
     background-color: var(--color-surface-subtler);
   }

--- a/turbo.json
+++ b/turbo.json
@@ -130,9 +130,6 @@
     },
     "deploy:staging": {
       "dependsOn": ["cicheck", "^deploy:staging"]
-    },
-    "coverage:total": {
-      "dependsOn": ["test", "test:integration", "^coverage:total"]
     }
   }
 }


### PR DESCRIPTION
Refactor build workflows to better utilize turbo caching

- replaced `actions/cache` with `rharkor/caching-for-turbo` which works way better (works at all I guess)
- removed `prebuild` and `build` steps from CI tasks
- added more descriptive names to the CI tasks (they were both just called "CI")
- removed `coverage:total` config from turbo, because its not even a turbo running task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new caching mechanism for turbo builds across various workflows to enhance build efficiency.
	- Added new environment variables for Contentful in the staging deployment workflow.

- **Bug Fixes**
	- Corrected indentation for environment variables in the Rays Dashboard production deployment workflow.

- **Documentation**
	- Updated naming conventions for caching steps to improve clarity across deployment workflows.

- **Chores**
	- Streamlined CI workflows by removing unnecessary build steps and restructuring job dependencies.
	- Enhanced event handling capabilities for CI workflows by updating trigger conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->