### PR TITLE
Get SUMR balances from chain

### DIFF
--- a/apps/earn-protocol/app/earn/claim/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/earn/claim/[walletAddress]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 import { getDelegatesVotes } from '@/app/server-handlers/delegates-votes'
+import { getSumrBalances } from '@/app/server-handlers/sumr-balances'
 import { getSumrDelegateStake } from '@/app/server-handlers/sumr-delegate-stake'
 import { ClaimPageViewComponent } from '@/components/layout/ClaimPageView/ClaimPageViewComponent'
 import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/types'
@@ -21,9 +22,12 @@ const ClaimPage = async ({ params }: ClaimPageProps) => {
     redirect(`/earn`)
   }
 
-  const [votes, { sumrDelegated, delegatedTo }] = await Promise.all([
+  const [votes, sumrStakeDelegate, sumrBalances] = await Promise.all([
     getDelegatesVotes(),
     getSumrDelegateStake({
+      walletAddress,
+    }),
+    getSumrBalances({
       walletAddress,
     }),
   ])
@@ -34,9 +38,9 @@ const ClaimPage = async ({ params }: ClaimPageProps) => {
     sumrEarned: '123.45',
     sumrToClaim: '1.23',
     sumrApy: '0.0123',
-    sumrDelegated,
-    delegatedTo,
+    sumrStakeDelegate,
     votes,
+    sumrBalances,
   }
 
   return <ClaimPageViewComponent walletAddress={walletAddress} externalData={externalData} />

--- a/apps/earn-protocol/app/earn/portfolio/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/earn/portfolio/[walletAddress]/page.tsx
@@ -1,4 +1,3 @@
-import { type TokenSymbolsList } from '@summerfi/app-types'
 import { parseServerResponseToClient } from '@summerfi/app-utils'
 import { type IArmadaPosition } from '@summerfi/sdk-client'
 
@@ -8,6 +7,7 @@ import { portfolioWalletAssetsHandler } from '@/app/server-handlers/portfolio/po
 import { getGlobalRebalances } from '@/app/server-handlers/sdk/get-global-rebalances'
 import { getUserPositions } from '@/app/server-handlers/sdk/get-user-positions'
 import { getVaultsList } from '@/app/server-handlers/sdk/get-vaults-list'
+import { getSumrBalances } from '@/app/server-handlers/sumr-balances'
 import { getSumrDelegateStake } from '@/app/server-handlers/sumr-delegate-stake'
 import systemConfigHandler from '@/app/server-handlers/system-config'
 import { PortfolioPageView } from '@/components/layout/PortfolioPageView/PortfolioPageView'
@@ -29,8 +29,9 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     positions,
     systemConfig,
     { rebalances },
-    { sumrDelegated, delegatedTo },
+    sumrStakeDelegate,
     sumrEligibility,
+    sumrBalances,
   ] = await Promise.all([
     portfolioWalletAssetsHandler(walletAddress),
     getVaultsList(),
@@ -41,6 +42,9 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
       walletAddress,
     }),
     fetchRaysLeaderboard({ userAddress: walletAddress.toLowerCase(), page: '1', limit: '1' }),
+    getSumrBalances({
+      walletAddress,
+    }),
   ])
 
   const positionsJsonSafe = positions
@@ -61,18 +65,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     userVaultsIds.includes(rebalance.vault.id.toLowerCase()),
   )
 
-  const totalSumr = walletData.assets.find(
-    (asset) => asset.symbol === ('SUMMER' as TokenSymbolsList),
-  )?.balance
-
   const rewardsData: ClaimDelegateExternalData = {
     sumrPrice: '0',
     sumrEarned: '123.45',
     sumrToClaim: '1.23',
     sumrApy: '0.0123',
-    sumrDelegated,
-    delegatedTo,
-    totalSumr: totalSumr?.toString() ?? '0',
+    sumrStakeDelegate,
+    sumrBalances,
   }
 
   const totalRays = Number(sumrEligibility.leaderboard[0]?.totalPoints ?? 0)

--- a/apps/earn-protocol/app/earn/stake-delegate/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/earn/stake-delegate/[walletAddress]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 import { getDelegatesVotes } from '@/app/server-handlers/delegates-votes'
+import { getSumrBalances } from '@/app/server-handlers/sumr-balances'
 import { getSumrDelegateStake } from '@/app/server-handlers/sumr-delegate-stake'
 import { StakeDelegateViewComponent } from '@/components/layout/StakeDelegatePageView/StakeDelegateViewComponent'
 import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/types'
@@ -21,9 +22,12 @@ const StakeDelegatePage = async ({ params }: StakeDelegatePageProps) => {
     redirect(`/earn`)
   }
 
-  const [votes, { sumrDelegated, delegatedTo }] = await Promise.all([
+  const [votes, sumrStakeDelegate, sumrBalances] = await Promise.all([
     getDelegatesVotes(),
     getSumrDelegateStake({
+      walletAddress,
+    }),
+    getSumrBalances({
       walletAddress,
     }),
   ])
@@ -34,9 +38,9 @@ const StakeDelegatePage = async ({ params }: StakeDelegatePageProps) => {
     sumrEarned: '123.45',
     sumrToClaim: '1.23',
     sumrApy: '0.0123',
-    sumrDelegated,
-    delegatedTo,
+    sumrStakeDelegate,
     votes,
+    sumrBalances,
   }
 
   return <StakeDelegateViewComponent walletAddress={walletAddress} externalData={externalData} />

--- a/apps/earn-protocol/app/server-handlers/sumr-balances/index.ts
+++ b/apps/earn-protocol/app/server-handlers/sumr-balances/index.ts
@@ -1,0 +1,125 @@
+import { SDKChainId } from '@summerfi/app-types'
+import { SummerTokenAbi } from '@summerfi/armada-protocol-abis'
+import { getChainInfoByChainId } from '@summerfi/sdk-common'
+import BigNumber from 'bignumber.js'
+import { type Address, createPublicClient, http } from 'viem'
+import { base } from 'viem/chains'
+
+import { backendSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { SDKChainIdToRpcGatewayMap } from '@/constants/networks-list'
+
+export interface SumrBalancesData {
+  ethereum: string
+  arbitrum: string
+  base: string
+  total: string
+}
+
+/**
+ * Fetches SUMR token balances across different chains for a given wallet address
+ * @param {Object} params - The parameters object
+ * @param {string} params.walletAddress - The wallet address to check balances for
+ * @returns {Promise<SumrBalancesData>} Object containing SUMR balances for each chain and total
+ * @throws {Error} If there's an error fetching the balances
+ */
+export const getSumrBalances = async ({
+  walletAddress,
+}: {
+  walletAddress: string
+}): Promise<SumrBalancesData> => {
+  try {
+    const resolvedWalletAddress = walletAddress as Address
+
+    const chainConfigs = [
+      { chain: base, chainId: SDKChainId.BASE },
+      // TODO uncomment once SUMR token will be deploy on networks below
+      //   { chain: mainnet, chainId: SDKChainId.MAINNET },
+      //   { chain: arbitrum, chainId: SDKChainId.ARBITRUM },
+      //   { chain: optimism, chainId: SDKChainId.OPTIMISM },
+    ]
+
+    const balances = await Promise.all(
+      chainConfigs.map(async ({ chain, chainId }) => {
+        const publicClient = createPublicClient({
+          chain,
+          transport: http(SDKChainIdToRpcGatewayMap[chainId]),
+        })
+
+        try {
+          const chainResponse = await backendSDK.chains.getChain({
+            chainInfo: getChainInfoByChainId(chainId),
+          })
+
+          const sumrToken = await chainResponse.tokens
+            .getTokenBySymbol({
+              symbol: 'SUMMER',
+            })
+            .catch(() => null)
+
+          if (!sumrToken) {
+            // Token not available on this network
+            return {
+              chain: chain.name.toLowerCase(),
+              balance: '0',
+            }
+          }
+
+          const balanceResult = await publicClient.readContract({
+            abi: SummerTokenAbi,
+            address: sumrToken.address.value,
+            functionName: 'balanceOf',
+            args: [resolvedWalletAddress],
+          })
+
+          if (balanceResult === undefined) {
+            return {
+              chain: chain.name.toLowerCase(),
+              balance: '0',
+            }
+          }
+
+          return {
+            chain: chain.name.toLowerCase(),
+            balance: new BigNumber(balanceResult.toString())
+              .shiftedBy(-sumrToken.decimals)
+              .toString(),
+          }
+        } catch (error) {
+          // Log the error but don't throw, return 0 balance instead
+          // eslint-disable-next-line no-console
+          console.error(`Error fetching balance for ${chain.name}:`, error)
+
+          return {
+            chain: chain.name.toLowerCase(),
+            balance: '0',
+          }
+        }
+      }),
+    )
+
+    const result = {
+      ethereum: '0',
+      arbitrum: '0',
+      base: '0',
+      total: '0',
+    }
+
+    const total = balances.reduce((acc, { balance }) => acc.plus(balance), new BigNumber(0))
+
+    balances.forEach(({ chain, balance }) => {
+      result[chain as keyof Omit<SumrBalancesData, 'total'>] = balance
+    })
+
+    return {
+      ...result,
+      total: total.toString(),
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error in getSumrBalances:', error)
+
+    throw new Error(
+      `Failed to get SUMR balances: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    )
+  }
+}

--- a/apps/earn-protocol/components/layout/ClaimPageView/ClaimPageView.tsx
+++ b/apps/earn-protocol/components/layout/ClaimPageView/ClaimPageView.tsx
@@ -16,7 +16,7 @@ interface ClaimPageViewProps {
 export const ClaimPageView: FC<ClaimPageViewProps> = ({ walletAddress, externalData }) => {
   const [state, dispatch] = useReducer(claimDelegateReducer, {
     ...claimDelegateState,
-    delegatee: externalData.delegatedTo,
+    delegatee: externalData.sumrStakeDelegate.delegatedTo,
     walletAddress,
   })
 

--- a/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
+++ b/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
@@ -94,7 +94,7 @@ export const PortfolioPageView: FC<PortfolioPageViewProps> = ({
       <div style={{ display: 'flex', flexDirection: 'column', padding: '0 16px', width: '100%' }}>
         <PortfolioHeader
           walletAddress={walletAddress}
-          totalSumr={rewardsData.totalSumr}
+          totalSumr={rewardsData.sumrBalances.total}
           totalWalletValue={totalWalletValue}
         />
         <TabBar

--- a/apps/earn-protocol/components/layout/StakeDelegatePageView/StakeDelegatePageView.tsx
+++ b/apps/earn-protocol/components/layout/StakeDelegatePageView/StakeDelegatePageView.tsx
@@ -21,7 +21,7 @@ export const StakeDelegatePageView: FC<StakeDelegatePageViewProps> = ({
 }) => {
   const [state, dispatch] = useReducer(claimDelegateReducer, {
     ...claimDelegateState,
-    delegatee: externalData.delegatedTo,
+    delegatee: externalData.sumrStakeDelegate.delegatedTo,
     walletAddress,
   })
 

--- a/apps/earn-protocol/constants/networks-list.ts
+++ b/apps/earn-protocol/constants/networks-list.ts
@@ -102,6 +102,9 @@ export const baseGoerliRpc = getRpc(NetworkNames.baseGoerli)
 export const SDKChainIdToRpcGatewayMap = {
   [SDKChainId.ARBITRUM]: arbitrumMainnetRpc,
   [SDKChainId.BASE]: baseMainnetRpc,
+  [SDKChainId.MAINNET]: mainnetRpc,
+  [SDKChainId.OPTIMISM]: optimismMainnetRpc,
+  [SDKChainId.SEPOLIA]: baseGoerliRpc, // dummy for now, not used anyway
 }
 
 const mainnetConfig: NetworkConfig = {

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateCompletedSubstep/ClaimDelegateStakeDelegateCompletedSubstep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateCompletedSubstep/ClaimDelegateStakeDelegateCompletedSubstep.tsx
@@ -43,7 +43,7 @@ export const ClaimDelegateStakeDelegateCompletedSubstep: FC<
       </Text>
     </>
   )
-  const sumrPerYear = `${formatFiatBalance((Number(externalData.sumrDelegated) + Number(externalData.sumrEarned)) * Number(externalData.sumrApy))} $SUMR/yr`
+  const sumrPerYear = `${formatFiatBalance((Number(externalData.sumrStakeDelegate.sumrDelegated) + Number(externalData.sumrEarned)) * Number(externalData.sumrApy))} $SUMR/yr`
 
   if (state.delegatee === undefined) {
     // eslint-disable-next-line no-console
@@ -92,7 +92,8 @@ export const ClaimDelegateStakeDelegateCompletedSubstep: FC<
             <div className={classNames.withIcon}>
               <Icon tokenName="SUMR" />
               <Text as="h4" variant="h4">
-                {Number(externalData.sumrDelegated) + Number(externalData.sumrEarned)}
+                {Number(externalData.sumrStakeDelegate.sumrDelegated) +
+                  Number(externalData.sumrEarned)}
               </Text>
             </div>
           </div>

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeDelegateStep/substeps/ClaimDelegateStakeDelegateSubstep/ClaimDelegateStakeDelegateSubstep.tsx
@@ -46,11 +46,13 @@ export const ClaimDelegateStakeDelegateSubstep: FC<ClaimDelegateStakeDelegateSub
   const claimedInUSD = formatFiatBalance(Number(externalData.sumrEarned) * estimatedSumrPrice)
 
   const apy = formatDecimalAsPercent(externalData.sumrApy)
-  const sumrPerYear = `*${formatFiatBalance((Number(externalData.sumrDelegated) + Number(externalData.sumrEarned)) * Number(externalData.sumrApy))} $SUMR / Year`
+  const sumrPerYear = `*${formatFiatBalance((Number(externalData.sumrStakeDelegate.sumrDelegated) + Number(externalData.sumrEarned)) * Number(externalData.sumrApy))} $SUMR / Year`
 
   const handleStakeAndDelegate = () => {
     dispatch({ type: 'update-delegate-status', payload: ClaimDelegateTxStatuses.COMPLETED })
   }
+
+  const hasNothingToStake = externalData.sumrBalances.base === '0'
 
   return (
     <div className={classNames.claimDelegateStakeDelegateSubstepWrapper}>
@@ -135,14 +137,16 @@ export const ClaimDelegateStakeDelegateSubstep: FC<ClaimDelegateStakeDelegateSub
             variant="primarySmall"
             style={{ paddingRight: 'var(--general-space-32)' }}
             onClick={handleStakeAndDelegate}
-            disabled={!state.delegatee || state.delegatee === externalData.delegatedTo}
+            disabled={
+              !state.delegatee || state.delegatee === externalData.sumrStakeDelegate.delegatedTo
+            }
           >
             <WithArrow
               style={{ color: 'var(--earn-protocol-secondary-100)' }}
               variant="p3semi"
               as="p"
             >
-              Stake & Delegate
+              {hasNothingToStake ? 'Delegate' : 'Stake & Delegate'}
             </WithArrow>
           </Button>
         </div>

--- a/apps/earn-protocol/features/claim-and-delegate/state.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/state.ts
@@ -9,6 +9,7 @@ export const claimDelegateState: ClaimDelegateState = {
   delegatee: undefined,
   claimStatus: undefined,
   delegateStatus: undefined,
+  stakingStatus: undefined,
   walletAddress: '0x0', // dummy, invalid address for init
 }
 
@@ -36,6 +37,11 @@ export const claimDelegateReducer = (
       return {
         ...prevState,
         delegateStatus: action.payload,
+      }
+    case 'update-staking-status':
+      return {
+        ...prevState,
+        stakingStatus: action.payload,
       }
     default:
       return prevState

--- a/apps/earn-protocol/features/claim-and-delegate/types.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/types.ts
@@ -1,3 +1,6 @@
+import { type SumrBalancesData } from '@/app/server-handlers/sumr-balances'
+import { type SumrDelegateStakeData } from '@/app/server-handlers/sumr-delegate-stake'
+
 export enum ClaimDelegateSteps {
   TERMS = 'terms',
   CLAIM = 'claim',
@@ -6,7 +9,7 @@ export enum ClaimDelegateSteps {
 
 export enum ClaimDelegateTxStatuses {
   PENDING = 'pending',
-  COMPLETED = 'COMPLETED',
+  COMPLETED = 'completed',
   FAILED = 'failed',
 }
 
@@ -15,6 +18,7 @@ export type ClaimDelegateState = {
   delegatee: string | undefined
   claimStatus: ClaimDelegateTxStatuses | undefined
   delegateStatus: ClaimDelegateTxStatuses | undefined
+  stakingStatus: ClaimDelegateTxStatuses | undefined
   walletAddress: string
 }
 
@@ -35,15 +39,18 @@ export type ClaimDelegateReducerAction =
       type: 'update-delegate-status'
       payload: ClaimDelegateTxStatuses
     }
+  | {
+      type: 'update-staking-status'
+      payload: ClaimDelegateTxStatuses
+    }
 
 export type ClaimDelegateExternalData = {
   sumrPrice: string
   sumrEarned: string
   sumrToClaim: string
   sumrApy: string
-  sumrDelegated: string
-  delegatedTo: string
-  totalSumr?: string
+  sumrStakeDelegate: SumrDelegateStakeData
+  sumrBalances: SumrBalancesData
   votes?: {
     delegate: string
     amountOfVotes: string

--- a/apps/earn-protocol/features/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -36,13 +36,13 @@ const TransakTrigger = ({
 
 interface PortfolioHeaderProps {
   walletAddress: string
-  totalSumr: string | undefined
+  totalSumr: string
   totalWalletValue: number
 }
 
 export const PortfolioHeader: FC<PortfolioHeaderProps> = ({
   walletAddress,
-  totalSumr = '0',
+  totalSumr,
   totalWalletValue,
 }) => {
   const { userWalletAddress } = useUserWallet()

--- a/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
@@ -61,12 +61,12 @@ interface StakedAndDelegatedSumrProps {
 const StakedAndDelegatedSumr: FC<StakedAndDelegatedSumrProps> = ({ rewardsData }) => {
   const { walletAddress } = useParams()
   const rawApy = rewardsData.sumrApy
-  const rawStaked = rewardsData.sumrDelegated
+  const rawStaked = rewardsData.sumrStakeDelegate.sumrDelegated
 
   const value = formatCryptoBalance(rawStaked)
   const apy = formatDecimalAsPercent(rawApy)
 
-  const isDelegated = rewardsData.delegatedTo !== ADDRESS_ZERO
+  const isDelegated = rewardsData.sumrStakeDelegate.sumrDelegated !== ADDRESS_ZERO
 
   const handleRemoveDelegation = () => {
     // TODO: Implement remove delegation
@@ -117,8 +117,8 @@ const YourTotalSumr: FC<YourTotalSumrProps> = ({ rewardsData }) => {
   const assumedSumrPriceRaw = Number(sumrNetApyConfig.dilutedValuation) / SUMR_CAP
   const assumedSumrPrice = formatFiatBalance(assumedSumrPriceRaw)
 
-  const rawTotalSumr = Number(rewardsData.totalSumr ?? 0)
-  const rawTotalSumrUSD = formatFiatBalance(rawTotalSumr * assumedSumrPriceRaw)
+  const rawTotalSumr = Number(rewardsData.sumrBalances.total)
+  const rawTotalSumrUSD = rawTotalSumr * assumedSumrPriceRaw
 
   const totalSumr = formatCryptoBalance(rawTotalSumr)
   const totalSumrUSD = formatFiatBalance(rawTotalSumrUSD)
@@ -153,7 +153,8 @@ const YourDelegate: FC<YourDelegateProps> = ({ rewardsData }) => {
   const { walletAddress } = useParams()
 
   const delegatee = sumrDelegates.find(
-    (item) => item.address.toLowerCase() === rewardsData.delegatedTo.toLowerCase(),
+    (item) =>
+      item.address.toLowerCase() === rewardsData.sumrStakeDelegate.sumrDelegated.toLowerCase(),
   )
 
   const value = delegatee ? delegatee.title : 'No delegate'


### PR DESCRIPTION
## Description
Updates SUMR balance and delegation data structure across earn protocol pages to use new handlers and consistent data types

## Changes
- Refactored SUMR balance handling to use new `getSumrBalances` handler
- Updated delegation data structure to use `sumrStakeDelegate` consistently
- Added staking status to claim/delegate state management
- Added mainnet and optimism RPC endpoints
- Updated UI components to reflect new data structure

## Benefits
1. More consistent data handling for SUMR balances across pages
2. Cleaner separation of concerns between balance and delegation data
3. Improved state management for staking operations

## Testing
- Verify SUMR balance display in Portfolio view
- Test delegation flow with new data structure
- Confirm staking status updates correctly in UI

## Next steps
- Implement remove delegation functionality
- Add tests for new balance handlers
- Update documentation for new data structures

## Additional Notes
This refactor prepares for improved SUMR token management and delegation features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to retrieve SUMR token balances across multiple blockchain networks
	- Enhanced balance tracking and display for user portfolios

- **Bug Fixes**
	- Updated data structure for handling stake delegate and balance information
	- Improved precision in balance calculations

- **Refactor**
	- Restructured external data management for claim, portfolio, and stake delegate pages
	- Simplified balance and delegation data retrieval

- **Chores**
	- Updated network RPC mappings
	- Refined type definitions for claim and delegate states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->