### PR TITLE
Refactor Transak network handling in PortfolioHeader and TransakWidget components

### DIFF
--- a/apps/earn-protocol/features/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -1,35 +1,15 @@
 import { type FC, useState } from 'react'
 import { useUser } from '@account-kit/react'
 import { Button, DataBlock, Dropdown, Icon, LoadableAvatar, Text } from '@summerfi/app-earn-ui'
-import { type IconNamesList } from '@summerfi/app-types'
+import { type DropdownRawOption } from '@summerfi/app-types'
 import { formatAddress, formatCryptoBalance, formatFiatBalance } from '@summerfi/app-utils'
 
 import { TransakWidget } from '@/features/transak/components/TransakWidget/TransakWidget'
+import { transakNetworkOptions } from '@/features/transak/consts'
+import { type TransakNetworkOption } from '@/features/transak/types'
 import { useUserWallet } from '@/hooks/use-user-wallet'
 
 import classNames from './PortfolioHeader.module.scss'
-
-const transakNetworkOptions: {
-  label: string
-  value: string
-  iconName: IconNamesList
-}[] = [
-  {
-    label: 'Ethereum',
-    value: 'ethereum',
-    iconName: 'earn_network_ethereum',
-  },
-  {
-    label: 'Base',
-    value: 'base',
-    iconName: 'earn_network_base',
-  },
-  {
-    label: 'Arbitrum',
-    value: 'arbitrum',
-    iconName: 'earn_network_arbitrum',
-  },
-]
 
 const TransakTrigger = ({
   isOpen,
@@ -65,11 +45,11 @@ export const PortfolioHeader: FC<PortfolioHeaderProps> = ({
 }) => {
   const { userWalletAddress } = useUserWallet()
   const [isTransakOpen, setIsTransakOpen] = useState(false)
-  const [transakNetwork, setTransakNetwork] = useState<string | null>(null)
+  const [transakNetwork, setTransakNetwork] = useState<TransakNetworkOption | null>(null)
   const user = useUser()
 
-  const handleNetworkSelect = (option: { value: string }) => {
-    setTransakNetwork(option.value)
+  const handleNetworkSelect = (option: DropdownRawOption) => {
+    setTransakNetwork(transakNetworkOptions.find((item) => item.value === option.value) ?? null)
     setIsTransakOpen(true)
   }
 
@@ -87,7 +67,7 @@ export const PortfolioHeader: FC<PortfolioHeaderProps> = ({
             Swap
           </Button> */}
           <Dropdown
-            dropdownValue={{ value: transakNetwork ?? '', content: null }}
+            dropdownValue={{ value: transakNetwork?.value ?? '', content: null }}
             trigger={TransakTrigger}
             isDisabled={!userWalletAddress}
             options={transakNetworkOptions.map((option) => ({

--- a/apps/earn-protocol/features/transak/components/TransakWidget/TransakWidget.tsx
+++ b/apps/earn-protocol/features/transak/components/TransakWidget/TransakWidget.tsx
@@ -25,6 +25,7 @@ import { transakInitialReducerState, transakReducer } from '@/features/transak/s
 import {
   TransakAction,
   type TransakEventOrderData,
+  type TransakNetworkOption,
   TransakOrderDataStatus,
   TransakSteps,
 } from '@/features/transak/types'
@@ -35,7 +36,7 @@ interface TransakWidgetProps {
   onClose: () => void
   walletAddress: string
   email?: string
-  injectedNetwork?: string
+  injectedNetwork?: TransakNetworkOption
 }
 
 export const TransakWidget: FC<TransakWidgetProps> = ({
@@ -56,6 +57,8 @@ export const TransakWidget: FC<TransakWidgetProps> = ({
   })
 
   const { step, fiatAmount, fiatCurrency, paymentMethod, eventOrderData } = state
+
+  const resolvedChainId = injectedNetwork ? injectedNetwork.chainId : chain.id
 
   useEffect(() => {
     if (isOpen) {
@@ -134,7 +137,7 @@ export const TransakWidget: FC<TransakWidgetProps> = ({
           [SDKChainId.MAINNET]: 'ethereum',
           [SDKChainId.BASE]: 'base',
           [SDKChainId.ARBITRUM]: 'arbitrum',
-        }[chain.id],
+        }[resolvedChainId],
         email,
         ...getTransakConfigInitData({
           fiatAmount,
@@ -152,7 +155,12 @@ export const TransakWidget: FC<TransakWidgetProps> = ({
 
   const sidebarProps: SidebarProps = {
     title: getTransakTitle({ state }),
-    content: getTransakContent({ dispatch, state, isMobile, injectedNetwork }),
+    content: getTransakContent({
+      dispatch,
+      state,
+      isMobile,
+      injectedNetworkValue: injectedNetwork?.value,
+    }),
     primaryButton: {
       label: getTransakPrimaryButtonLabel({ state }),
       action: async () => {
@@ -160,7 +168,7 @@ export const TransakWidget: FC<TransakWidgetProps> = ({
           case TransakSteps.INITIAL:
             return dispatch({ type: 'update-step', payload: TransakSteps.ABOUT_KYC })
           case TransakSteps.ABOUT_KYC:
-            if (chain.id === SDKChainId.MAINNET) {
+            if (chain.id === SDKChainId.MAINNET && !injectedNetwork) {
               return dispatch({ type: 'update-step', payload: TransakSteps.SWITCH_TO_L2 })
             }
 

--- a/apps/earn-protocol/features/transak/consts.ts
+++ b/apps/earn-protocol/features/transak/consts.ts
@@ -1,6 +1,7 @@
-import { type DropdownOption, NetworkNames } from '@summerfi/app-types'
+import { type DropdownOption, NetworkNames, SDKChainId } from '@summerfi/app-types'
 
 import {
+  type TransakNetworkOption,
   TransakOrderDataStatus,
   TransakPaymentOptions,
   type TransakSupportedNetworksNames,
@@ -147,3 +148,24 @@ export const transakCryptoOptions: {
     },
   ],
 }
+
+export const transakNetworkOptions: TransakNetworkOption[] = [
+  {
+    label: 'Ethereum',
+    value: 'ethereum',
+    chainId: SDKChainId.MAINNET,
+    iconName: 'earn_network_ethereum',
+  },
+  {
+    label: 'Base',
+    value: 'base',
+    chainId: SDKChainId.BASE,
+    iconName: 'earn_network_base',
+  },
+  {
+    label: 'Arbitrum',
+    value: 'arbitrum',
+    chainId: SDKChainId.ARBITRUM,
+    iconName: 'earn_network_arbitrum',
+  },
+]

--- a/apps/earn-protocol/features/transak/helpers/get-transak-content.tsx
+++ b/apps/earn-protocol/features/transak/helpers/get-transak-content.tsx
@@ -25,12 +25,12 @@ export const getTransakContent = ({
   dispatch,
   state,
   isMobile,
-  injectedNetwork,
+  injectedNetworkValue,
 }: {
   dispatch: Dispatch<TransakReducerAction>
   state: TransakReducerState
   isMobile: boolean
-  injectedNetwork?: string
+  injectedNetworkValue?: string
 }): ReactNode => {
   switch (state.step) {
     case TransakSteps.INITIAL:
@@ -42,7 +42,9 @@ export const getTransakContent = ({
     case TransakSteps.SWITCH_TO_L2:
       return <TransakSwitchToL2Step dispatch={dispatch} />
     case TransakSteps.EXCHANGE:
-      return <TransakExchange dispatch={dispatch} state={state} injectedNetwork={injectedNetwork} />
+      return (
+        <TransakExchange dispatch={dispatch} state={state} injectedNetwork={injectedNetworkValue} />
+      )
     case TransakSteps.KYC:
       return (
         <div

--- a/apps/earn-protocol/features/transak/types.ts
+++ b/apps/earn-protocol/features/transak/types.ts
@@ -1,3 +1,4 @@
+import { type IconNamesList, type SDKChainId } from '@summerfi/app-types'
 import { type Transak } from '@transak/transak-sdk'
 
 import { type NetworkNames } from '@/constants/networks-list'
@@ -203,3 +204,10 @@ export type TransakSupportedNetworksNames =
   | NetworkNames.baseMainnet
   | NetworkNames.arbitrumMainnet
   | NetworkNames.optimismMainnet
+
+export interface TransakNetworkOption {
+  label: string
+  value: string
+  iconName: IconNamesList
+  chainId: SDKChainId
+}


### PR DESCRIPTION
## Description
Refactor Transak network handling to improve type safety and network selection logic

## Changes
- Move `transakNetworkOptions` to dedicated consts file
- Add `TransakNetworkOption` type with chainId support
- Update network selection handling in PortfolioHeader
- Improve type safety in TransakWidget component

## Benefits
1. Better type safety across Transak-related components
2. Centralized network configuration management
3. More reliable network switching behavior

## Testing
- Verify Transak widget opens correctly for each network
- Test network selection dropdown functionality
- Confirm proper network switching behavior

## Next steps
- Consider adding network validation checks
- Add error handling for unsupported networks

## Additional Notes
This refactor focuses on improving the type safety and maintainability of the Transak integration while keeping the core functionality unchanged.