### PR TITLE
Claim sumr tx handling

### DIFF
--- a/apps/earn-protocol/account-kit/config.ts
+++ b/apps/earn-protocol/account-kit/config.ts
@@ -1,4 +1,4 @@
-import { alchemy, arbitrum, base, mainnet } from '@account-kit/infra'
+import { alchemy, arbitrum, base, mainnet, optimism } from '@account-kit/infra'
 import { type AlchemyAccountsUIConfig, cookieStorage, createConfig } from '@account-kit/react'
 import { SDKChainId, SDKSupportedNetworkIdsEnum } from '@summerfi/app-types'
 import { QueryClient } from '@tanstack/react-query'
@@ -12,12 +12,14 @@ export const SDKChainIdToAAChainMap = {
   [SDKChainId.ARBITRUM]: arbitrum,
   [SDKChainId.BASE]: base,
   [SDKChainId.MAINNET]: mainnet,
+  [SDKChainId.OPTIMISM]: optimism,
 }
 
 export const GasSponsorshipIdMap = {
   [SDKChainId.ARBITRUM]: undefined,
   [SDKChainId.BASE]: '7d552463-eba5-4eac-a940-56f0515243f2',
   [SDKChainId.MAINNET]: undefined,
+  [SDKChainId.OPTIMISM]: undefined,
 }
 
 const uiConfig: AlchemyAccountsUIConfig = {
@@ -63,6 +65,7 @@ export const getAccountKitConfig = ({
         [SDKSupportedNetworkIdsEnum.ARBITRUM]: arbitrum,
         [SDKSupportedNetworkIdsEnum.BASE]: base,
         [SDKSupportedNetworkIdsEnum.MAINNET]: mainnet,
+        [SDKSupportedNetworkIdsEnum.OPTIMISM]: optimism,
       }[chainId ?? defaultChain.id] as Chain,
       chains: Object.values(SDKChainIdToAAChainMap).map((chain) => ({
         chain,

--- a/apps/earn-protocol/app/server-handlers/sumr-to-claim/index.ts
+++ b/apps/earn-protocol/app/server-handlers/sumr-to-claim/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-mixed-operators */
 import { SDKChainId } from '@summerfi/app-types'
 import { getChainInfoByChainId } from '@summerfi/sdk-common'
 import { Address } from '@summerfi/sdk-common/common'
@@ -30,11 +31,11 @@ export const getSumrToClaim = async ({
   })
 
   return {
-    total: Number(aggregatedRewards.total),
+    total: Number(aggregatedRewards.total) / 10 ** 18,
     perChain: Object.fromEntries(
       Object.entries(aggregatedRewards.perChain).map(([chainId, amount]) => [
         chainId,
-        Number(amount),
+        Number(amount) / 10 ** 18,
       ]),
     ),
   }

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep.module.scss
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep.module.scss
@@ -10,11 +10,23 @@
     align-items: center;
     max-width: 560px;
     margin-bottom: var(--general-space-32);
+    cursor: pointer;
+    border: 1px solid transparent;
 
     .valueWithIcon {
       display: flex;
       align-items: center;
       gap: var(--general-space-16);
+    }
+
+    &Active {
+      border: 1px solid var(--earn-protocol-primary-100);
+      background-color: var(--earn-protocol-neutral-80);
+    }
+
+    &:hover {
+      background-color: var(--earn-protocol-neutral-80);
+      transition: background-color 0.3s ease;
     }
   }
 

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateToClaim.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateToClaim.tsx
@@ -1,0 +1,73 @@
+import { type FC } from 'react'
+import { Card, Icon, Text } from '@summerfi/app-earn-ui'
+import { SDKChainId } from '@summerfi/app-types'
+import clsx from 'clsx'
+
+import classNames from './ClaimDelegateClaimStep.module.scss'
+
+const networkLabels = {
+  [SDKChainId.BASE]: 'BASE Network',
+  [SDKChainId.OPTIMISM]: 'OPTIMISM Network',
+  [SDKChainId.ARBITRUM]: 'ARBITRUM Network',
+  [SDKChainId.MAINNET]: 'MAINNET Network',
+}
+
+const networkSDKChainIdIconMap = {
+  [SDKChainId.MAINNET]: <Icon iconName="earn_network_ethereum" size={17} />,
+  [SDKChainId.BASE]: <Icon iconName="earn_network_base" size={17} />,
+  [SDKChainId.ARBITRUM]: <Icon iconName="earn_network_arbitrum" size={17} />,
+  [SDKChainId.OPTIMISM]: <Icon iconName="earn_network_optimism" size={17} />,
+}
+
+interface ClaimDelegateToClaimProps {
+  earned: string
+  earnedInUSD: string
+  chainId: SDKChainId.BASE | SDKChainId.OPTIMISM | SDKChainId.MAINNET | SDKChainId.ARBITRUM
+  isActive: boolean
+  onClick: () => void
+}
+
+export const ClaimDelegateToClaim: FC<ClaimDelegateToClaimProps> = ({
+  earned,
+  earnedInUSD,
+  chainId,
+  isActive,
+  onClick,
+}) => {
+  return (
+    <Card
+      className={clsx(classNames.cardWrapper, {
+        [classNames.cardWrapperActive]: isActive,
+      })}
+      onClick={onClick}
+    >
+      <Text as="p" variant="p1semi" style={{ color: 'var(--earn-protocol-secondary-40)' }}>
+        You have earned
+      </Text>
+      <div className={classNames.valueWithIcon}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--general-space-4)',
+            position: 'relative',
+          }}
+        >
+          <Icon tokenName="SUMR" size={36} />
+          <div style={{ position: 'absolute', top: '-4px', right: '-4px' }}>
+            {networkSDKChainIdIconMap[chainId]}
+          </div>
+        </div>
+        <Text as="h2" variant="h2">
+          {earned}
+        </Text>
+      </div>
+      <Text as="p" variant="p2semi" style={{ color: 'var(--earn-protocol-secondary-40)' }}>
+        ${earnedInUSD}
+      </Text>
+      <Text as="p" variant="p2semi" style={{ color: 'var(--earn-protocol-secondary-60)' }}>
+        {networkLabels[chainId]}
+      </Text>
+    </Card>
+  )
+}

--- a/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
@@ -82,16 +82,16 @@ interface StakedAndDelegatedSumrProps {
 
 const StakedAndDelegatedSumr: FC<StakedAndDelegatedSumrProps> = ({ rewardsData }) => {
   const { walletAddress } = useParams()
-  const rawApy = rewardsData.sumrStakingInfo.sumrStakingApy
-  const rawStaked = rewardsData.sumrStakeDelegate.sumrDelegated
-  const rawDecayFactor = rewardsData.sumrStakeDelegate.delegatedToDecayFactor
   const { setChain } = useChain()
   const { clientChainId } = useClientChainId()
 
-  const value = formatCryptoBalance(rawStaked)
-  const apy = formatDecimalAsPercent(rawApy * rawDecayFactor)
+  const rawApy = rewardsData.sumrStakingInfo.sumrStakingApy
+  const isDelegated = rewardsData.sumrStakeDelegate.delegatedTo !== ADDRESS_ZERO
+  const rawStakedAndDelegated = isDelegated ? rewardsData.sumrStakeDelegate.sumrDelegated : '0'
+  const rawDecayFactor = rewardsData.sumrStakeDelegate.delegatedToDecayFactor
 
-  const isDelegated = rewardsData.sumrStakeDelegate.sumrDelegated !== ADDRESS_ZERO
+  const value = formatCryptoBalance(rawStakedAndDelegated)
+  const apy = formatDecimalAsPercent(rawApy * rawDecayFactor)
 
   const handleRemoveDelegation = () => {
     // delegation is only supported on base

--- a/apps/earn-protocol/hooks/use-claim-sumr-transaction.ts
+++ b/apps/earn-protocol/hooks/use-claim-sumr-transaction.ts
@@ -1,0 +1,54 @@
+'use client'
+import { useSendUserOperation, useSmartAccountClient } from '@account-kit/react'
+
+import { accountType } from '@/account-kit/config'
+
+import { useAppSDK } from './use-app-sdk'
+
+export const useClaimSumrTransaction = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: () => void
+  onError: () => void
+}): {
+  claimSumrTransaction: () => Promise<unknown>
+  isLoading: boolean
+  error: Error | null
+} => {
+  const { getAggregatedClaimsForChainTX, getCurrentUser, getChainInfo } = useAppSDK()
+
+  const { client: smartAccountClient } = useSmartAccountClient({ type: accountType })
+
+  const {
+    sendUserOperationAsync,
+    error: sendUserOperationError,
+    isSendingUserOperation,
+  } = useSendUserOperation({
+    client: smartAccountClient,
+    waitForTxn: true,
+    onSuccess,
+    onError,
+  })
+
+  const claimSumrTransaction = async () => {
+    const user = getCurrentUser()
+    const chainInfo = getChainInfo()
+
+    const tx = await getAggregatedClaimsForChainTX({ user, chainInfo })
+
+    return await sendUserOperationAsync({
+      uo: {
+        target: tx.transaction.target.value,
+        data: tx.transaction.calldata,
+        value: BigInt(tx.transaction.value),
+      },
+    })
+  }
+
+  return {
+    claimSumrTransaction,
+    isLoading: isSendingUserOperation,
+    error: sendUserOperationError,
+  }
+}

--- a/packages/app-types/types/src/earn-protocol/index.ts
+++ b/packages/app-types/types/src/earn-protocol/index.ts
@@ -67,6 +67,7 @@ export type SDKSupportedChain = (typeof sdkSupportedChains)[number]
 export enum SDKSupportedNetworkIdsEnum {
   ARBITRUM = ChainId.ARBITRUM,
   BASE = ChainId.BASE,
+  OPTIMISM = ChainId.OPTIMISM,
   MAINNET = ChainId.MAINNET,
 }
 


### PR DESCRIPTION
## Description
Add Optimism network support and multi-chain SUMR claiming functionality

## Changes
- Added Optimism chain configuration to account-kit setup
- Implemented multi-chain SUMR claiming UI with network selection
- Added proper SUMR token decimals handling (18 decimals)
- Created new ClaimDelegateToClaim component for per-chain claims
- Added useClaimSumrTransaction hook for claim transactions

## Benefits
1. Users can now claim SUMR tokens from multiple networks
2. Better UX with clear network-specific claim amounts
3. Improved transaction handling with proper chain switching

## Testing
- Verify SUMR claiming works on all supported networks
- Test network switching when claiming from different chains
- Confirm proper token decimal handling
- Check claim UI states (pending, success, failed)

## Next steps
- Monitor multi-chain claim performance
- Consider adding claim analytics
- Add transaction status notifications

## Additional Notes
This PR expands SUMR claiming to support multiple networks, with Optimism being the newest addition.