### PR TITLE
Add support for displaying unique protocols in VaultsListView

### DIFF
--- a/apps/earn-protocol/components/layout/VaultsListView/VaultsListView.tsx
+++ b/apps/earn-protocol/components/layout/VaultsListView/VaultsListView.tsx
@@ -119,6 +119,26 @@ export const VaultsListView = ({ selectedNetwork, vaultsList }: VaultsListViewPr
     )
   }, [vaultsList])
 
+  const formattedProtocolsSupportedList = useMemo(
+    () =>
+      new Set(
+        vaultsList.reduce(
+          (acc, { arks }) => [
+            // converting a list which looks like `protocolName-token-chainId`
+            // into a unique list of protocols for all vaults
+            ...acc,
+            ...arks
+              .map((ark) => ark.name?.split('-')[0])
+              .filter((arkName): arkName is string => Boolean(arkName)),
+          ],
+          [] as string[],
+        ),
+      ),
+    [vaultsList],
+  )
+
+  const formattedProtocolsSupportedCount = formattedProtocolsSupportedList.size
+
   return (
     <VaultGrid
       isMobile={isMobile}
@@ -149,11 +169,12 @@ export const VaultsListView = ({ selectedNetwork, vaultsList }: VaultsListViewPr
           />
           <DataBlock
             title="Protocols Supported"
-            // TODO: fill data
-            titleTooltip="Tooltip about protocols or something"
+            // TODO: fill data (this is just a placeholder)
+            titleTooltip={`Protocols supported: ${Array.from(formattedProtocolsSupportedList).join(
+              ', ',
+            )}`}
             size="large"
-            // TODO: fill data
-            value="6"
+            value={formattedProtocolsSupportedCount}
           />
         </SimpleGrid>
       }


### PR DESCRIPTION
This pull request includes changes to the `VaultsListView` component in the `apps/earn-protocol` project to enhance the display of supported protocols. The most important changes include adding a memoized list of unique protocols and updating the tooltip and value display for the protocols supported data block.

Enhancements to `VaultsListView`:

* Added a memoized list of unique protocols supported by all vaults using `useMemo` and `reduce` to create a set of protocol names. (`apps/earn-protocol/components/layout/VaultsListView/VaultsListView.tsx`)
* Updated the `Protocols Supported` data block to display the count and list of protocols in the tooltip, using the newly created memoized list. (`apps/earn-protocol/components/layout/VaultsListView/VaultsListView.tsx`)