### PR TITLE
Update subgraphNameByChainMap for Arbitrum chain

### DIFF
--- a/sdk/subgraph-manager-common/src/utils/subgraphNameByChainMap.ts
+++ b/sdk/subgraph-manager-common/src/utils/subgraphNameByChainMap.ts
@@ -2,5 +2,5 @@ import { ChainId } from '@summerfi/serverless-shared'
 
 export const subgraphNameByChainMap: Partial<Record<ChainId, string>> = {
   [ChainId.BASE]: 'summer-protocol-base',
-  [ChainId.ARBITRUM]: 'summer-protocol-artitrum',
+  [ChainId.ARBITRUM]: 'summer-protocol-arbitrum',
 }

--- a/sdk/subgraph-manager-common/src/utils/subgraphNameByChainMap.ts
+++ b/sdk/subgraph-manager-common/src/utils/subgraphNameByChainMap.ts
@@ -2,4 +2,5 @@ import { ChainId } from '@summerfi/serverless-shared'
 
 export const subgraphNameByChainMap: Partial<Record<ChainId, string>> = {
   [ChainId.BASE]: 'summer-protocol-base',
+  [ChainId.ARBITRUM]: 'summer-protocol-artitrum',
 }


### PR DESCRIPTION
This pull request includes a change to the `subgraphNameByChainMap` in the `subgraphNameByChainMap.ts` file to add support for the Arbitrum chain.

* [`sdk/subgraph-manager-common/src/utils/subgraphNameByChainMap.ts`](diffhunk://#diff-ce401ececd8dc45d2cc22c264c7fef8b935a2a7e1a5d61ce207165b67bc4118fR5): Added `ChainId.ARBITRUM` to the `subgraphNameByChainMap` to support the Arbitrum chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the Arbitrum chain by mapping `ChainId.ARBITRUM` to the subgraph name `'summer-protocol-arbitrum'`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->