### PR TITLE
Add 'id' field to GraphQL queries for improved data retrieval

### DIFF
--- a/sdk/subgraph-manager-common/src/queries/global-rebalances.graphql
+++ b/sdk/subgraph-manager-common/src/queries/global-rebalances.graphql
@@ -4,6 +4,7 @@ query GetGlobalRebalances {
     amount
     amountUSD
     asset {
+      id
       symbol
       decimals
     }
@@ -36,6 +37,7 @@ query GetGlobalRebalances {
       id
       name
       inputToken {
+        id
         symbol
       }
     }

--- a/sdk/subgraph-manager-common/src/queries/users-activity.graphql
+++ b/sdk/subgraph-manager-common/src/queries/users-activity.graphql
@@ -16,6 +16,7 @@ query GetUsersActivity {
       id
       name
       inputToken {
+        id
         symbol
         decimals
       }

--- a/sdk/subgraph-manager-common/src/queries/vaults.graphql
+++ b/sdk/subgraph-manager-common/src/queries/vaults.graphql
@@ -8,6 +8,7 @@ query GetVaults {
     rewardTokens {
       id
       token {
+        id
         symbol
         decimals
       }
@@ -17,6 +18,7 @@ query GetVaults {
       id
       name
       inputToken {
+        id
         name
         symbol
         decimals
@@ -30,11 +32,13 @@ query GetVaults {
       lastUpdateTimestamp
     }
     inputToken {
+      id
       name
       symbol
       decimals
     }
     outputToken {
+      id
       name
       symbol
       decimals
@@ -66,6 +70,7 @@ query GetVault($id: ID!) {
     rewardTokens {
       id
       token {
+        id
         symbol
         decimals
       }
@@ -108,6 +113,7 @@ query GetVault($id: ID!) {
         id
         name
         inputToken {
+          id
           symbol
         }
       }
@@ -120,6 +126,7 @@ query GetVault($id: ID!) {
       cumulativeEarnings
       cumulativeWithdrawals
       inputToken {
+        id
         name
         symbol
         decimals
@@ -145,11 +152,13 @@ query GetVault($id: ID!) {
       lastUpdateTimestamp
     }
     inputToken {
+      id
       name
       symbol
       decimals
     }
     outputToken {
+      id
       name
       symbol
       decimals


### PR DESCRIPTION
Enhance various GraphQL queries by adding an 'id' field to improve data retrieval and facilitate better data handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GraphQL queries to include additional `id` fields for assets and tokens, improving data detail and identification.
	- Updated queries include `GetGlobalRebalances`, `GetUsersActivity`, `GetVaults`, and `GetVault`, ensuring consistency across various entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->