### PR TITLE
Add Discord notifications for SDK deployment start and success

### DIFF
--- a/.github/workflows/deploy-sdk-production.yaml
+++ b/.github/workflows/deploy-sdk-production.yaml
@@ -38,6 +38,20 @@ jobs:
       CONFIG_URL: ${{ secrets.CONFIG_URL }}
       CONFIG_URL_RAYS: ${{ secrets.CONFIG_URL_RAYS }}
     steps:
+      - name: Send start notification to Discord
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
+          DISCORD_EMBEDS:
+            '[{"title":"Link to GitHub Action:
+            ${{github.run_id}}","url":"https://github.com/${{github.repository}}/actions/runs/${{github.run_id
+            }}"}]'
+        with:
+          args:
+            'SDK deployment `${{github.run_id}}` started on production 🚀 (from branch `${{
+            github.ref_name }}` by [${{github.triggering_actor
+            }}](https://github.com/${{github.triggering_actor }}).'
+
       - name: Git clone the repository
         uses: actions/checkout@v3
 
@@ -72,3 +86,10 @@ jobs:
       - name: Deploy app
         run: |
           pnpm run sst:deploy:sdk:prod
+
+      - name: Send success notification to Discord
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
+        with:
+          args: 'SDK deployment `${{github.run_id}}` finished successfully on staging 🎉\n '

--- a/.github/workflows/deploy-sdk-production.yaml
+++ b/.github/workflows/deploy-sdk-production.yaml
@@ -92,4 +92,4 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
-          args: 'SDK deployment `${{github.run_id}}` finished successfully on staging 🎉\n '
+          args: 'SDK deployment `${{github.run_id}}` finished successfully on production 🎉\n '

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -46,8 +46,8 @@ jobs:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
             [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}) ->
-            [${{github.run_id }}](https://github.com/${{ github.repository}}/actions/runs/${{
-            github.run_id }}))'
+            [${{github.run_id }}](https://github.com/${{
+            github.repository}}/actions/runs/${{github.run_id }}))'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,7 +44,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            'SDK deployment ([${{github.run_id }}](github.com/${{
+            'SDK deployment ([${{github.run_id }}](https://github.com/${{
             github.repository}}/actions/runs/${{ github.run_id }})) started on staging 🚀 (from
             branch `${{ github.ref_name }}` by [${{github.triggering_actor
             }}](https://github.com/${{github.triggering_actor }})).'

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -42,13 +42,11 @@ jobs:
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
-          DISCORD_EMBEDS: ''
+          DISCORD_EMBEDS: '{"embeds":[{"title":"Google it!","url":"https://google.com/"}]}'
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
-            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}) -
-            [${{github.run_id
-            }}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id }})).'
+            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -45,9 +45,9 @@ jobs:
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
-            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}) ->
-            [${{github.run_id }}](https://github.com/${{
-            github.repository}}/actions/runs/${{github.run_id }}))'
+            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}) -
+            [${{github.run_id
+            }}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id }}))'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -38,6 +38,15 @@ jobs:
       CONFIG_URL: ${{ secrets.CONFIG_URL }}
       CONFIG_URL_RAYS: ${{ secrets.CONFIG_URL_RAYS }}
     steps:
+      - name: Send start notification to Discord
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
+        with:
+          args:
+            'SDK deployment started on staging ...\n (from ${{ github.ref }} by
+            ${{github.triggering_actor }}).'
+
       - name: Git clone the repository
         uses: actions/checkout@v3
 
@@ -73,6 +82,16 @@ jobs:
       - name: Deploy app
         run: |
           pnpm run sst:deploy:sdk:staging
+
+      - name: Send success notification to Discord
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
+        with:
+          args:
+            'SDK deployed successfully on staging 🎉\n (from ${{ github.ref }} by
+            ${{github.triggering_actor }}).'
+
       - name: Trigger e2e tests in e2e-tests repository
         env:
           E2E_TESTS_PAT: ${{ secrets.E2E_TESTS_PAT }}

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,7 +44,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
+            '[SDK deployment](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+            github.run_id }}) started on staging 🚀 (from branch `${{ github.ref_name }}` by
             [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }})).'
 
       - name: Git clone the repository

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -45,7 +45,8 @@ jobs:
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
-            __${{github.triggering_actor }}__).'
+            [${{github.triggering_actor }}](https://github.com/piotrwitek${{github.triggering_actor
+            }})).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -47,7 +47,7 @@ jobs:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
             [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}) -
             [${{github.run_id
-            }}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id }}))'
+            }}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id }})).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,7 +44,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            'SDK deployment ([${{github.run_id }}](${{ github.server_url }}/${{
+            'SDK deployment ([${{github.run_id }}](github.com/${{
             github.repository}}/actions/runs/${{ github.run_id }})) started on staging 🚀 (from
             branch `${{ github.ref_name }}` by [${{github.triggering_actor
             }}](https://github.com/${{github.triggering_actor }})).'

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -43,13 +43,14 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
           DISCORD_EMBEDS:
-            '[{"title":"Link to run:
+            '[{"title":"Link to GitHub Action:
             ${{github.run_id}}","url":"https://github.com/${{github.repository}}/actions/runs/${{github.run_id
             }}"}]'
         with:
           args:
-            'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
-            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}).'
+            'SDK deployment `${{github.run_id}}` started on staging 🚀 (from branch `${{
+            github.ref_name }}` by [${{github.triggering_actor
+            }}](https://github.com/${{github.triggering_actor }}).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3
@@ -92,9 +93,7 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
-          args:
-            'SDK deployed successfully on staging 🎉\n (from ${{ github.ref }} by
-            ${{github.triggering_actor }}).'
+          args: 'SDK deployment `${{github.run_id}}` finished successfully on staging 🎉\n '
 
       - name: Trigger e2e tests in e2e-tests repository
         env:

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
-          DISCORD_EMBEDS: '{"embeds":[{"title":"Google it!","url":"https://google.com/"}]}'
+          DISCORD_EMBEDS: '[{"title":"Google it!","url":"https://google.com/"}]'
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,10 +44,10 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            'SDK deployment ([${{github.run_id }}](https://github.com/${{
-            github.repository}}/actions/runs/${{ github.run_id }})) started on staging 🚀 (from
-            branch `${{ github.ref_name }}` by [${{github.triggering_actor
-            }}](https://github.com/${{github.triggering_actor }})).'
+            'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
+            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }}) ->
+            [${{github.run_id }}](https://github.com/${{ github.repository}}/actions/runs/${{
+            github.run_id }}))'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -42,7 +42,10 @@ jobs:
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
-          DISCORD_EMBEDS: '[{"title":"Google it!","url":"https://google.com/"}]'
+          DISCORD_EMBEDS:
+            '[{"title":"Link to run:
+            ${{github.run_id}}","url":"https://github.com/${{github.repository}}/actions/runs/${{github.run_id
+            }}"}]'
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
+          DISCORD_EMBEDS: ''
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,8 +44,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            'SDK deployment started on staging ...\n (from ${{ github.ref }} by
-            ${{github.triggering_actor }}).'
+            'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
+            __${{github.triggering_actor }}__).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -45,8 +45,7 @@ jobs:
         with:
           args:
             'SDK deployment started on staging 🚀 (from branch `${{ github.ref_name }}` by
-            [${{github.triggering_actor }}](https://github.com/piotrwitek${{github.triggering_actor
-            }})).'
+            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }})).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,9 +44,10 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            '[SDK deployment](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
-            github.run_id }}) started on staging 🚀 (from branch `${{ github.ref_name }}` by
-            [${{github.triggering_actor }}](https://github.com/${{github.triggering_actor }})).'
+            'SDK deployment [${{github.run_id }}](${{ github.server_url }}/${{
+            github.repository}}/actions/runs/${{ github.run_id }}) started on staging 🚀 (from
+            branch `${{ github.ref_name }}` by [${{github.triggering_actor
+            }}](https://github.com/${{github.triggering_actor }})).'
 
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-sdk-staging.yaml
+++ b/.github/workflows/deploy-sdk-staging.yaml
@@ -44,8 +44,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SDK_DEPLOY }}
         with:
           args:
-            'SDK deployment [${{github.run_id }}](${{ github.server_url }}/${{
-            github.repository}}/actions/runs/${{ github.run_id }}) started on staging 🚀 (from
+            'SDK deployment ([${{github.run_id }}](${{ github.server_url }}/${{
+            github.repository}}/actions/runs/${{ github.run_id }})) started on staging 🚀 (from
             branch `${{ github.ref_name }}` by [${{github.triggering_actor
             }}](https://github.com/${{github.triggering_actor }})).'
 


### PR DESCRIPTION
This pull request introduces Discord notifications for both the start and successful completion of SDK deployments. Notifications are sent using a specified webhook, providing real-time updates during the deployment process for both production and staging environments. Additionally, various tests and fixes have been included to ensure the reliability of these notifications.