### PR TITLE
Enhance rebalance activity tracking and display across portfolio components

### DIFF
--- a/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
+++ b/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
@@ -39,6 +39,11 @@ export const PortfolioPageView: FC<PortfolioPageViewProps> = ({
     defaultTab: PortfolioTabs.OVERVIEW,
   })
 
+  const totalRebalances = positions.reduce(
+    (acc, position) => acc + Number(position.vaultData.rebalanceCount),
+    0,
+  )
+
   const tabs = [
     {
       id: PortfolioTabs.OVERVIEW,
@@ -54,7 +59,11 @@ export const PortfolioPageView: FC<PortfolioPageViewProps> = ({
       id: PortfolioTabs.REBALANCE_ACTIVITY,
       label: 'Rebalance Activity',
       content: (
-        <PortfolioRebalanceActivity rebalancesList={rebalancesList} walletAddress={walletAddress} />
+        <PortfolioRebalanceActivity
+          rebalancesList={rebalancesList}
+          walletAddress={walletAddress}
+          totalRebalances={totalRebalances}
+        />
       ),
     },
     {

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
@@ -312,7 +312,11 @@ export const VaultManageViewComponent = ({
             }
             defaultExpanded
           >
-            <RebalancingActivity rebalancesList={rebalancesList} vaultId={vault.id} />
+            <RebalancingActivity
+              rebalancesList={rebalancesList}
+              vaultId={vault.id}
+              totalRebalances={Number(vault.rebalanceCount)}
+            />
           </Expander>
           <Expander
             title={

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -303,7 +303,11 @@ export const VaultOpenViewComponent = ({
             }
             defaultExpanded
           >
-            <RebalancingActivity rebalancesList={rebalancesList} vaultId={vault.id} />
+            <RebalancingActivity
+              rebalancesList={rebalancesList}
+              vaultId={vault.id}
+              totalRebalances={Number(vault.rebalanceCount)}
+            />
           </Expander>
           <Expander
             title={

--- a/apps/earn-protocol/features/portfolio/components/PortfolioRebalanceActivity/PortfolioRebalanceActivity.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioRebalanceActivity/PortfolioRebalanceActivity.tsx
@@ -13,6 +13,7 @@ import classNames from './PortfolioRebalanceActivity.module.scss'
 interface PortfolioRebalanceActivityProps {
   rebalancesList: SDKGlobalRebalancesType
   walletAddress: string
+  totalRebalances: number
 }
 
 const initialRows = 10
@@ -20,10 +21,13 @@ const initialRows = 10
 export const PortfolioRebalanceActivity: FC<PortfolioRebalanceActivityProps> = ({
   rebalancesList,
   walletAddress,
+  totalRebalances,
 }) => {
-  const totalItems = rebalancesList.length
-  const savedTimeInHours = useMemo(() => getRebalanceSavedTimeInHours(totalItems), [totalItems])
-  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalItems), [totalItems])
+  const savedTimeInHours = useMemo(
+    () => getRebalanceSavedTimeInHours(totalRebalances),
+    [totalRebalances],
+  )
+  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalRebalances), [totalRebalances])
 
   const [current, setCurrent] = useState(initialRows)
 
@@ -42,7 +46,7 @@ export const PortfolioRebalanceActivity: FC<PortfolioRebalanceActivityProps> = (
   const blocks = [
     {
       title: 'Rebalance actions',
-      value: formatShorthandNumber(totalItems, { precision: 0 }),
+      value: formatShorthandNumber(totalRebalances, { precision: 0 }),
     },
     {
       title: 'User saved time',
@@ -70,7 +74,10 @@ export const PortfolioRebalanceActivity: FC<PortfolioRebalanceActivityProps> = (
           />
         ))}
       </div>
-      <InfiniteScroll loadMore={handleMoreItems} hasMore={totalItems > currentlyLoadedList.length}>
+      <InfiniteScroll
+        loadMore={handleMoreItems}
+        hasMore={totalRebalances > currentlyLoadedList.length}
+      >
         <PortfolioRebalanceActivityList
           rebalancesList={currentlyLoadedList}
           walletAddress={walletAddress}

--- a/apps/earn-protocol/features/rebalance-activity/components/RebalanceActivityView/RebalanceActivityView.tsx
+++ b/apps/earn-protocol/features/rebalance-activity/components/RebalanceActivityView/RebalanceActivityView.tsx
@@ -107,7 +107,7 @@ export const RebalanceActivityView: FC<RebalanceActivityViewProps> = ({
     },
   ]
 
-  const totalItems = rebalancesList.length
+  const totalItems = vaultsList.reduce((acc, vault) => acc + Number(vault.rebalanceCount), 0)
   const savedTimeInHours = useMemo(() => getRebalanceSavedTimeInHours(totalItems), [totalItems])
   const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalItems), [totalItems])
 

--- a/apps/earn-protocol/features/rebalance-activity/components/RebalancingActivity/RebalancingActivity.tsx
+++ b/apps/earn-protocol/features/rebalance-activity/components/RebalancingActivity/RebalancingActivity.tsx
@@ -11,14 +11,21 @@ import { getRebalanceSavedTimeInHours } from '@/features/rebalance-activity/help
 interface RebalancingActivityProps {
   rebalancesList: SDKGlobalRebalancesType
   vaultId: string
+  totalRebalances: number
 }
 
 const rowsToDisplay = 4
 
-export const RebalancingActivity: FC<RebalancingActivityProps> = ({ rebalancesList, vaultId }) => {
-  const totalItems = rebalancesList.length
-  const savedTimeInHours = useMemo(() => getRebalanceSavedTimeInHours(totalItems), [totalItems])
-  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalItems), [totalItems])
+export const RebalancingActivity: FC<RebalancingActivityProps> = ({
+  rebalancesList,
+  vaultId,
+  totalRebalances,
+}) => {
+  const savedTimeInHours = useMemo(
+    () => getRebalanceSavedTimeInHours(totalRebalances),
+    [totalRebalances],
+  )
+  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalRebalances), [totalRebalances])
 
   return (
     <Card style={{ marginTop: 'var(--spacing-space-medium)' }}>
@@ -34,7 +41,7 @@ export const RebalancingActivity: FC<RebalancingActivityProps> = ({ rebalancesLi
             flexWrap: 'wrap',
           }}
         >
-          <DataBlock title="Rebalance actions" size="small" value={`${rebalancesList.length}`} />
+          <DataBlock title="Rebalance actions" size="small" value={`${totalRebalances}`} />
           <DataBlock title="User saved time" size="small" value={`${savedTimeInHours} Hours`} />
           <DataBlock
             title="Gas cost savings"

--- a/apps/earn-protocol/graphql/clients/position-history/client.ts
+++ b/apps/earn-protocol/graphql/clients/position-history/client.ts
@@ -460,6 +460,7 @@ export enum ArkDailySnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -683,6 +684,7 @@ export enum ArkHourlySnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -1036,6 +1038,7 @@ export enum Ark_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -1367,6 +1370,7 @@ export enum Board_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -1485,6 +1489,7 @@ export enum DailyInterestRate_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -1826,6 +1831,7 @@ export enum Deposit_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -2147,6 +2153,7 @@ export enum Disembark_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -2619,6 +2626,7 @@ export enum HourlyInterestRate_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -3503,6 +3511,7 @@ export enum Position_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -3739,6 +3748,7 @@ export enum PostActionArkSnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -3960,6 +3970,7 @@ export enum PostActionVaultSnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -5352,6 +5363,7 @@ export enum Rebalance_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -5499,6 +5511,7 @@ export enum RewardsManager_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -5840,6 +5853,7 @@ export enum Staked_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -7113,6 +7127,7 @@ export enum Unstaked_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -7486,6 +7501,7 @@ export type Vault = {
   pricePerShare?: Maybe<Scalars['BigDecimal']['output']>;
   /**  The protocol this vault belongs to  */
   protocol: YieldAggregator;
+  rebalanceCount: Scalars['BigInt']['output'];
   rebalances: Array<Rebalance>;
   /**  Per-block reward token emission as of the current block normalized to a day, in token's native amount. This should be ideally calculated as the theoretical rate instead of the realized amount.  */
   rewardTokenEmissionsAmount: Array<Scalars['BigInt']['output']>;
@@ -7960,6 +7976,7 @@ export enum VaultDailySnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -8330,6 +8347,7 @@ export enum VaultHourlySnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -8643,6 +8661,7 @@ export enum VaultWeeklySnapshot_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -8980,6 +8999,14 @@ export type Vault_Filter = {
   protocol_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   protocol_starts_with?: InputMaybe<Scalars['String']['input']>;
   protocol_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rebalanceCount?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rebalanceCount_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_not?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   rebalances_?: InputMaybe<Rebalance_Filter>;
   rewardTokenEmissionsAmount?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   rewardTokenEmissionsAmount_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -9150,6 +9177,7 @@ export enum Vault_OrderBy {
   protocol__totalPoolCount = 'protocol__totalPoolCount',
   protocol__totalValueLockedUSD = 'protocol__totalValueLockedUSD',
   protocol__type = 'protocol__type',
+  rebalanceCount = 'rebalanceCount',
   rebalances = 'rebalances',
   rewardTokenEmissionsAmount = 'rewardTokenEmissionsAmount',
   rewardTokenEmissionsAmountsPerOutputToken = 'rewardTokenEmissionsAmountsPerOutputToken',
@@ -9279,6 +9307,7 @@ export enum WeeklyInterestRate_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',
@@ -9620,6 +9649,7 @@ export enum Withdraw_OrderBy {
   vault__outputTokenPriceUSD = 'vault__outputTokenPriceUSD',
   vault__outputTokenSupply = 'vault__outputTokenSupply',
   vault__pricePerShare = 'vault__pricePerShare',
+  vault__rebalanceCount = 'vault__rebalanceCount',
   vault__stakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   vault__stakingRewardsManager = 'vault__stakingRewardsManager',
   vault__symbol = 'vault__symbol',

--- a/sdk/subgraph-manager-common/src/generated/client.ts
+++ b/sdk/subgraph-manager-common/src/generated/client.ts
@@ -460,6 +460,7 @@ export enum ArkDailySnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -683,6 +684,7 @@ export enum ArkHourlySnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -1036,6 +1038,7 @@ export enum Ark_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -1367,6 +1370,7 @@ export enum Board_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -1485,6 +1489,7 @@ export enum DailyInterestRate_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -1826,6 +1831,7 @@ export enum Deposit_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -2147,6 +2153,7 @@ export enum Disembark_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -2619,6 +2626,7 @@ export enum HourlyInterestRate_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -3503,6 +3511,7 @@ export enum Position_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -3739,6 +3748,7 @@ export enum PostActionArkSnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -3960,6 +3970,7 @@ export enum PostActionVaultSnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -5352,6 +5363,7 @@ export enum Rebalance_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -5499,6 +5511,7 @@ export enum RewardsManager_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -5840,6 +5853,7 @@ export enum Staked_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -7113,6 +7127,7 @@ export enum Unstaked_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -7486,6 +7501,7 @@ export type Vault = {
   pricePerShare?: Maybe<Scalars['BigDecimal']['output']>;
   /**  The protocol this vault belongs to  */
   protocol: YieldAggregator;
+  rebalanceCount: Scalars['BigInt']['output'];
   rebalances: Array<Rebalance>;
   /**  Per-block reward token emission as of the current block normalized to a day, in token's native amount. This should be ideally calculated as the theoretical rate instead of the realized amount.  */
   rewardTokenEmissionsAmount: Array<Scalars['BigInt']['output']>;
@@ -7960,6 +7976,7 @@ export enum VaultDailySnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -8330,6 +8347,7 @@ export enum VaultHourlySnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -8643,6 +8661,7 @@ export enum VaultWeeklySnapshot_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -8980,6 +8999,14 @@ export type Vault_Filter = {
   protocol_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   protocol_starts_with?: InputMaybe<Scalars['String']['input']>;
   protocol_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rebalanceCount?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rebalanceCount_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_not?: InputMaybe<Scalars['BigInt']['input']>;
+  rebalanceCount_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   rebalances_?: InputMaybe<Rebalance_Filter>;
   rewardTokenEmissionsAmount?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   rewardTokenEmissionsAmount_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -9150,6 +9177,7 @@ export enum Vault_OrderBy {
   ProtocolTotalPoolCount = 'protocol__totalPoolCount',
   ProtocolTotalValueLockedUsd = 'protocol__totalValueLockedUSD',
   ProtocolType = 'protocol__type',
+  RebalanceCount = 'rebalanceCount',
   Rebalances = 'rebalances',
   RewardTokenEmissionsAmount = 'rewardTokenEmissionsAmount',
   RewardTokenEmissionsAmountsPerOutputToken = 'rewardTokenEmissionsAmountsPerOutputToken',
@@ -9279,6 +9307,7 @@ export enum WeeklyInterestRate_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -9620,6 +9649,7 @@ export enum Withdraw_OrderBy {
   VaultOutputTokenPriceUsd = 'vault__outputTokenPriceUSD',
   VaultOutputTokenSupply = 'vault__outputTokenSupply',
   VaultPricePerShare = 'vault__pricePerShare',
+  VaultRebalanceCount = 'vault__rebalanceCount',
   VaultStakedOutputTokenAmount = 'vault__stakedOutputTokenAmount',
   VaultStakingRewardsManager = 'vault__stakingRewardsManager',
   VaultSymbol = 'vault__symbol',
@@ -10005,7 +10035,7 @@ export type GetUserPositionsQueryVariables = Exact<{
 }>;
 
 
-export type GetUserPositionsQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string } }> };
+export type GetUserPositionsQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, rebalanceCount: bigint, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string } }> };
 
 export type GetUserPositionQueryVariables = Exact<{
   accountAddress: Scalars['String']['input'];
@@ -10030,14 +10060,14 @@ export type GetUsersActivityQuery = { __typename?: 'Query', positions: Array<{ _
 export type GetVaultsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetVaultsQuery = { __typename?: 'Query', vaults: Array<{ __typename?: 'Vault', id: string, name?: string | null, rewardTokenEmissionsAmount: Array<bigint>, rewardTokenEmissionsUSD?: Array<string> | null, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, depositLimit: bigint, createdTimestamp: bigint, totalValueLockedUSD: string, cumulativeTotalRevenueUSD: string, cumulativeSupplySideRevenueUSD: string, cumulativeProtocolSideRevenueUSD: string, lastUpdateTimestamp: bigint, apr7d: string, apr30d: string, apr90d: string, apr180d: string, apr365d: string, calculatedApr: string, aprValues: Array<string>, withdrawableTotalAssets?: bigint | null, withdrawableTotalAssetsUSD?: string | null, protocol: { __typename?: 'YieldAggregator', network: Network }, rewardTokens: Array<{ __typename?: 'RewardToken', id: string, token: { __typename?: 'Token', id: string, symbol: string, decimals: number } }>, arks: Array<{ __typename?: 'Ark', id: string, name?: string | null, details?: string | null, createdTimestamp: bigint, lastUpdateTimestamp: bigint, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, fees: Array<{ __typename?: 'VaultFee', id: string, feePercentage?: string | null, feeType: VaultFeeType }> }>, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number } | null, dailyInterestRates: Array<{ __typename?: 'DailyInterestRate', averageRate: string, date: bigint }>, hourlyInterestRates: Array<{ __typename?: 'HourlyInterestRate', averageRate: string, date: bigint }>, weeklyInterestRates: Array<{ __typename?: 'WeeklyInterestRate', averageRate: string, date: bigint }> }> };
+export type GetVaultsQuery = { __typename?: 'Query', vaults: Array<{ __typename?: 'Vault', id: string, name?: string | null, rewardTokenEmissionsAmount: Array<bigint>, rewardTokenEmissionsUSD?: Array<string> | null, rebalanceCount: bigint, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, depositLimit: bigint, createdTimestamp: bigint, totalValueLockedUSD: string, cumulativeTotalRevenueUSD: string, cumulativeSupplySideRevenueUSD: string, cumulativeProtocolSideRevenueUSD: string, lastUpdateTimestamp: bigint, apr7d: string, apr30d: string, apr90d: string, apr180d: string, apr365d: string, calculatedApr: string, aprValues: Array<string>, withdrawableTotalAssets?: bigint | null, withdrawableTotalAssetsUSD?: string | null, protocol: { __typename?: 'YieldAggregator', network: Network }, rewardTokens: Array<{ __typename?: 'RewardToken', id: string, token: { __typename?: 'Token', id: string, symbol: string, decimals: number } }>, arks: Array<{ __typename?: 'Ark', id: string, name?: string | null, details?: string | null, createdTimestamp: bigint, lastUpdateTimestamp: bigint, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, fees: Array<{ __typename?: 'VaultFee', id: string, feePercentage?: string | null, feeType: VaultFeeType }> }>, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number } | null, dailyInterestRates: Array<{ __typename?: 'DailyInterestRate', averageRate: string, date: bigint }>, hourlyInterestRates: Array<{ __typename?: 'HourlyInterestRate', averageRate: string, date: bigint }>, weeklyInterestRates: Array<{ __typename?: 'WeeklyInterestRate', averageRate: string, date: bigint }> }> };
 
 export type GetVaultQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetVaultQuery = { __typename?: 'Query', vault?: { __typename?: 'Vault', id: string, name?: string | null, rewardTokenEmissionsUSD?: Array<string> | null, rewardTokenEmissionsAmount: Array<bigint>, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, depositLimit: bigint, createdTimestamp: bigint, totalValueLockedUSD: string, cumulativeTotalRevenueUSD: string, cumulativeSupplySideRevenueUSD: string, cumulativeProtocolSideRevenueUSD: string, lastUpdateTimestamp: bigint, apr7d: string, apr30d: string, apr90d: string, apr180d: string, apr365d: string, calculatedApr: string, aprValues: Array<string>, withdrawableTotalAssets?: bigint | null, withdrawableTotalAssetsUSD?: string | null, protocol: { __typename?: 'YieldAggregator', network: Network }, rewardTokens: Array<{ __typename?: 'RewardToken', id: string, token: { __typename?: 'Token', id: string, symbol: string, decimals: number } }>, rebalances: Array<{ __typename?: 'Rebalance', id: string, amount: bigint, amountUSD: string, timestamp: bigint, asset: { __typename?: 'Token', id: string, symbol: string, decimals: number }, from: { __typename?: 'Ark', name?: string | null, depositLimit: bigint, calculatedApr: string, totalValueLockedUSD: string }, to: { __typename?: 'Ark', name?: string | null, depositLimit: bigint, calculatedApr: string, totalValueLockedUSD: string }, toPostAction: { __typename?: 'PostActionArkSnapshot', totalValueLockedUSD: string, depositLimit: bigint }, fromPostAction: { __typename?: 'PostActionArkSnapshot', totalValueLockedUSD: string, depositLimit: bigint }, protocol: { __typename?: 'YieldAggregator', name: string, network: Network }, vault: { __typename?: 'Vault', id: string, name?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string } } }>, arks: Array<{ __typename?: 'Ark', id: string, name?: string | null, details?: string | null, depositLimit: bigint, cumulativeEarnings: bigint, inputTokenBalance: bigint, calculatedApr: string, createdTimestamp: bigint, lastUpdateTimestamp: bigint, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, dailySnapshots: Array<{ __typename?: 'ArkDailySnapshot', id: string, apr: string, totalValueLockedUSD: string, inputTokenBalance: bigint }>, hourlySnapshots: Array<{ __typename?: 'ArkHourlySnapshot', id: string, calculatedApr: string, totalValueLockedUSD: string, inputTokenBalance: bigint }>, fees: Array<{ __typename?: 'VaultFee', id: string, feePercentage?: string | null, feeType: VaultFeeType }> }>, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number } | null, dailyInterestRates: Array<{ __typename?: 'DailyInterestRate', averageRate: string, date: bigint }>, hourlyInterestRates: Array<{ __typename?: 'HourlyInterestRate', averageRate: string, date: bigint }>, weeklyInterestRates: Array<{ __typename?: 'WeeklyInterestRate', averageRate: string, date: bigint }> } | null };
+export type GetVaultQuery = { __typename?: 'Query', vault?: { __typename?: 'Vault', id: string, name?: string | null, rewardTokenEmissionsUSD?: Array<string> | null, rewardTokenEmissionsAmount: Array<bigint>, rebalanceCount: bigint, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, depositLimit: bigint, createdTimestamp: bigint, totalValueLockedUSD: string, cumulativeTotalRevenueUSD: string, cumulativeSupplySideRevenueUSD: string, cumulativeProtocolSideRevenueUSD: string, lastUpdateTimestamp: bigint, apr7d: string, apr30d: string, apr90d: string, apr180d: string, apr365d: string, calculatedApr: string, aprValues: Array<string>, withdrawableTotalAssets?: bigint | null, withdrawableTotalAssetsUSD?: string | null, protocol: { __typename?: 'YieldAggregator', network: Network }, rewardTokens: Array<{ __typename?: 'RewardToken', id: string, token: { __typename?: 'Token', id: string, symbol: string, decimals: number } }>, rebalances: Array<{ __typename?: 'Rebalance', id: string, amount: bigint, amountUSD: string, timestamp: bigint, asset: { __typename?: 'Token', id: string, symbol: string, decimals: number }, from: { __typename?: 'Ark', name?: string | null, depositLimit: bigint, calculatedApr: string, totalValueLockedUSD: string }, to: { __typename?: 'Ark', name?: string | null, depositLimit: bigint, calculatedApr: string, totalValueLockedUSD: string }, toPostAction: { __typename?: 'PostActionArkSnapshot', totalValueLockedUSD: string, depositLimit: bigint }, fromPostAction: { __typename?: 'PostActionArkSnapshot', totalValueLockedUSD: string, depositLimit: bigint }, protocol: { __typename?: 'YieldAggregator', name: string, network: Network }, vault: { __typename?: 'Vault', id: string, name?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string } } }>, arks: Array<{ __typename?: 'Ark', id: string, name?: string | null, details?: string | null, depositLimit: bigint, cumulativeEarnings: bigint, inputTokenBalance: bigint, calculatedApr: string, createdTimestamp: bigint, lastUpdateTimestamp: bigint, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, dailySnapshots: Array<{ __typename?: 'ArkDailySnapshot', id: string, apr: string, totalValueLockedUSD: string, inputTokenBalance: bigint }>, hourlySnapshots: Array<{ __typename?: 'ArkHourlySnapshot', id: string, calculatedApr: string, totalValueLockedUSD: string, inputTokenBalance: bigint }>, fees: Array<{ __typename?: 'VaultFee', id: string, feePercentage?: string | null, feeType: VaultFeeType }> }>, inputToken: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, name: string, symbol: string, decimals: number } | null, dailyInterestRates: Array<{ __typename?: 'DailyInterestRate', averageRate: string, date: bigint }>, hourlyInterestRates: Array<{ __typename?: 'HourlyInterestRate', averageRate: string, date: bigint }>, weeklyInterestRates: Array<{ __typename?: 'WeeklyInterestRate', averageRate: string, date: bigint }> } | null };
 
 
 export const GetGlobalRebalancesDocument = gql`
@@ -10113,6 +10143,7 @@ export const GetUserPositionsDocument = gql`
       inputTokenBalance
       inputTokenPriceUSD
       outputTokenPriceUSD
+      rebalanceCount
       inputToken {
         id
         symbol
@@ -10275,6 +10306,7 @@ export const GetVaultsDocument = gql`
     }
     rewardTokenEmissionsAmount
     rewardTokenEmissionsUSD
+    rebalanceCount
     arks {
       id
       name
@@ -10357,6 +10389,7 @@ export const GetVaultDocument = gql`
     }
     rewardTokenEmissionsUSD
     rewardTokenEmissionsAmount
+    rebalanceCount
     rebalances(orderBy: timestamp, orderDirection: desc) {
       id
       amount

--- a/sdk/subgraph-manager-common/src/queries/positions.graphql
+++ b/sdk/subgraph-manager-common/src/queries/positions.graphql
@@ -21,6 +21,7 @@ query GetUserPositions($accountAddress: String!) {
       inputTokenBalance
       inputTokenPriceUSD
       outputTokenPriceUSD
+      rebalanceCount
       inputToken {
         id
         symbol

--- a/sdk/subgraph-manager-common/src/queries/vaults.graphql
+++ b/sdk/subgraph-manager-common/src/queries/vaults.graphql
@@ -15,6 +15,7 @@ query GetVaults {
     }
     rewardTokenEmissionsAmount
     rewardTokenEmissionsUSD
+    rebalanceCount
     arks {
       id
       name
@@ -108,6 +109,7 @@ query GetVault($id: ID!) {
     }
     rewardTokenEmissionsUSD
     rewardTokenEmissionsAmount
+    rebalanceCount
     rebalances(orderBy: timestamp, orderDirection: desc) {
       id
       amount


### PR DESCRIPTION
## Description
Add rebalanceCount field to track total rebalances across vaults and positions

## Changes
- Added rebalanceCount field to Vault type in GraphQL schema
- Updated components to use totalRebalances instead of rebalancesList length
- Modified queries to include rebalanceCount field
- Added rebalanceCount to OrderBy enums and filters

## Benefits
1. More accurate tracking of total rebalances directly from the vault
2. Better performance by using stored count instead of array length
3. Consistent rebalance counting across different views

## Testing
- Verify rebalanceCount appears in vault queries
- Check that rebalance activity views show correct totals
- Confirm portfolio view displays accurate rebalance counts
- Test that infinite scroll pagination works with new count

## Next steps
- Monitor performance impact of using stored count vs array length
- Consider adding rebalance count analytics/metrics
- Update documentation to reflect new rebalance counting method

## Additional Notes
This change improves data accuracy and performance by using a stored rebalanceCount instead of calculating it from the rebalancesList length. The implementation is consistent across portfolio, vault manage, and vault open views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a `rebalanceCount` field to track the number of rebalance operations for vaults
	- Enhanced rebalancing activity views with total rebalances information

- **Improvements**
	- Updated portfolio and vault management components to display more detailed rebalancing metrics
	- Modified GraphQL queries to retrieve rebalance count for vaults and positions

- **Technical Updates**
	- Introduced new prop `totalRebalances` across multiple components to provide comprehensive rebalancing insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->