### PR TITLE
Enhance position mapping with staked balances in GraphQL queries

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -27,6 +27,15 @@ export const mapGraphDataToArmadaPosition =
 
     console.log('position', position)
 
+    const fleetBalance = BigNumber(position.inputTokenBalance.toString()).div(
+      10 ** position.vault.inputToken.decimals,
+    )
+    const stakedBalance = BigNumber(position.stakedInputTokenBalance.toString()).div(
+      10 ** position.vault.inputToken.decimals,
+    )
+    const sharesBalance = BigNumber(position.outputTokenBalance.toString())
+    const stakedSharesBalance = BigNumber(position.stakedOutputTokenBalance.toString())
+
     return ArmadaPosition.createFrom({
       id: ArmadaPositionId.createFrom({ id: position.id, user: user }),
 
@@ -39,9 +48,7 @@ export const mapGraphDataToArmadaPosition =
         }),
       }),
       amount: TokenAmount.createFrom({
-        amount: BigNumber(position.inputTokenBalance.toString())
-          .div(10 ** position.vault.inputToken.decimals)
-          .toString(),
+        amount: fleetBalance.plus(stakedBalance).toString(),
         token: Token.createFrom({
           chainInfo,
           address: Address.createFromEthereum({
@@ -85,7 +92,7 @@ export const mapGraphDataToArmadaPosition =
         }),
       ),
       shares: TokenAmount.createFrom({
-        amount: position.outputTokenBalance.toString(),
+        amount: sharesBalance.plus(stakedSharesBalance).toString(),
         token: Token.createFrom({
           chainInfo,
           address: Address.createFromEthereum({

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -30,7 +30,7 @@ export const mapGraphDataToArmadaPosition =
     const fleetBalance = BigNumber(position.inputTokenBalance.toString()).div(
       10 ** position.vault.inputToken.decimals,
     )
-    const stakedBalance = BigNumber(position.stakedInputTokenBalance.toString()).div(
+    const stakedFleetBalance = BigNumber(position.stakedInputTokenBalance.toString()).div(
       10 ** position.vault.inputToken.decimals,
     )
     const sharesBalance = BigNumber(position.outputTokenBalance.toString())
@@ -48,7 +48,7 @@ export const mapGraphDataToArmadaPosition =
         }),
       }),
       amount: TokenAmount.createFrom({
-        amount: fleetBalance.plus(stakedBalance).toString(),
+        amount: fleetBalance.plus(stakedFleetBalance).toString(),
         token: Token.createFrom({
           chainInfo,
           address: Address.createFromEthereum({

--- a/sdk/subgraph-manager-common/src/generated/client.ts
+++ b/sdk/subgraph-manager-common/src/generated/client.ts
@@ -8220,7 +8220,7 @@ export type GetUserPositionsQueryVariables = Exact<{
 }>;
 
 
-export type GetUserPositionsQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string } }> };
+export type GetUserPositionsQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string } }> };
 
 export type GetUserPositionQueryVariables = Exact<{
   accountAddress: Scalars['String']['input'];
@@ -8228,7 +8228,7 @@ export type GetUserPositionQueryVariables = Exact<{
 }>;
 
 
-export type GetUserPositionQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string } }> };
+export type GetUserPositionQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string } }> };
 
 export type GetUserActivityQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -8310,6 +8310,8 @@ export const GetUserPositionsDocument = gql`
     id
     inputTokenBalance
     outputTokenBalance
+    stakedInputTokenBalance
+    stakedOutputTokenBalance
     deposits {
       amount
       amountUSD
@@ -8353,6 +8355,8 @@ export const GetUserPositionDocument = gql`
     id
     inputTokenBalance
     outputTokenBalance
+    stakedInputTokenBalance
+    stakedOutputTokenBalance
     deposits {
       amount
       amountUSD

--- a/sdk/subgraph-manager-common/src/queries/positions.graphql
+++ b/sdk/subgraph-manager-common/src/queries/positions.graphql
@@ -3,6 +3,8 @@ query GetUserPositions($accountAddress: String!) {
     id
     inputTokenBalance
     outputTokenBalance
+    stakedInputTokenBalance
+    stakedOutputTokenBalance
     deposits {
       amount
       amountUSD
@@ -45,6 +47,8 @@ query GetUserPosition($accountAddress: String!, $vaultId: String!) {
     id
     inputTokenBalance
     outputTokenBalance
+    stakedInputTokenBalance
+    stakedOutputTokenBalance
     deposits {
       amount
       amountUSD

--- a/sdk/subgraph-manager-common/src/queries/vaults.graphql
+++ b/sdk/subgraph-manager-common/src/queries/vaults.graphql
@@ -171,6 +171,7 @@ query GetVault($id: ID!) {
     inputTokenBalance
     inputTokenPriceUSD
     outputTokenPriceUSD
+
     depositLimit
     createdTimestamp
     totalValueLockedUSD


### PR DESCRIPTION
Add staked input and output token balances to position mapping and update related GraphQL queries accordingly. This improves the data representation for user positions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new fields for token balances in GraphQL queries: `stakedInputTokenBalance` and `stakedOutputTokenBalance` for user positions.
	- Added `depositLimit` field to the `GetVault` query for enhanced vault information.

- **Improvements**
	- Refactored balance calculations for clarity and maintainability in token position handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->