### PR TITLE
Add Savings USDs token to StaticTokensList

### DIFF
--- a/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
+++ b/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
@@ -215,6 +215,14 @@ export const StaticTokensData: TokenListData = {
       logoURI: '',
     },
     {
+      name: 'Staked USDs',
+      address: '0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD',
+      symbol: 'sUSDs',
+      decimals: 18,
+      chainId: 1,
+      logoURI: '',
+    },
+    {
       name: 'USDA',
       address: '0x0000206329b97DB379d5E1Bf586BbDB969C63274',
       symbol: 'USDA',

--- a/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
+++ b/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
@@ -215,7 +215,7 @@ export const StaticTokensData: TokenListData = {
       logoURI: '',
     },
     {
-      name: 'Staked USDs',
+      name: 'Savings USDs',
       address: '0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD',
       symbol: 'sUSDs',
       decimals: 18,


### PR DESCRIPTION
Add Savings USDs token to StaticTokensList

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new cryptocurrency token: "Savings USDs" (sUSDs) to the token list.
	- This token is now available for use on the Ethereum Mainnet with specified properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->