### PR TITLE
Earn protocol - Landing page - data-testid properties for e2e tests

### DIFF
--- a/packages/app-earn-ui/src/components/molecules/StrategyTitle/StrategyTitle.tsx
+++ b/packages/app-earn-ui/src/components/molecules/StrategyTitle/StrategyTitle.tsx
@@ -36,7 +36,10 @@ export const StrategyTitle: FC<StrategyTitleProps> = ({
       <div style={{ display: 'flex', alignItems: 'center', position: 'relative' }}>
         <Icon tokenName={symbol} variant="xxl" />
         {(networkId ?? networkName) && (
-          <div style={{ position: 'absolute', top: '-3px', left: '-3px' }}>
+          <div
+            style={{ position: 'absolute', top: '-3px', left: '-3px' }}
+            data-testid="strategy-network"
+          >
             {networkId && networkIdIconMap[networkId]}
             {networkName && networkNameIconMap[networkName]}
           </div>
@@ -44,7 +47,12 @@ export const StrategyTitle: FC<StrategyTitleProps> = ({
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <Text as="h4" variant="h4" style={{ color: 'white', fontSize: '24px', lineHeight: '30px' }}>
+        <Text
+          as="h4"
+          variant="h4"
+          style={{ color: 'white', fontSize: '24px', lineHeight: '30px' }}
+          data-testid="strategy-token"
+        >
           {symbol}
         </Text>
         {value && <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>{value}</div>}


### PR DESCRIPTION
## Description
Adding data-testid properties for e2e tests - Earn protocol - Landing page

## Changes
- data-testid="strategy-network"
- data-testid="strategy-token"

## Benefits
1. With these properties it's much easier to locate elements when automating e2e tests.

## Testing
New properties can be seen by running Earn protocol's landing page locally.
![Screenshot 2024-10-22 at 12 56 32](https://github.com/user-attachments/assets/22f131f4-020e-418c-96b5-7b3a38756939)
![Screenshot 2024-10-22 at 12 56 10](https://github.com/user-attachments/assets/8cc0f053-737e-4bdb-bbb0-52675b2d1c4a)



Please review and provide any feedback or suggestions for improvement.
