### PR TITLE
Monorepo-ts-exclude-config

### DIFF
--- a/__template-package__/tsconfig.build.json
+++ b/__template-package__/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/__template-package__/tsconfig.build.json
+++ b/__template-package__/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/__template-package__/tsconfig.json
+++ b/__template-package__/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/__template-package__/tsconfig.json
+++ b/__template-package__/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/__template-package__/tsconfig.test.json
+++ b/__template-package__/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/__template-package__/tsconfig.test.json
+++ b/__template-package__/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/apps/earn-protocol-landing-page/tsconfig.json
+++ b/apps/earn-protocol-landing-page/tsconfig.json
@@ -23,5 +23,5 @@
     ".next/types/**/*.ts",
     "./.eslintrc.cjs"
   ],
-  "exclude": ["node_modules","dist", "out/**/*", "scripts/**/*"]
+  "exclude": ["node_modules", "dist", "out/**/*", "scripts/**/*", ".next"]
 }

--- a/apps/earn-protocol-landing-page/tsconfig.json
+++ b/apps/earn-protocol-landing-page/tsconfig.json
@@ -23,5 +23,5 @@
     ".next/types/**/*.ts",
     "./.eslintrc.cjs"
   ],
-  "exclude": ["node_modules", "out/**/*", "scripts/**/*"]
+  "exclude": ["node_modules","dist", "out/**/*", "scripts/**/*"]
 }

--- a/apps/earn-protocol/tsconfig.json
+++ b/apps/earn-protocol/tsconfig.json
@@ -23,5 +23,5 @@
     ".next/types/**/*.ts",
     "./.eslintrc.cjs"
   ],
-  "exclude": ["node_modules","dist", "out/**/*", "scripts/**/*"]
+  "exclude": ["node_modules", "dist", "out/**/*", "scripts/**/*", ".next"]
 }

--- a/apps/earn-protocol/tsconfig.json
+++ b/apps/earn-protocol/tsconfig.json
@@ -23,5 +23,5 @@
     ".next/types/**/*.ts",
     "./.eslintrc.cjs"
   ],
-  "exclude": ["node_modules", "out/**/*", "scripts/**/*"]
+  "exclude": ["node_modules","dist", "out/**/*", "scripts/**/*"]
 }

--- a/apps/rays-dashboard/tsconfig.json
+++ b/apps/rays-dashboard/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     "./.eslintrc.cjs"
   ],
-  "exclude": ["node_modules", "out/**/*", "scripts/**/*"]
+  "exclude": ["node_modules","dist", "out/**/*", "scripts/**/*"]
 }

--- a/apps/rays-dashboard/tsconfig.json
+++ b/apps/rays-dashboard/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     "./.eslintrc.cjs"
   ],
-  "exclude": ["node_modules","dist", "out/**/*", "scripts/**/*"]
+  "exclude": ["node_modules", "dist", "out/**/*", "scripts/**/*", ".next"]
 }

--- a/armada-protocol/abis/tsconfig.build.json
+++ b/armada-protocol/abis/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/armada-protocol/abis/tsconfig.json
+++ b/armada-protocol/abis/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/background-jobs/update-rays-cron-function/tsconfig.json
+++ b/background-jobs/update-rays-cron-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/background-jobs/update-rays-cron-function/tsconfig.json
+++ b/background-jobs/update-rays-cron-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/external-api/get-collateral-locked-function/tsconfig.json
+++ b/external-api/get-collateral-locked-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/external-api/get-collateral-locked-function/tsconfig.json
+++ b/external-api/get-collateral-locked-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/aave-spark-subgraph/tsconfig.json
+++ b/packages/aave-spark-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/aave-spark-subgraph/tsconfig.json
+++ b/packages/aave-spark-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/abis/tsconfig.json
+++ b/packages/abis/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/abstractions/tsconfig.json
+++ b/packages/abstractions/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/abstractions/tsconfig.json
+++ b/packages/abstractions/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/ajna-subgraph/tsconfig.json
+++ b/packages/ajna-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/ajna-subgraph/tsconfig.json
+++ b/packages/ajna-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/app-db/tsconfig.json
+++ b/packages/app-db/tsconfig.json
@@ -9,5 +9,5 @@
     "declaration": true
   },
   "include": ["./index.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/app-db/tsconfig.json
+++ b/packages/app-db/tsconfig.json
@@ -9,5 +9,5 @@
     "declaration": true
   },
   "include": ["./index.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/automation-subgraph/tsconfig.json
+++ b/packages/automation-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/automation-subgraph/tsconfig.json
+++ b/packages/automation-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/borrow-db/tsconfig.build.json
+++ b/packages/borrow-db/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/scripts/**/*"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "src/scripts/**/*"]
 }

--- a/packages/borrow-db/tsconfig.build.json
+++ b/packages/borrow-db/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules", "**/*.spec.ts", "src/scripts/**/*"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/scripts/**/*"]
 }

--- a/packages/borrow-db/tsconfig.json
+++ b/packages/borrow-db/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/borrow-db/tsconfig.json
+++ b/packages/borrow-db/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/borrow-db/tsconfig.test.json
+++ b/packages/borrow-db/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/borrow-db/tsconfig.test.json
+++ b/packages/borrow-db/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/common/tsconfig.test.json
+++ b/packages/common/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/common/tsconfig.test.json
+++ b/packages/common/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/contracts-utils/tsconfig.json
+++ b/packages/contracts-utils/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/contracts-utils/tsconfig.json
+++ b/packages/contracts-utils/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/contracts-utils/tsconfig.test.json
+++ b/packages/contracts-utils/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/contracts-utils/tsconfig.test.json
+++ b/packages/contracts-utils/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/core-contracts/tsconfig.json
+++ b/packages/core-contracts/tsconfig.json
@@ -6,5 +6,11 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "src/**/*.json", "scripts/**/*.ts", "hardhat.config.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/deployments/hardhat/*.json", "src/local.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.spec.ts",
+    "src/deployments/hardhat/*.json",
+    "src/local.ts"
+  ]
 }

--- a/packages/core-contracts/tsconfig.json
+++ b/packages/core-contracts/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "src/**/*.json", "scripts/**/*.ts", "hardhat.config.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts", "src/deployments/hardhat/*.json", "src/local.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/deployments/hardhat/*.json", "src/local.ts"]
 }

--- a/packages/core-contracts/tsconfig.test.json
+++ b/packages/core-contracts/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "scripts"
   },
   "include": ["scripts/**/*.ts", "./hardhat.config.ts", "tasks/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/core-contracts/tsconfig.test.json
+++ b/packages/core-contracts/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "scripts"
   },
   "include": ["scripts/**/*.ts", "./hardhat.config.ts", "tasks/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/defi-llama-client/tsconfig.json
+++ b/packages/defi-llama-client/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/defi-llama-client/tsconfig.json
+++ b/packages/defi-llama-client/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-configs/tsconfig.json
+++ b/packages/deployment-configs/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-configs/tsconfig.json
+++ b/packages/deployment-configs/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-configs/tsconfig.test.json
+++ b/packages/deployment-configs/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/deployment-configs/tsconfig.test.json
+++ b/packages/deployment-configs/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/deployment-types/tsconfig.json
+++ b/packages/deployment-types/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-types/tsconfig.json
+++ b/packages/deployment-types/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-types/tsconfig.test.json
+++ b/packages/deployment-types/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/deployment-types/tsconfig.test.json
+++ b/packages/deployment-types/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/deployment-utils/tsconfig.json
+++ b/packages/deployment-utils/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-utils/tsconfig.json
+++ b/packages/deployment-utils/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/deployment-utils/tsconfig.test.json
+++ b/packages/deployment-utils/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/deployment-utils/tsconfig.test.json
+++ b/packages/deployment-utils/tsconfig.test.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/hardhat-utils/tsconfig.json
+++ b/packages/hardhat-utils/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/hardhat-utils/tsconfig.json
+++ b/packages/hardhat-utils/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/hardhat-utils/tsconfig.test.json
+++ b/packages/hardhat-utils/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/hardhat-utils/tsconfig.test.json
+++ b/packages/hardhat-utils/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/morpho-blue-external-api-client/tsconfig.json
+++ b/packages/morpho-blue-external-api-client/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/morpho-blue-external-api-client/tsconfig.json
+++ b/packages/morpho-blue-external-api-client/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/morpho-blue-external-api-client/tsconfig.test.json
+++ b/packages/morpho-blue-external-api-client/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/morpho-blue-external-api-client/tsconfig.test.json
+++ b/packages/morpho-blue-external-api-client/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/morpho-blue-subgraph/tsconfig.json
+++ b/packages/morpho-blue-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/morpho-blue-subgraph/tsconfig.json
+++ b/packages/morpho-blue-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/morpho-blue-subgraph/tsconfig.test.json
+++ b/packages/morpho-blue-subgraph/tsconfig.test.json
@@ -7,5 +7,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/morpho-blue-subgraph/tsconfig.test.json
+++ b/packages/morpho-blue-subgraph/tsconfig.test.json
@@ -7,5 +7,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/prices-subgraph/tsconfig.json
+++ b/packages/prices-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/prices-subgraph/tsconfig.json
+++ b/packages/prices-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/rays-db/tsconfig.build.json
+++ b/packages/rays-db/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/scripts/**/*"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "src/scripts/**/*"]
 }

--- a/packages/rays-db/tsconfig.build.json
+++ b/packages/rays-db/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules", "**/*.spec.ts", "src/scripts/**/*"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/scripts/**/*"]
 }

--- a/packages/rays-db/tsconfig.json
+++ b/packages/rays-db/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/rays-db/tsconfig.json
+++ b/packages/rays-db/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/rays-db/tsconfig.test.json
+++ b/packages/rays-db/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/rays-db/tsconfig.test.json
+++ b/packages/rays-db/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/redis-cache/tsconfig.json
+++ b/packages/redis-cache/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/redis-cache/tsconfig.json
+++ b/packages/redis-cache/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/serverless-shared/tsconfig.json
+++ b/packages/serverless-shared/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/serverless-shared/tsconfig.json
+++ b/packages/serverless-shared/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/summer-earn-protocol-subgraph/tsconfig.build.json
+++ b/packages/summer-earn-protocol-subgraph/tsconfig.build.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/summer-earn-protocol-subgraph/tsconfig.build.json
+++ b/packages/summer-earn-protocol-subgraph/tsconfig.build.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/summer-earn-protocol-subgraph/tsconfig.json
+++ b/packages/summer-earn-protocol-subgraph/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/summer-earn-protocol-subgraph/tsconfig.json
+++ b/packages/summer-earn-protocol-subgraph/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/summer-earn-protocol-subgraph/tsconfig.test.json
+++ b/packages/summer-earn-protocol-subgraph/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/summer-earn-protocol-subgraph/tsconfig.test.json
+++ b/packages/summer-earn-protocol-subgraph/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/summer-events-subgraph/tsconfig.json
+++ b/packages/summer-events-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/summer-events-subgraph/tsconfig.json
+++ b/packages/summer-events-subgraph/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/summer-protocol-db/tsconfig.build.json
+++ b/packages/summer-protocol-db/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/scripts/**/*"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "src/scripts/**/*"]
 }

--- a/packages/summer-protocol-db/tsconfig.build.json
+++ b/packages/summer-protocol-db/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules", "**/*.spec.ts", "src/scripts/**/*"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts", "src/scripts/**/*"]
 }

--- a/packages/summer-protocol-db/tsconfig.json
+++ b/packages/summer-protocol-db/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/summer-protocol-db/tsconfig.json
+++ b/packages/summer-protocol-db/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.mts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/summer-protocol-db/tsconfig.test.json
+++ b/packages/summer-protocol-db/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/summer-protocol-db/tsconfig.test.json
+++ b/packages/summer-protocol-db/tsconfig.test.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/triggers-calculations/tsconfig.json
+++ b/packages/triggers-calculations/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/triggers-calculations/tsconfig.json
+++ b/packages/triggers-calculations/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/triggers-calculations/tsconfig.test.json
+++ b/packages/triggers-calculations/tsconfig.test.json
@@ -8,5 +8,5 @@
   },
   "include": ["src/**/*.ts"],
   "files": ["node_modules/jest-expect-message/types/index.d.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/triggers-calculations/tsconfig.test.json
+++ b/packages/triggers-calculations/tsconfig.test.json
@@ -8,5 +8,5 @@
   },
   "include": ["src/**/*.ts"],
   "files": ["node_modules/jest-expect-message/types/index.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/triggers-shared/tsconfig.json
+++ b/packages/triggers-shared/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/packages/triggers-shared/tsconfig.json
+++ b/packages/triggers-shared/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/packages/typescript-config/tsconfig.base.json
+++ b/packages/typescript-config/tsconfig.base.json
@@ -60,5 +60,6 @@
     {
       "path": "../rays-db/tsconfig.build.json"
     }
-  ]
+  ],
+  "exclude": ["../../node_modules", "../../.sst", "../../turbo", "../../.turbo"]
 }

--- a/packages/typescript-config/tsconfig.nextjs.json
+++ b/packages/typescript-config/tsconfig.nextjs.json
@@ -11,5 +11,5 @@
     "types": ["node", "jest", "jest-extended"]
   },
   "include": ["src", "next-env.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/packages/typescript-config/tsconfig.nextjs.json
+++ b/packages/typescript-config/tsconfig.nextjs.json
@@ -11,5 +11,5 @@
     "types": ["node", "jest", "jest-extended"]
   },
   "include": ["src", "next-env.d.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/abi-provider-common/tsconfig.json
+++ b/sdk/abi-provider-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/abi-provider-common/tsconfig.json
+++ b/sdk/abi-provider-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/abi-provider-common/tsconfig.test.json
+++ b/sdk/abi-provider-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/abi-provider-common/tsconfig.test.json
+++ b/sdk/abi-provider-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/abi-provider-service/tsconfig.build.json
+++ b/sdk/abi-provider-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/abi-provider-service/tsconfig.build.json
+++ b/sdk/abi-provider-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/abi-provider-service/tsconfig.json
+++ b/sdk/abi-provider-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/abi-provider-service/tsconfig.json
+++ b/sdk/abi-provider-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/abi-provider-service/tsconfig.test.json
+++ b/sdk/abi-provider-service/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/abi-provider-service/tsconfig.test.json
+++ b/sdk/abi-provider-service/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/address-book-common/tsconfig.json
+++ b/sdk/address-book-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/address-book-common/tsconfig.json
+++ b/sdk/address-book-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/address-book-common/tsconfig.test.json
+++ b/sdk/address-book-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/address-book-common/tsconfig.test.json
+++ b/sdk/address-book-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/address-book-service/tsconfig.build.json
+++ b/sdk/address-book-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/address-book-service/tsconfig.build.json
+++ b/sdk/address-book-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/address-book-service/tsconfig.json
+++ b/sdk/address-book-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/address-book-service/tsconfig.json
+++ b/sdk/address-book-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/address-book-service/tsconfig.test.json
+++ b/sdk/address-book-service/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/address-book-service/tsconfig.test.json
+++ b/sdk/address-book-service/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/allowance-manager-common/tsconfig.json
+++ b/sdk/allowance-manager-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/allowance-manager-common/tsconfig.json
+++ b/sdk/allowance-manager-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/allowance-manager-common/tsconfig.test.json
+++ b/sdk/allowance-manager-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/allowance-manager-common/tsconfig.test.json
+++ b/sdk/allowance-manager-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/allowance-manager-service/tsconfig.build.json
+++ b/sdk/allowance-manager-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/allowance-manager-service/tsconfig.build.json
+++ b/sdk/allowance-manager-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/allowance-manager-service/tsconfig.json
+++ b/sdk/allowance-manager-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/allowance-manager-service/tsconfig.json
+++ b/sdk/allowance-manager-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/allowance-manager-service/tsconfig.test.json
+++ b/sdk/allowance-manager-service/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/allowance-manager-service/tsconfig.test.json
+++ b/sdk/allowance-manager-service/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/armada-protocol-common/tsconfig.json
+++ b/sdk/armada-protocol-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/armada-protocol-common/tsconfig.json
+++ b/sdk/armada-protocol-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/armada-protocol-common/tsconfig.test.json
+++ b/sdk/armada-protocol-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/armada-protocol-common/tsconfig.test.json
+++ b/sdk/armada-protocol-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/armada-protocol-service/tsconfig.build.json
+++ b/sdk/armada-protocol-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/armada-protocol-service/tsconfig.build.json
+++ b/sdk/armada-protocol-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/armada-protocol-service/tsconfig.json
+++ b/sdk/armada-protocol-service/tsconfig.json
@@ -26,5 +26,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/armada-protocol-service/tsconfig.json
+++ b/sdk/armada-protocol-service/tsconfig.json
@@ -26,5 +26,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/armada-protocol-service/tsconfig.test.json
+++ b/sdk/armada-protocol-service/tsconfig.test.json
@@ -31,5 +31,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/armada-protocol-service/tsconfig.test.json
+++ b/sdk/armada-protocol-service/tsconfig.test.json
@@ -31,5 +31,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-common/tsconfig.build.json
+++ b/sdk/blockchain-client-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-common/tsconfig.build.json
+++ b/sdk/blockchain-client-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/blockchain-client-common/tsconfig.json
+++ b/sdk/blockchain-client-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-common/tsconfig.json
+++ b/sdk/blockchain-client-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/blockchain-client-common/tsconfig.test.json
+++ b/sdk/blockchain-client-common/tsconfig.test.json
@@ -13,5 +13,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/blockchain-client-common/tsconfig.test.json
+++ b/sdk/blockchain-client-common/tsconfig.test.json
@@ -13,5 +13,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-provider/tsconfig.build.json
+++ b/sdk/blockchain-client-provider/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-provider/tsconfig.build.json
+++ b/sdk/blockchain-client-provider/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/blockchain-client-provider/tsconfig.json
+++ b/sdk/blockchain-client-provider/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-provider/tsconfig.json
+++ b/sdk/blockchain-client-provider/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/blockchain-client-provider/tsconfig.test.json
+++ b/sdk/blockchain-client-provider/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/blockchain-client-provider/tsconfig.test.json
+++ b/sdk/blockchain-client-provider/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/configuration-provider-common/tsconfig.json
+++ b/sdk/configuration-provider-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/configuration-provider-common/tsconfig.json
+++ b/sdk/configuration-provider-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/configuration-provider-common/tsconfig.test.json
+++ b/sdk/configuration-provider-common/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/configuration-provider-common/tsconfig.test.json
+++ b/sdk/configuration-provider-common/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/configuration-provider/tsconfig.build.json
+++ b/sdk/configuration-provider/tsconfig.build.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/configuration-provider/tsconfig.build.json
+++ b/sdk/configuration-provider/tsconfig.build.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/configuration-provider/tsconfig.json
+++ b/sdk/configuration-provider/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/configuration-provider/tsconfig.json
+++ b/sdk/configuration-provider/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/configuration-provider/tsconfig.test.json
+++ b/sdk/configuration-provider/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/configuration-provider/tsconfig.test.json
+++ b/sdk/configuration-provider/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/contracts-provider-common/tsconfig.json
+++ b/sdk/contracts-provider-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/contracts-provider-common/tsconfig.json
+++ b/sdk/contracts-provider-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/contracts-provider-common/tsconfig.test.json
+++ b/sdk/contracts-provider-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/contracts-provider-common/tsconfig.test.json
+++ b/sdk/contracts-provider-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/contracts-provider-service/tsconfig.build.json
+++ b/sdk/contracts-provider-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/contracts-provider-service/tsconfig.build.json
+++ b/sdk/contracts-provider-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/contracts-provider-service/tsconfig.json
+++ b/sdk/contracts-provider-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/contracts-provider-service/tsconfig.json
+++ b/sdk/contracts-provider-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/contracts-provider-service/tsconfig.test.json
+++ b/sdk/contracts-provider-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/contracts-provider-service/tsconfig.test.json
+++ b/sdk/contracts-provider-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/oracle-common/tsconfig.json
+++ b/sdk/oracle-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/oracle-common/tsconfig.json
+++ b/sdk/oracle-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/oracle-common/tsconfig.test.json
+++ b/sdk/oracle-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/oracle-common/tsconfig.test.json
+++ b/sdk/oracle-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/oracle-service/tsconfig.build.json
+++ b/sdk/oracle-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/oracle-service/tsconfig.build.json
+++ b/sdk/oracle-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/oracle-service/tsconfig.json
+++ b/sdk/oracle-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/oracle-service/tsconfig.json
+++ b/sdk/oracle-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/oracle-service/tsconfig.test.json
+++ b/sdk/oracle-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/oracle-service/tsconfig.test.json
+++ b/sdk/oracle-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/order-planner-common/tsconfig.json
+++ b/sdk/order-planner-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/order-planner-common/tsconfig.json
+++ b/sdk/order-planner-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/order-planner-common/tsconfig.test.json
+++ b/sdk/order-planner-common/tsconfig.test.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/order-planner-common/tsconfig.test.json
+++ b/sdk/order-planner-common/tsconfig.test.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/order-planner-service/tsconfig.json
+++ b/sdk/order-planner-service/tsconfig.json
@@ -7,5 +7,5 @@
   },
   "references": [{ "path": "../tokens-common" }, { "path": "../oracle-common" }],
   "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/order-planner-service/tsconfig.json
+++ b/sdk/order-planner-service/tsconfig.json
@@ -7,5 +7,5 @@
   },
   "references": [{ "path": "../tokens-common" }, { "path": "../oracle-common" }],
   "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/order-planner-service/tsconfig.test.json
+++ b/sdk/order-planner-service/tsconfig.test.json
@@ -29,5 +29,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/order-planner-service/tsconfig.test.json
+++ b/sdk/order-planner-service/tsconfig.test.json
@@ -29,5 +29,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/protocol-manager-common/tsconfig.build.json
+++ b/sdk/protocol-manager-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/protocol-manager-common/tsconfig.build.json
+++ b/sdk/protocol-manager-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/protocol-manager-common/tsconfig.test.json
+++ b/sdk/protocol-manager-common/tsconfig.test.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/protocol-manager-common/tsconfig.test.json
+++ b/sdk/protocol-manager-common/tsconfig.test.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/protocol-manager-service/tsconfig.build.json
+++ b/sdk/protocol-manager-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/protocol-manager-service/tsconfig.build.json
+++ b/sdk/protocol-manager-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/protocol-manager-service/tsconfig.test.json
+++ b/sdk/protocol-manager-service/tsconfig.test.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/protocol-manager-service/tsconfig.test.json
+++ b/sdk/protocol-manager-service/tsconfig.test.json
@@ -18,5 +18,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/protocol-plugins-common/tsconfig.test.json
+++ b/sdk/protocol-plugins-common/tsconfig.test.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/protocol-plugins-common/tsconfig.test.json
+++ b/sdk/protocol-plugins-common/tsconfig.test.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/protocol-plugins/tsconfig.test.json
+++ b/sdk/protocol-plugins/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/protocol-plugins/tsconfig.test.json
+++ b/sdk/protocol-plugins/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-client-react/tsconfig.build.json
+++ b/sdk/sdk-client-react/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-client-react/tsconfig.build.json
+++ b/sdk/sdk-client-react/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-client-react/tsconfig.json
+++ b/sdk/sdk-client-react/tsconfig.json
@@ -7,5 +7,5 @@
     "jsx": "react" // Add this line
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-client-react/tsconfig.json
+++ b/sdk/sdk-client-react/tsconfig.json
@@ -7,5 +7,5 @@
     "jsx": "react" // Add this line
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-client-react/tsconfig.test.json
+++ b/sdk/sdk-client-react/tsconfig.test.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-client-react/tsconfig.test.json
+++ b/sdk/sdk-client-react/tsconfig.test.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-client/tsconfig.build.json
+++ b/sdk/sdk-client/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-client/tsconfig.build.json
+++ b/sdk/sdk-client/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-client/tsconfig.json
+++ b/sdk/sdk-client/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-client/tsconfig.json
+++ b/sdk/sdk-client/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-client/tsconfig.test.json
+++ b/sdk/sdk-client/tsconfig.test.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-client/tsconfig.test.json
+++ b/sdk/sdk-client/tsconfig.test.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-common/tsconfig.build.json
+++ b/sdk/sdk-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-common/tsconfig.build.json
+++ b/sdk/sdk-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-common/tsconfig.bundle.json
+++ b/sdk/sdk-common/tsconfig.bundle.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-common/tsconfig.bundle.json
+++ b/sdk/sdk-common/tsconfig.bundle.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-common/tsconfig.json
+++ b/sdk/sdk-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-common/tsconfig.json
+++ b/sdk/sdk-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-common/tsconfig.test.json
+++ b/sdk/sdk-common/tsconfig.test.json
@@ -9,5 +9,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-common/tsconfig.test.json
+++ b/sdk/sdk-common/tsconfig.test.json
@@ -9,5 +9,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-e2e/tsconfig.json
+++ b/sdk/sdk-e2e/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-e2e/tsconfig.json
+++ b/sdk/sdk-e2e/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-e2e/tsconfig.test.json
+++ b/sdk/sdk-e2e/tsconfig.test.json
@@ -30,5 +30,5 @@
     }
   },
   "include": ["tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-e2e/tsconfig.test.json
+++ b/sdk/sdk-e2e/tsconfig.test.json
@@ -30,5 +30,5 @@
     }
   },
   "include": ["tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-router-function/tsconfig.json
+++ b/sdk/sdk-router-function/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-router-function/tsconfig.json
+++ b/sdk/sdk-router-function/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-router-function/tsconfig.test.json
+++ b/sdk/sdk-router-function/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-router-function/tsconfig.test.json
+++ b/sdk/sdk-router-function/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-server-common/tsconfig.json
+++ b/sdk/sdk-server-common/tsconfig.json
@@ -7,5 +7,5 @@
   },
   "references": [{ "path": "../testing-utils" }],
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-server-common/tsconfig.json
+++ b/sdk/sdk-server-common/tsconfig.json
@@ -7,5 +7,5 @@
   },
   "references": [{ "path": "../testing-utils" }],
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-server-common/tsconfig.test.json
+++ b/sdk/sdk-server-common/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-server-common/tsconfig.test.json
+++ b/sdk/sdk-server-common/tsconfig.test.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-server/tsconfig.json
+++ b/sdk/sdk-server/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/sdk-server/tsconfig.json
+++ b/sdk/sdk-server/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-server/tsconfig.test.json
+++ b/sdk/sdk-server/tsconfig.test.json
@@ -14,5 +14,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/sdk-server/tsconfig.test.json
+++ b/sdk/sdk-server/tsconfig.test.json
@@ -14,5 +14,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/simulator-service/tsconfig.build.json
+++ b/sdk/simulator-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/simulator-service/tsconfig.build.json
+++ b/sdk/simulator-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/simulator-service/tsconfig.test.json
+++ b/sdk/simulator-service/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/simulator-service/tsconfig.test.json
+++ b/sdk/simulator-service/tsconfig.test.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-common/tsconfig.build.json
+++ b/sdk/subgraph-manager-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/subgraph-manager-common/tsconfig.build.json
+++ b/sdk/subgraph-manager-common/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-common/tsconfig.json
+++ b/sdk/subgraph-manager-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/subgraph-manager-common/tsconfig.json
+++ b/sdk/subgraph-manager-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-common/tsconfig.test.json
+++ b/sdk/subgraph-manager-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-common/tsconfig.test.json
+++ b/sdk/subgraph-manager-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/subgraph-manager-service/tsconfig.build.json
+++ b/sdk/subgraph-manager-service/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/subgraph-manager-service/tsconfig.build.json
+++ b/sdk/subgraph-manager-service/tsconfig.build.json
@@ -7,5 +7,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-service/tsconfig.json
+++ b/sdk/subgraph-manager-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/subgraph-manager-service/tsconfig.json
+++ b/sdk/subgraph-manager-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-service/tsconfig.test.json
+++ b/sdk/subgraph-manager-service/tsconfig.test.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/subgraph-manager-service/tsconfig.test.json
+++ b/sdk/subgraph-manager-service/tsconfig.test.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/swap-common/tsconfig.json
+++ b/sdk/swap-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/swap-common/tsconfig.json
+++ b/sdk/swap-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/swap-common/tsconfig.test.json
+++ b/sdk/swap-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/swap-common/tsconfig.test.json
+++ b/sdk/swap-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/swap-service/tsconfig.build.json
+++ b/sdk/swap-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/swap-service/tsconfig.build.json
+++ b/sdk/swap-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/swap-service/tsconfig.json
+++ b/sdk/swap-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/swap-service/tsconfig.json
+++ b/sdk/swap-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/swap-service/tsconfig.test.json
+++ b/sdk/swap-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/swap-service/tsconfig.test.json
+++ b/sdk/swap-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tenderly-utils/tsconfig.build.json
+++ b/sdk/tenderly-utils/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tenderly-utils/tsconfig.build.json
+++ b/sdk/tenderly-utils/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tenderly-utils/tsconfig.json
+++ b/sdk/tenderly-utils/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tenderly-utils/tsconfig.json
+++ b/sdk/tenderly-utils/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "e2e/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tenderly-utils/tsconfig.test.json
+++ b/sdk/tenderly-utils/tsconfig.test.json
@@ -11,5 +11,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tenderly-utils/tsconfig.test.json
+++ b/sdk/tenderly-utils/tsconfig.test.json
@@ -11,5 +11,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/testing-utils/tsconfig.json
+++ b/sdk/testing-utils/tsconfig.json
@@ -11,5 +11,5 @@
     "scripts/**/*.ts",
     "../tenderly-utils/src/TenderlyDevNet.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/testing-utils/tsconfig.json
+++ b/sdk/testing-utils/tsconfig.json
@@ -11,5 +11,5 @@
     "scripts/**/*.ts",
     "../tenderly-utils/src/TenderlyDevNet.ts"
   ],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/testing-utils/tsconfig.test.json
+++ b/sdk/testing-utils/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/testing-utils/tsconfig.test.json
+++ b/sdk/testing-utils/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tokens-common/tsconfig.json
+++ b/sdk/tokens-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tokens-common/tsconfig.json
+++ b/sdk/tokens-common/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tokens-common/tsconfig.test.json
+++ b/sdk/tokens-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tokens-common/tsconfig.test.json
+++ b/sdk/tokens-common/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tokens-service/tsconfig.build.json
+++ b/sdk/tokens-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tokens-service/tsconfig.build.json
+++ b/sdk/tokens-service/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tokens-service/tsconfig.json
+++ b/sdk/tokens-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tokens-service/tsconfig.json
+++ b/sdk/tokens-service/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tokens-service/tsconfig.test.json
+++ b/sdk/tokens-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tokens-service/tsconfig.test.json
+++ b/sdk/tokens-service/tsconfig.test.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tools/genStrategyDefinitions/tsconfig.json
+++ b/sdk/tools/genStrategyDefinitions/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/sdk/tools/genStrategyDefinitions/tsconfig.json
+++ b/sdk/tools/genStrategyDefinitions/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tools/genStrategyDefinitions/tsconfig.test.json
+++ b/sdk/tools/genStrategyDefinitions/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/sdk/tools/genStrategyDefinitions/tsconfig.test.json
+++ b/sdk/tools/genStrategyDefinitions/tsconfig.test.json
@@ -5,5 +5,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/stacks/tsconfig.json
+++ b/stacks/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist"
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }

--- a/summerfi-api/get-apy-function/tsconfig.json
+++ b/summerfi-api/get-apy-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-apy-function/tsconfig.json
+++ b/summerfi-api/get-apy-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-meta-morpho-details-function/tsconfig.json
+++ b/summerfi-api/get-meta-morpho-details-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-meta-morpho-details-function/tsconfig.json
+++ b/summerfi-api/get-meta-morpho-details-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-migrations-function/tsconfig.json
+++ b/summerfi-api/get-migrations-function/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/summerfi-api/get-migrations-function/tsconfig.json
+++ b/summerfi-api/get-migrations-function/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/summerfi-api/get-migrations-function/tsconfig.test.json
+++ b/summerfi-api/get-migrations-function/tsconfig.test.json
@@ -7,5 +7,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/summerfi-api/get-migrations-function/tsconfig.test.json
+++ b/summerfi-api/get-migrations-function/tsconfig.test.json
@@ -7,5 +7,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/summerfi-api/get-morpho-claims-function/tsconfig.json
+++ b/summerfi-api/get-morpho-claims-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-morpho-claims-function/tsconfig.json
+++ b/summerfi-api/get-morpho-claims-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-position-rays-function/tsconfig.json
+++ b/summerfi-api/get-position-rays-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-position-rays-function/tsconfig.json
+++ b/summerfi-api/get-position-rays-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-rays-function/tsconfig.json
+++ b/summerfi-api/get-rays-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-rays-function/tsconfig.json
+++ b/summerfi-api/get-rays-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-rays-leaderboard-function/tsconfig.json
+++ b/summerfi-api/get-rays-leaderboard-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-rays-leaderboard-function/tsconfig.json
+++ b/summerfi-api/get-rays-leaderboard-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-rays-multipliers-function/tsconfig.json
+++ b/summerfi-api/get-rays-multipliers-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-rays-multipliers-function/tsconfig.json
+++ b/summerfi-api/get-rays-multipliers-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "sst-env.d.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-triggers-function/tsconfig.json
+++ b/summerfi-api/get-triggers-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/get-triggers-function/tsconfig.json
+++ b/summerfi-api/get-triggers-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/portfolio-assets-function/tsconfig.json
+++ b/summerfi-api/portfolio-assets-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/portfolio-assets-function/tsconfig.json
+++ b/summerfi-api/portfolio-assets-function/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/portfolio-assets-function/tsconfig.test.json
+++ b/summerfi-api/portfolio-assets-function/tsconfig.test.json
@@ -7,5 +7,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/summerfi-api/portfolio-assets-function/tsconfig.test.json
+++ b/summerfi-api/portfolio-assets-function/tsconfig.test.json
@@ -7,5 +7,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/summerfi-api/portfolio-overview-function/tsconfig.json
+++ b/summerfi-api/portfolio-overview-function/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/summerfi-api/portfolio-overview-function/tsconfig.json
+++ b/summerfi-api/portfolio-overview-function/tsconfig.json
@@ -6,5 +6,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/summerfi-api/portfolio-overview-function/tsconfig.test.json
+++ b/summerfi-api/portfolio-overview-function/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/summerfi-api/portfolio-overview-function/tsconfig.test.json
+++ b/summerfi-api/portfolio-overview-function/tsconfig.test.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/summerfi-api/setup-trigger-function/tsconfig.json
+++ b/summerfi-api/setup-trigger-function/tsconfig.json
@@ -10,5 +10,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules","dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/setup-trigger-function/tsconfig.json
+++ b/summerfi-api/setup-trigger-function/tsconfig.json
@@ -10,5 +10,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/summerfi-api/setup-trigger-function/tsconfig.test.json
+++ b/summerfi-api/setup-trigger-function/tsconfig.test.json
@@ -12,5 +12,5 @@
   },
   "files": ["node_modules/jest-expect-message/types/index.d.ts"],
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","dist"]
 }

--- a/summerfi-api/setup-trigger-function/tsconfig.test.json
+++ b/summerfi-api/setup-trigger-function/tsconfig.test.json
@@ -12,5 +12,5 @@
   },
   "files": ["node_modules/jest-expect-message/types/index.d.ts"],
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules","dist"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This pull request includes updates to the `tsconfig.json` files across various packages and applications to ensure the `dist` directory is excluded from TypeScript compilation. This change helps prevent potential issues with recompiling already compiled code.

Exclusion of `dist` directory from TypeScript compilation:

* [`__template-package__/tsconfig.build.json`](diffhunk://#diff-1ebdbf5231ba61c8adc2eef38f9e9449d90fbcf0ba95f070a7eb39b230db46c5L9-R9): Added "dist" to the `exclude` array.
* [`apps/earn-protocol-landing-page/tsconfig.json`](diffhunk://#diff-131d833ef30022632e00b22a9549c14cdb9671bb1755d2bc586eb328d77fc9ccL26-R26): Added "dist" and ".next" to the `exclude` array.
* [`apps/rays-dashboard/tsconfig.json`](diffhunk://#diff-5cc5878cea75de815bd10879112e542fe328e6df9ea0d3b69567e9ed5498fb4dL25-R25): Added "dist" and ".next" to the `exclude` array.
* [`packages/borrow-db/tsconfig.build.json`](diffhunk://#diff-0e3da9ee88dc1d25f04b7536d77b69b17134ff20a4dff64d8499f5d8bc980443L8-R8): Added "dist" to the `exclude` array.
* [`packages/common/tsconfig.json`](diffhunk://#diff-df9c60c5c8335f6227e3cdcd08f4220e8fd36d1ec1ec88469d041cf174cf3758L9-R9): Added "dist" to the `exclude` array.