### PR TITLE
Refactor token retrieval to use summer token fetching from backendSDK

### DIFF
--- a/apps/earn-protocol/app/server-handlers/sumr-balances/index.ts
+++ b/apps/earn-protocol/app/server-handlers/sumr-balances/index.ts
@@ -52,15 +52,9 @@ export const getSumrBalances = async ({
         })
 
         try {
-          const chainResponse = await backendSDK.chains.getChain({
+          const sumrToken = await backendSDK.armada.users.getSummerToken({
             chainInfo: getChainInfoByChainId(chainId),
           })
-
-          const sumrToken = await chainResponse.tokens
-            .getTokenBySymbol({
-              symbol: 'SUMMER',
-            })
-            .catch(() => null)
 
           if (!sumrToken || sumrToken.address.value.toLowerCase() === zeroAddress.toLowerCase()) {
             // Token not available on this network

--- a/apps/earn-protocol/app/server-handlers/sumr-decay-factor/index.ts
+++ b/apps/earn-protocol/app/server-handlers/sumr-decay-factor/index.ts
@@ -35,12 +35,8 @@ export const getSumrDecayFactor = async (addresses: string[]): Promise<SumrDecay
     let sumrToken
 
     try {
-      const chainResponse = await backendSDK.chains.getChain({
+      sumrToken = await backendSDK.armada.users.getSummerToken({
         chainInfo: getChainInfoByChainId(SDKChainId.BASE),
-      })
-
-      sumrToken = await chainResponse.tokens.getTokenBySymbol({
-        symbol: 'SUMMER',
       })
     } catch (error) {
       throw new Error(

--- a/apps/earn-protocol/app/server-handlers/sumr-delegate-stake/index.ts
+++ b/apps/earn-protocol/app/server-handlers/sumr-delegate-stake/index.ts
@@ -39,26 +39,11 @@ export const getSumrDelegateStake = async ({
       transport: http(SDKChainIdToRpcGatewayMap[SDKChainId.BASE]),
     })
 
-    let tokens
-
-    try {
-      const chainResponse = await backendSDK.chains.getChain({
-        chainInfo: getChainInfoByChainId(SDKChainId.BASE),
-      })
-
-      // eslint-disable-next-line prefer-destructuring
-      tokens = chainResponse.tokens
-    } catch (error) {
-      throw new Error(
-        `Failed to fetch chain data: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      )
-    }
-
     let sumrToken
 
     try {
-      sumrToken = await tokens.getTokenBySymbol({
-        symbol: 'SUMMER',
+      sumrToken = await backendSDK.armada.users.getSummerToken({
+        chainInfo: getChainInfoByChainId(SDKChainId.BASE),
       })
     } catch (error) {
       throw new Error(

--- a/apps/earn-protocol/app/server-handlers/sumr-staking-info/index.ts
+++ b/apps/earn-protocol/app/server-handlers/sumr-staking-info/index.ts
@@ -30,19 +30,9 @@ export const getSumrStakingInfo = async (): Promise<SumrStakingInfoData> => {
       transport: http(SDKChainIdToRpcGatewayMap[SDKChainId.BASE]),
     })
 
-    const chainResponse = await backendSDK.chains
-      .getChain({
+    const sumrToken = await backendSDK.armada.users
+      .getSummerToken({
         chainInfo: getChainInfoByChainId(SDKChainId.BASE),
-      })
-      .catch((error) => {
-        throw new Error(`Failed to get chain info: ${error.message}`)
-      })
-
-    const { tokens } = chainResponse
-
-    const sumrToken = await tokens
-      .getTokenBySymbol({
-        symbol: 'SUMMER',
       })
       .catch((error) => {
         throw new Error(`Failed to get SUMMER token: ${error.message}`)

--- a/apps/earn-protocol/features/claim-and-delegate/hooks/use-decay-factor.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/hooks/use-decay-factor.ts
@@ -2,13 +2,14 @@
 import { SDKChainId } from '@summerfi/app-types'
 import { ADDRESS_ZERO } from '@summerfi/app-utils'
 import { SummerTokenAbi } from '@summerfi/armada-protocol-abis'
+import { getChainInfoByChainId } from '@summerfi/sdk-common'
 import { useQuery } from '@tanstack/react-query'
 import BigNumber from 'bignumber.js'
 import { type Address, createPublicClient, http } from 'viem'
 import { base } from 'viem/chains'
 
+import { backendSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
 import { SDKChainIdToRpcGatewayMap } from '@/constants/networks-list'
-import { useAppSDK } from '@/hooks/use-app-sdk'
 
 type DecayFactorResponse = {
   decayFactor: number | undefined
@@ -27,8 +28,6 @@ type DecayFactorResponse = {
  *  - error: Error object if request fails
  */
 export const useDecayFactor = (delegatedAddress?: string): DecayFactorResponse => {
-  const sdk = useAppSDK()
-
   const fetchDecayFactor = async (address: Address): Promise<number> => {
     try {
       const publicClient = createPublicClient({
@@ -36,10 +35,9 @@ export const useDecayFactor = (delegatedAddress?: string): DecayFactorResponse =
         transport: http(SDKChainIdToRpcGatewayMap[SDKChainId.BASE]),
       })
 
-      const sumrToken = await sdk
-        .getTokenBySymbol({
-          chainId: SDKChainId.BASE,
-          symbol: 'SUMMER',
+      const sumrToken = await backendSDK.armada.users
+        .getSummerToken({
+          chainInfo: getChainInfoByChainId(SDKChainId.BASE),
         })
         .catch((error) => {
           throw new Error(`Failed to fetch SUMMER token: ${error.message}`)


### PR DESCRIPTION
Replace the previous method of retrieving the SUMMER token with a direct call to the backendSDK for improved efficiency and clarity.