### PR TITLE
Refactor and integrate aggregated rewards handling

### DIFF
--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerClaims.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerClaims.ts
@@ -24,13 +24,13 @@ export interface IArmadaManagerClaims {
   hasClaimedDistributions: (params: { user: IUser }) => Promise<Record<string, boolean>>
 
   /**
-   * @name aggregatedClaims
+   * @name getAggregatedRewards
    * @description Returns the amount a user is eligible to claim cross-chain
    * @param params.user The user
    * @returns Promise<number>
    * @throws Error
    */
-  aggregatedRewards: (params: { user: IUser }) => Promise<{
+  getAggregatedRewards: (params: { user: IUser }) => Promise<{
     total: bigint
     perChain: Record<number, bigint>
   }>
@@ -58,7 +58,7 @@ export interface IArmadaManagerClaims {
 
   /**
    * @name getClaimProtocolUsageRewardsTx
-   * @description Claims protoclo usage rewards for a user
+   * @description Claims protocol usage rewards for a user
    * @param params.user The user
    * @param params.chainInfo The chain info
    * @param params.fleetCommandersAddresses The fleet commanders addresses

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerClaims.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerClaims.ts
@@ -221,9 +221,9 @@ export class ArmadaManagerClaims implements IArmadaManagerClaims {
       })
   }
 
-  async aggregatedRewards(
-    params: Parameters<IArmadaManagerClaims['aggregatedRewards']>[0],
-  ): ReturnType<IArmadaManagerClaims['aggregatedRewards']> {
+  async getAggregatedRewards(
+    params: Parameters<IArmadaManagerClaims['getAggregatedRewards']>[0],
+  ): ReturnType<IArmadaManagerClaims['getAggregatedRewards']> {
     const merkleDistributionRewards = await this.getMerkleDistributionRewards(params.user)
     const voteDelegationRewards = await this.getVoteDelegationRewards(params.user)
 

--- a/sdk/sdk-client-react/src/handlers/getAggregatedRewardsHandler.ts
+++ b/sdk/sdk-client-react/src/handlers/getAggregatedRewardsHandler.ts
@@ -1,0 +1,11 @@
+import type { ISDKManager } from '@summerfi/sdk-client'
+import { type IUser } from '@summerfi/sdk-common'
+
+export const getAggregatedRewardsHandler =
+  (sdk: ISDKManager) =>
+  async ({ user }: { user: IUser; fleetAddress: string }) => {
+    const position = await sdk.armada.users.getAggregatedRewards({
+      user,
+    })
+    return position
+  }

--- a/sdk/sdk-client-react/src/hooks/useSDK.ts
+++ b/sdk/sdk-client-react/src/hooks/useSDK.ts
@@ -12,6 +12,7 @@ import { getWalletAddressHandler } from '../factories/getWalletAddressHandler'
 import { getCurrentUserHandler } from '../handlers/getCurrentUserHandler'
 import { getChainInfoHandler } from '../handlers/getChainInfoHandler'
 import { getSwapQuoteHandler } from '../handlers/getSwapQuoteHandler'
+import { getAggregatedRewardsHandler } from '../handlers/getAggregatedRewardsHandler'
 
 type UseSdk = {
   walletAddress?: string
@@ -50,6 +51,9 @@ export const useSDK = (params: UseSdk) => {
   // SWAPS
   const getSwapQuote = useMemo(() => getSwapQuoteHandler(sdk), [sdk])
 
+  // CLAIMS
+  const getAggregatedRewards = useMemo(() => getAggregatedRewardsHandler(sdk), [sdk])
+
   const memo = useMemo(
     () => ({
       getCurrentUser,
@@ -62,6 +66,7 @@ export const useSDK = (params: UseSdk) => {
       getUserPositions,
       getUserPosition,
       getSwapQuote,
+      getAggregatedRewards,
     }),
     [
       getCurrentUser,
@@ -74,6 +79,7 @@ export const useSDK = (params: UseSdk) => {
       getUserPositions,
       getUserPosition,
       getSwapQuote,
+      getAggregatedRewards,
     ],
   )
 

--- a/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
@@ -114,4 +114,10 @@ export class ArmadaManagerUsersClient extends IRPCClient implements IArmadaManag
   }> {
     return this.rpcClient.armada.users.getTotalBalance.query(params)
   }
+
+  async getAggregatedRewards(
+    params: Parameters<IArmadaManagerUsersClient['getAggregatedRewards']>[0],
+  ): ReturnType<IArmadaManagerUsersClient['getAggregatedRewards']> {
+    return this.rpcClient.armada.users.getAggregatedRewards.query(params)
+  }
 }

--- a/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
@@ -204,12 +204,11 @@ export interface IArmadaManagerUsersClient {
    * @method getAggregatedRewards
    * @description Returns the aggregated rewards of a user in a Fleet
    *
-   * @param vaultId ID of the vault to check the rewards in
    * @param user Address of the user to check the rewards for
    *
    * @returns The aggregated rewards of the user in the Fleet
    */
-  getAggregatedRewards(params: { vaultId: IArmadaVaultId; user: IUser }): Promise<{
+  getAggregatedRewards(params: { user: IUser }): Promise<{
     total: bigint
     perChain: Record<number, bigint>
   }>

--- a/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
@@ -199,4 +199,18 @@ export interface IArmadaManagerUsersClient {
     shares: ITokenAmount
     assets: ITokenAmount
   }>
+
+  /**
+   * @method getAggregatedRewards
+   * @description Returns the aggregated rewards of a user in a Fleet
+   *
+   * @param vaultId ID of the vault to check the rewards in
+   * @param user Address of the user to check the rewards for
+   *
+   * @returns The aggregated rewards of the user in the Fleet
+   */
+  getAggregatedRewards(params: { vaultId: IArmadaVaultId; user: IUser }): Promise<{
+    total: bigint
+    perChain: Record<number, bigint>
+  }>
 }

--- a/sdk/sdk-server/src/SDKAppRouter.ts
+++ b/sdk/sdk-server/src/SDKAppRouter.ts
@@ -41,6 +41,7 @@ import { getUserActivityRaw } from './armada-protocol-handlers/users/getUserActi
 import { getFleetBalance } from './armada-protocol-handlers/users/getFleetBalance'
 import { getStakedBalance } from './armada-protocol-handlers/users/getStakedBalance'
 import { getTotalBalance } from './armada-protocol-handlers/users/getTotalBalance'
+import { getAggregatedRewards } from './armada-protocol-handlers/users/getAggregatedRewards'
 
 /**
  * Server
@@ -84,6 +85,7 @@ export const sdkAppRouter = router({
       getFleetBalance: getFleetBalance,
       getStakedBalance: getStakedBalance,
       getTotalBalance: getTotalBalance,
+      getAggregatedRewards: getAggregatedRewards,
     },
     keepers: {
       rebalance: rebalance,

--- a/sdk/sdk-server/src/armada-protocol-handlers/users/getAggregatedRewards.ts
+++ b/sdk/sdk-server/src/armada-protocol-handlers/users/getAggregatedRewards.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { publicProcedure } from '../../SDKTRPC'
+import { isUser, type IUser } from '@summerfi/sdk-common'
+
+export const getAggregatedRewards = publicProcedure
+  .input(
+    z.object({
+      user: z.custom<IUser>(isUser),
+    }),
+  )
+  .query(async (opts) => {
+    return opts.ctx.armadaManager.claims.getAggregatedRewards(opts.input)
+  })


### PR DESCRIPTION
Refactor methods related to aggregated rewards and introduce a new handler for retrieving user rewards, integrating it into the useSDK hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `getAggregatedRewards` method across multiple SDK components
	- Enhanced rewards retrieval functionality for users across different chains

- **Bug Fixes**
	- Corrected a typo in method description for protocol usage rewards

- **Refactor**
	- Renamed `aggregatedRewards` method to `getAggregatedRewards` for improved naming consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->