### PR TITLE
Add Stake Delegate Pages and Update External Data Types

### DIFF
--- a/apps/earn-protocol/app/earn/stake-delegate/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/earn/stake-delegate/[walletAddress]/page.tsx
@@ -1,0 +1,33 @@
+import { isValidAddress } from '@summerfi/serverless-shared'
+import { redirect } from 'next/navigation'
+
+import { StakeDelegatePageView } from '@/components/layout/StakeDelegatePageView/StakeDelegatePageView'
+import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/types'
+
+export const revalidate = 60
+
+type StakeDelegatePageProps = {
+  params: {
+    walletAddress: string
+  }
+}
+
+const StakeDelegatePage = ({ params }: StakeDelegatePageProps) => {
+  const { walletAddress } = params
+
+  if (!isValidAddress(walletAddress)) {
+    redirect(`/earn`)
+  }
+
+  // TODO fetch external data once available and data needed for transactions
+  const externalData: ClaimDelegateExternalData = {
+    sumrPrice: '0',
+    sumrEarned: '123.12',
+    sumrApy: '0.032',
+    sumrDelegated: '50',
+  }
+
+  return <StakeDelegatePageView walletAddress={walletAddress} externalData={externalData} />
+}
+
+export default StakeDelegatePage

--- a/apps/earn-protocol/app/earn/stake-delegate/page.tsx
+++ b/apps/earn-protocol/app/earn/stake-delegate/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation'
+
+export const revalidate = 60
+
+const StakeDelegateRedirectPage = () => {
+  redirect(`/earn`)
+}
+
+export default StakeDelegateRedirectPage

--- a/apps/earn-protocol/components/layout/ClaimPageView/ClaimPageView.tsx
+++ b/apps/earn-protocol/components/layout/ClaimPageView/ClaimPageView.tsx
@@ -4,13 +4,13 @@ import { type FC, useReducer } from 'react'
 import { ClaimDelegateForm } from '@/features/claim-and-delegate/components/ClaimDelegateForm/ClaimDelegateForm'
 import { ClaimDelegateHeader } from '@/features/claim-and-delegate/components/ClaimDelegateHeader/ClaimDelegateHeader'
 import { claimDelegateReducer, claimDelegateState } from '@/features/claim-and-delegate/state'
-import { type ClamDelegateExternalData } from '@/features/claim-and-delegate/types'
+import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/types'
 
 import classNames from './ClaimPageView.module.scss'
 
 interface ClaimPageViewProps {
   walletAddress: string
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimPageView: FC<ClaimPageViewProps> = ({ walletAddress, externalData }) => {

--- a/apps/earn-protocol/components/layout/MasterPage/MasterPage.tsx
+++ b/apps/earn-protocol/components/layout/MasterPage/MasterPage.tsx
@@ -1,7 +1,7 @@
 import { type FC, type PropsWithChildren } from 'react'
 import { Footer, NewsletterWrapper, Text } from '@summerfi/app-earn-ui'
-import dynamic from 'next/dynamic'
 
+// import dynamic from 'next/dynamic'
 import { NavigationWrapper } from '@/components/layout/Navigation/NavigationWrapper'
 import { WalletInit } from '@/components/molecules/WalletInit/WalletInit'
 
@@ -10,9 +10,9 @@ import masterPageStyles from './MasterPage.module.scss'
 
 interface MasterPageProps {}
 
-const SetForkModal = dynamic(() => import('@/components/organisms/SetFork/SetForkModal'), {
-  ssr: false,
-})
+// const SetForkModal = dynamic(() => import('@/components/organisms/SetFork/SetForkModal'), {
+//   ssr: false,
+// })
 
 export const MasterPage: FC<PropsWithChildren<MasterPageProps>> = ({ children }) => {
   return (
@@ -32,7 +32,7 @@ export const MasterPage: FC<PropsWithChildren<MasterPageProps>> = ({ children })
             gap: '20px',
           }}
         >
-          <SetForkModal />
+          {/* <SetForkModal /> */}
           <Footer
             logo="/img/branding/logo-light.svg"
             newsletter={

--- a/apps/earn-protocol/components/layout/StakeDelegatePageView/StakeDelegatePageView.module.scss
+++ b/apps/earn-protocol/components/layout/StakeDelegatePageView/StakeDelegatePageView.module.scss
@@ -1,0 +1,32 @@
+.stakeDelegatePageWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--general-space-16);
+  max-width: 1072px;
+  width: 100%;
+
+  @media (min-width: 768px) {
+    padding: 0;
+  }
+
+  .stakeDelegateHeaderWrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    margin-bottom: var(--general-space-24);
+    width: 100%;
+
+    .pathLinkWrapper {
+      display: flex;
+      gap: var(--general-space-8);
+      margin-bottom: var(--general-space-12);
+    }
+  }
+
+  .stakeDelegateForm {
+    width: 100%;
+  }
+}

--- a/apps/earn-protocol/components/layout/StakeDelegatePageView/StakeDelegatePageView.tsx
+++ b/apps/earn-protocol/components/layout/StakeDelegatePageView/StakeDelegatePageView.tsx
@@ -1,0 +1,57 @@
+'use client'
+import { type FC, useReducer } from 'react'
+import { Card, Text } from '@summerfi/app-earn-ui'
+import Link from 'next/link'
+
+import { ClaimDelegateStakeDelegateStep } from '@/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/ClaimDelegateStakeDelegateStep'
+import { claimDelegateReducer, claimDelegateState } from '@/features/claim-and-delegate/state'
+import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/types'
+import { PortfolioTabs } from '@/features/portfolio/types'
+
+import classNames from './StakeDelegatePageView.module.scss'
+
+interface StakeDelegatePageViewProps {
+  walletAddress: string
+  externalData: ClaimDelegateExternalData
+}
+
+export const StakeDelegatePageView: FC<StakeDelegatePageViewProps> = ({
+  walletAddress,
+  externalData,
+}) => {
+  const [state, dispatch] = useReducer(claimDelegateReducer, {
+    ...claimDelegateState,
+    walletAddress,
+  })
+
+  return (
+    <div className={classNames.stakeDelegatePageWrapper}>
+      <div className={classNames.stakeDelegateHeaderWrapper}>
+        <div className={classNames.pathLinkWrapper}>
+          <Link
+            href={`/earn/portfolio/${state.walletAddress}?tab=${PortfolioTabs.REWARDS}`}
+            prefetch
+          >
+            <Text as="p" variant="p1" style={{ color: 'var(--earn-protocol-secondary-40)' }}>
+              $SUMR
+            </Text>
+          </Link>{' '}
+          /{' '}
+          <Text as="p" variant="p1">
+            Stake & Delegate
+          </Text>
+        </div>
+        <Text as="h2" variant="h2">
+          Stake & Delegate
+        </Text>
+      </div>
+      <Card variant="cardSecondary" className={classNames.stakeDelegateForm}>
+        <ClaimDelegateStakeDelegateStep
+          state={state}
+          dispatch={dispatch}
+          externalData={externalData}
+        />
+      </Card>
+    </div>
+  )
+}

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep.tsx
@@ -6,7 +6,7 @@ import {
   type ClaimDelegateReducerAction,
   type ClaimDelegateState,
   ClaimDelegateSteps,
-  type ClamDelegateExternalData,
+  type ClaimDelegateExternalData,
 } from '@/features/claim-and-delegate/types'
 
 import classNames from './ClaimDelegateClaimStep.module.scss'
@@ -14,7 +14,7 @@ import classNames from './ClaimDelegateClaimStep.module.scss'
 interface ClaimDelegateClaimStepProps {
   state: ClaimDelegateState
   dispatch: Dispatch<ClaimDelegateReducerAction>
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimDelegateClaimStep: FC<ClaimDelegateClaimStepProps> = ({

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateForm/ClaimDelegateForm.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateForm/ClaimDelegateForm.tsx
@@ -5,9 +5,9 @@ import { Card } from '@summerfi/app-earn-ui'
 import { ClaimDelegateFormContent } from '@/features/claim-and-delegate/components/ClaimDelegateFormContent/ClaimDelegateFormContent'
 import { ClaimDelegateFormHeader } from '@/features/claim-and-delegate/components/ClaimDelegateFormHeader/ClaimDelegateFormHeader'
 import type {
+  ClaimDelegateExternalData,
   ClaimDelegateReducerAction,
   ClaimDelegateState,
-  ClamDelegateExternalData,
 } from '@/features/claim-and-delegate/types'
 
 import classNames from './ClaimDelegateForm.module.scss'
@@ -15,7 +15,7 @@ import classNames from './ClaimDelegateForm.module.scss'
 interface ClaimDelegateFormProps {
   state: ClaimDelegateState
   dispatch: Dispatch<ClaimDelegateReducerAction>
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimDelegateForm: FC<ClaimDelegateFormProps> = ({

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateFormContent/ClaimDelegateFormContent.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateFormContent/ClaimDelegateFormContent.tsx
@@ -4,10 +4,10 @@ import { ClaimDelegateAcceptanceStep } from '@/features/claim-and-delegate/compo
 import { ClaimDelegateClaimStep } from '@/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep'
 import { ClaimDelegateStakeDelegateStep } from '@/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/ClaimDelegateStakeDelegateStep'
 import {
+  type ClaimDelegateExternalData,
   type ClaimDelegateReducerAction,
   type ClaimDelegateState,
   ClaimDelegateSteps,
-  type ClamDelegateExternalData,
 } from '@/features/claim-and-delegate/types'
 
 import classNames from './ClaimDelegateFormContent.module.scss'
@@ -15,7 +15,7 @@ import classNames from './ClaimDelegateFormContent.module.scss'
 interface ClaimDelegateFormContentProps {
   state: ClaimDelegateState
   dispatch: Dispatch<ClaimDelegateReducerAction>
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimDelegateFormContent: FC<ClaimDelegateFormContentProps> = ({

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/ClaimDelegateStakeDelegateStep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/ClaimDelegateStakeDelegateStep.tsx
@@ -3,16 +3,16 @@ import type { Dispatch, FC } from 'react'
 import { ClaimDelegateStakeDelegateCompletedSubstep } from '@/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateCompletedSubstep/ClaimDelegateStakeDelegateCompletedSubstep'
 import { ClaimDelegateStakeDelegateSubstep } from '@/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep'
 import {
+  type ClaimDelegateExternalData,
   type ClaimDelegateReducerAction,
   type ClaimDelegateState,
   ClaimDelegateTxStatuses,
-  type ClamDelegateExternalData,
 } from '@/features/claim-and-delegate/types'
 
 interface ClaimDelegateStakeDelegateStepProps {
   state: ClaimDelegateState
   dispatch: Dispatch<ClaimDelegateReducerAction>
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimDelegateStakeDelegateStep: FC<ClaimDelegateStakeDelegateStepProps> = ({
@@ -21,7 +21,7 @@ export const ClaimDelegateStakeDelegateStep: FC<ClaimDelegateStakeDelegateStepPr
   externalData,
 }) => {
   return (
-    <div>
+    <>
       {state.delegateStatus !== ClaimDelegateTxStatuses.COMPLETED && (
         <ClaimDelegateStakeDelegateSubstep
           state={state}
@@ -36,6 +36,6 @@ export const ClaimDelegateStakeDelegateStep: FC<ClaimDelegateStakeDelegateStepPr
           externalData={externalData}
         />
       )}
-    </div>
+    </>
   )
 }

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateCompletedSubstep/ClaimDelegateStakeDelegateCompletedSubstep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateCompletedSubstep/ClaimDelegateStakeDelegateCompletedSubstep.tsx
@@ -6,9 +6,9 @@ import { useParams } from 'next/navigation'
 
 import { sumrDelegates } from '@/features/claim-and-delegate/consts'
 import type {
+  ClaimDelegateExternalData,
   ClaimDelegateReducerAction,
   ClaimDelegateState,
-  ClamDelegateExternalData,
 } from '@/features/claim-and-delegate/types'
 import { PortfolioTabs } from '@/features/portfolio/types'
 
@@ -17,7 +17,7 @@ import classNames from './ClaimDelegateStakeDelegateCompletedSubstep.module.scss
 interface ClaimDelegateStakeDelegateCompletedSubstepProps {
   state: ClaimDelegateState
   dispatch: Dispatch<ClaimDelegateReducerAction>
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimDelegateStakeDelegateCompletedSubstep: FC<

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep.module.scss
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep.module.scss
@@ -3,6 +3,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--general-space-16);
+  width: 100%;
 
   .leftContent {
     display: flex;

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep.tsx
@@ -10,7 +10,7 @@ import {
   type ClaimDelegateReducerAction,
   type ClaimDelegateState,
   ClaimDelegateTxStatuses,
-  type ClamDelegateExternalData,
+  type ClaimDelegateExternalData,
 } from '@/features/claim-and-delegate/types'
 import { PortfolioTabs } from '@/features/portfolio/types'
 
@@ -19,7 +19,7 @@ import classNames from './ClaimDelegateStakeDelegateSubstep.module.scss'
 interface ClaimDelegateStakeDelegateSubstepProps {
   state: ClaimDelegateState
   dispatch: Dispatch<ClaimDelegateReducerAction>
-  externalData: ClamDelegateExternalData
+  externalData: ClaimDelegateExternalData
 }
 
 export const ClaimDelegateStakeDelegateSubstep: FC<ClaimDelegateStakeDelegateSubstepProps> = ({

--- a/apps/earn-protocol/features/claim-and-delegate/types.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/types.ts
@@ -36,7 +36,7 @@ export type ClaimDelegateReducerAction =
       payload: ClaimDelegateTxStatuses
     }
 
-export type ClamDelegateExternalData = {
+export type ClaimDelegateExternalData = {
   sumrPrice: string
   sumrEarned: string
   sumrApy: string

--- a/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
@@ -38,6 +38,7 @@ const SumrAvailableToClaim = () => {
 }
 
 const StakedAndDelegatedSumr = () => {
+  const { walletAddress } = useParams()
   const rawApy = 0.026
   const rawStaked = 3500
 
@@ -58,7 +59,7 @@ const StakedAndDelegatedSumr = () => {
         valueSize: 'large',
       }}
       actionable={
-        <Link href="/" target="_blank">
+        <Link href={`/earn/stake-delegate/${walletAddress}`} prefetch>
           <Text variant="p3semi" style={{ color: 'var(--earn-protocol-primary-100)' }}>
             Stake and delegate
           </Text>
@@ -104,6 +105,7 @@ const YourTotalSumr = () => {
 }
 
 const YourDelegate = () => {
+  const { walletAddress } = useParams()
   const value = 'No delegate'
 
   return (
@@ -115,7 +117,7 @@ const YourDelegate = () => {
         valueSize: 'large',
       }}
       actionable={
-        <Link href="/" target="_blank">
+        <Link href={`/earn/stake-delegate/${walletAddress}`} prefetch>
           <Text variant="p3semi" style={{ color: 'var(--earn-protocol-primary-100)' }}>
             Change delegate
           </Text>


### PR DESCRIPTION
- Introduced new `StakeDelegateRedirectPage` and `StakeDelegatePage` components for handling stake delegation navigation.
- Implemented validation for wallet addresses in `StakeDelegatePage`, redirecting to the earn page if invalid.
- Created `StakeDelegatePageView` component to display staking information, utilizing a new `ClaimDelegateExternalData` type.
- Updated existing components to replace `ClamDelegateExternalData` with the corrected `ClaimDelegateExternalData` type for consistency.
- Added styles for the new `StakeDelegatePageView` component.

This commit enhances the user experience by providing dedicated pages for stake delegation and ensuring type consistency across the application.

## Description
[Provide a brief description of the changes in this PR]

## Changes
- [List the main changes made in bullet points]

## Benefits
1. [List the benefits of these changes]
2.
3.

## Testing
[Describe how these changes were tested or how they can be tested]

## Next steps
- [List any follow-up actions or considerations]

## Additional Notes
[Any additional information, context, or notes for reviewers]

Please review and provide any feedback or suggestions for improvement.
