### PR TITLE
Saved time and gas cost calcs adjustment

### DIFF
--- a/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
+++ b/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
@@ -85,6 +85,7 @@ export const PortfolioPageView: FC<PortfolioPageViewProps> = ({
           rebalancesList={rebalancesList}
           walletAddress={walletAddress}
           totalRebalances={totalRebalances}
+          vaultsList={vaultsList}
         />
       ),
     },

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
@@ -353,6 +353,7 @@ export const VaultManageViewComponent = ({
                 rebalancesList={rebalancesList}
                 vaultId={vault.id}
                 totalRebalances={Number(vault.rebalanceCount)}
+                vaultsList={vaults}
               />
             </Expander>
             <Expander

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -340,6 +340,7 @@ export const VaultOpenViewComponent = ({
               rebalancesList={rebalancesList}
               vaultId={vault.id}
               totalRebalances={Number(vault.rebalanceCount)}
+              vaultsList={vaults}
             />
           </Expander>
           <Expander

--- a/apps/earn-protocol/features/portfolio/components/PortfolioRebalanceActivity/PortfolioRebalanceActivity.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioRebalanceActivity/PortfolioRebalanceActivity.tsx
@@ -1,7 +1,7 @@
 import { type FC, useMemo, useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroller'
 import { Card, DataBlock, Icon, Text, Tooltip } from '@summerfi/app-earn-ui'
-import { type SDKGlobalRebalancesType } from '@summerfi/app-types'
+import { type SDKGlobalRebalancesType, type SDKVaultsListType } from '@summerfi/app-types'
 import { formatFiatBalance, formatShorthandNumber } from '@summerfi/app-utils'
 
 import { PortfolioRebalanceActivityList } from '@/features/portfolio/components/PortfolioRebalanceActivityList/PortfolioRebalanceActivityList'
@@ -14,6 +14,7 @@ interface PortfolioRebalanceActivityProps {
   rebalancesList: SDKGlobalRebalancesType
   walletAddress: string
   totalRebalances: number
+  vaultsList: SDKVaultsListType
 }
 
 const initialRows = 10
@@ -22,12 +23,13 @@ export const PortfolioRebalanceActivity: FC<PortfolioRebalanceActivityProps> = (
   rebalancesList,
   walletAddress,
   totalRebalances,
+  vaultsList,
 }) => {
   const savedTimeInHours = useMemo(
     () => getRebalanceSavedTimeInHours(totalRebalances),
     [totalRebalances],
   )
-  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalRebalances), [totalRebalances])
+  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(vaultsList), [vaultsList])
 
   const [current, setCurrent] = useState(initialRows)
 

--- a/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioRewardsCards/PortfolioRewardsCards.tsx
@@ -308,7 +308,7 @@ const YourRays: FC<YourRaysProps> = ({ totalRays }) => {
   return (
     <DataModule
       dataBlock={{
-        title: 'Your season 2 $RAYS',
+        title: 'Your season 2 $SUMR',
         value,
         subValue: (
           <Text variant="p3semi" style={{ color: 'var(--earn-protocol-success-100)' }}>

--- a/apps/earn-protocol/features/rebalance-activity/components/RebalanceActivityView/RebalanceActivityView.tsx
+++ b/apps/earn-protocol/features/rebalance-activity/components/RebalanceActivityView/RebalanceActivityView.tsx
@@ -108,8 +108,9 @@ export const RebalanceActivityView: FC<RebalanceActivityViewProps> = ({
   ]
 
   const totalItems = vaultsList.reduce((acc, vault) => acc + Number(vault.rebalanceCount), 0)
+
   const savedTimeInHours = useMemo(() => getRebalanceSavedTimeInHours(totalItems), [totalItems])
-  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalItems), [totalItems])
+  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(vaultsList), [vaultsList])
 
   const cards = useMemo(
     () => getRebalanceActivityHeadingCards({ totalItems, savedGasCost, savedTimeInHours }),

--- a/apps/earn-protocol/features/rebalance-activity/components/RebalancingActivity/RebalancingActivity.tsx
+++ b/apps/earn-protocol/features/rebalance-activity/components/RebalancingActivity/RebalancingActivity.tsx
@@ -1,6 +1,6 @@
 import { type FC, useMemo } from 'react'
 import { Card, DataBlock, Icon, Text, Tooltip, WithArrow } from '@summerfi/app-earn-ui'
-import { type SDKGlobalRebalancesType } from '@summerfi/app-types'
+import { type SDKGlobalRebalancesType, type SDKVaultsListType } from '@summerfi/app-types'
 import { formatFiatBalance } from '@summerfi/app-utils'
 import Link from 'next/link'
 
@@ -12,6 +12,7 @@ interface RebalancingActivityProps {
   rebalancesList: SDKGlobalRebalancesType
   vaultId: string
   totalRebalances: number
+  vaultsList: SDKVaultsListType
 }
 
 const rowsToDisplay = 4
@@ -20,12 +21,13 @@ export const RebalancingActivity: FC<RebalancingActivityProps> = ({
   rebalancesList,
   vaultId,
   totalRebalances,
+  vaultsList,
 }) => {
   const savedTimeInHours = useMemo(
     () => getRebalanceSavedTimeInHours(totalRebalances),
     [totalRebalances],
   )
-  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(totalRebalances), [totalRebalances])
+  const savedGasCost = useMemo(() => getRebalanceSavedGasCost(vaultsList), [vaultsList])
 
   return (
     <Card style={{ marginTop: 'var(--spacing-space-medium)' }}>

--- a/apps/earn-protocol/features/rebalance-activity/helpers/get-saved-gas-cost.ts
+++ b/apps/earn-protocol/features/rebalance-activity/helpers/get-saved-gas-cost.ts
@@ -1,2 +1,39 @@
-// used 0.5$ per each rebalance action
-export const getRebalanceSavedGasCost = (totalItems: number) => totalItems * 0.5
+import { type SDKNetwork, type SDKVaultsListType } from '@summerfi/app-types'
+import { sdkNetworkToHumanNetwork } from '@summerfi/app-utils'
+
+const NETWORK_GAS_SAVINGS: { [key: string]: number } = {
+  base: 0.05, // $0.05
+  arbitrum: 0.05, // $0.05
+  mainnet: 20.0, // $20.00
+}
+
+type RebalanceCountsType = { total: number } & Partial<{ [key in SDKNetwork]: number }>
+
+/**
+ * Calculates the total gas cost savings from rebalances across all vaults
+ * @param vaultsList - List of vaults with their rebalance counts and network information
+ * @returns Total USD value of gas saved across all networks
+ */
+export const getRebalanceSavedGasCost = (vaultsList: SDKVaultsListType) => {
+  const rebalanceCounts = vaultsList.reduce<RebalanceCountsType>(
+    (acc, vault) => {
+      const { network } = vault.protocol
+      const count = Number(vault.rebalanceCount)
+
+      acc.total += count
+      acc[network] = (acc[network] ?? 0) + count
+
+      return acc
+    },
+    { total: 0 },
+  )
+
+  return Object.entries(rebalanceCounts)
+    .filter(([key]) => key !== 'total')
+    .reduce(
+      (total, [network, count]) =>
+        // eslint-disable-next-line no-mixed-operators
+        total + count * (NETWORK_GAS_SAVINGS[sdkNetworkToHumanNetwork(network as SDKNetwork)] || 0),
+      0,
+    )
+}

--- a/apps/earn-protocol/features/rebalance-activity/helpers/get-saved-time-in-hours.ts
+++ b/apps/earn-protocol/features/rebalance-activity/helpers/get-saved-time-in-hours.ts
@@ -1,2 +1,2 @@
-// used 3 min as average rebalance action
-export const getRebalanceSavedTimeInHours = (totalItems: number) => (totalItems * 3) / 60
+// used 5 min as average rebalance action
+export const getRebalanceSavedTimeInHours = (totalItems: number) => (totalItems * 5) / 60

--- a/apps/earn-protocol/features/rebalance-activity/table/mapper.tsx
+++ b/apps/earn-protocol/features/rebalance-activity/table/mapper.tsx
@@ -32,7 +32,7 @@ export const rebalanceActivityPurposeMapper = (
   const isFromBuffer = actionFromRawName === 'BufferArk'
   const isToBuffer = actionToRawName === 'BufferArk'
 
-  if (!isFromBuffer && !isToBuffer && Number(item.from.depositLimit) !== 0) {
+  if (!isFromBuffer && !isToBuffer && Number(item.fromPostAction.depositLimit) !== 0) {
     return Number(item.fromPostAction.totalValueLockedUSD) + Number(item.amountUSD) <
       Number(item.fromPostAction.depositLimit)
       ? { label: 'Rate Enhancement', icon: 'arrow_increase' }


### PR DESCRIPTION
## Description
Update rebalance activity calculations and gas savings logic

## Changes
- Added network-specific gas savings calculations
- Updated average rebalance time from 3 to 5 minutes
- Fixed deposit limit check in rebalance activity mapper
- Added vaultsList prop to rebalance activity components
- Enhanced gas savings calculation with per-network rates

## Benefits
1. More accurate gas savings calculations based on network
2. Better time estimation for rebalance actions
3. Fixed deposit limit validation in activity view

## Testing
- Verify gas savings calculations for each network (Base: $0.05, Arbitrum: $0.05, Mainnet: $20.00)
- Test rebalance activity display with multiple networks
- Confirm deposit limit checks work correctly
- Check time savings calculations with new 5-minute baseline

## Next steps
- Monitor gas savings accuracy
- Consider adding network-specific time calculations
- Add tooltips explaining savings calculations

## Additional Notes
This PR improves the accuracy of rebalance savings calculations by implementing network-specific gas costs and updating time estimates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `vaultsList` prop to multiple components to enhance rebalance activity tracking
	- Updated gas cost and time savings calculations to use more detailed vault information

- **Improvements**
	- Modified rebalance activity purpose mapping to use post-action deposit limit
	- Increased estimated time per rebalance action from 3 to 5 minutes

- **Performance**
	- Refined gas savings calculation across different networks
	- Improved type safety for rebalance-related functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->