### PR TITLE
Remove temporary mainnet environment variables and update RPC handling

### DIFF
--- a/.github/workflows/build-push-deploy-summerfi-earn-dev.yaml
+++ b/.github/workflows/build-push-deploy-summerfi-earn-dev.yaml
@@ -61,8 +61,6 @@ jobs:
       NEXT_PUBLIC_TRANSAK_ENVIRONMENT: ${{ secrets.NEXT_PUBLIC_TRANSAK_ENVIRONMENT }}
       TRANSAK_SECRET: ${{ secrets.TRANSAK_SECRET }}
       SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}
-      TEMPORARY_MAINNET_SUBGRAPH: ${{ secrets.TEMPORARY_MAINNET_SUBGRAPH }}
-      TEMPORARY_MAINNET_RPC: ${{ secrets.TEMPORARY_MAINNET_RPC }}
       SDK_API_URL: ${{ secrets.LAZY_SDK_API_URL }}
       EARN_PROTOCOL_JWT_SECRET: ${{ secrets.EARN_PROTOCOL_JWT_SECRET }}
       EARN_PROTOCOL_JWT_CHALLENGE_SECRET: ${{ secrets.EARN_PROTOCOL_JWT_CHALLENGE_SECRET }}
@@ -179,8 +177,6 @@ jobs:
                        --build-arg FUNCTIONS_API_URL=${{ secrets.FUNCTIONS_API_URL }} \
                        --build-arg EARN_MIXPANEL_KEY=${{ secrets.EARN_MIXPANEL_KEY }} \
                        --build-arg SUBGRAPH_BASE=${{ secrets.SUBGRAPH_BASE }} \
-                       --build-arg TEMPORARY_MAINNET_SUBGRAPH=${{ secrets.TEMPORARY_MAINNET_SUBGRAPH }} \
-                       --build-arg TEMPORARY_MAINNET_RPC=${{ secrets.TEMPORARY_MAINNET_RPC }} \
                        --build-arg NEXT_PUBLIC_EARN_MIXPANEL_KEY=${{ secrets.NEXT_PUBLIC_EARN_MIXPANEL_KEY }} \
                        --build-arg ACCOUNT_KIT_API_KEY=${{ secrets.ACCOUNT_KIT_API_KEY }} \
                        --build-arg FORECAST_API_URL=${{ secrets.FORECAST_API_URL }} \

--- a/apps/earn-protocol/app/api/rpcGateway/route.ts
+++ b/apps/earn-protocol/app/api/rpcGateway/route.ts
@@ -15,16 +15,10 @@ export async function POST(req: NextRequest) {
   if (!networkQuery) {
     return NextResponse.json({ error: 'Missing network query' }, { status: 400 })
   }
-  if (!process.env.TEMPORARY_MAINNET_RPC) {
-    return NextResponse.json(
-      { error: 'TEMPORARY_MAINNET_RPC env variable is not set' },
-      { status: 400 },
-    )
-  }
 
   const networkName = networkQuery.toString() as NetworkNames
   const rpcGatewayUrl =
-    networkName === NetworkNames.ethereumMainnet
+    networkName === NetworkNames.ethereumMainnet && process.env.TEMPORARY_MAINNET_RPC
       ? process.env.TEMPORARY_MAINNET_RPC
       : await getRpcGatewayUrl(networkName)
 

--- a/apps/earn-protocol/app/server-handlers/position-history/index.ts
+++ b/apps/earn-protocol/app/server-handlers/position-history/index.ts
@@ -29,15 +29,15 @@ export async function getPositionHistory({ network, address, vault }: GetPositio
       },
     })
 
-  if (!process.env.TEMPORARY_MAINNET_SUBGRAPH) {
-    throw new Error('TEMPORARY_MAINNET_SUBGRAPH env variable is not set')
-  }
-
   const clients = {
-    // [SDKNetwork.Mainnet]: new GraphQLClient(`${process.env.SUBGRAPH_BASE}/summer-protocol`, {
-    [SDKNetwork.Mainnet]: new GraphQLClient(process.env.TEMPORARY_MAINNET_SUBGRAPH, {
-      fetch: customFetchCache,
-    }),
+    [SDKNetwork.Mainnet]: new GraphQLClient(
+      process.env.TEMPORARY_MAINNET_SUBGRAPH
+        ? process.env.TEMPORARY_MAINNET_SUBGRAPH
+        : `${process.env.SUBGRAPH_BASE}/summer-protocol`,
+      {
+        fetch: customFetchCache,
+      },
+    ),
     [SDKNetwork.Base]: new GraphQLClient(`${process.env.SUBGRAPH_BASE}/summer-protocol-base`, {
       fetch: customFetchCache,
     }),


### PR DESCRIPTION
This pull request focuses on removing the usage of temporary environment variables `TEMPORARY_MAINNET_SUBGRAPH` and `TEMPORARY_MAINNET_RPC` from various parts of the codebase. The changes involve updates to workflow configuration files and server-side logic to ensure the application no longer relies on these temporary variables.

Key changes include:

### Workflow Configuration Updates:
* [`.github/workflows/build-push-deploy-summerfi-earn-dev.yaml`](diffhunk://#diff-ca4314a98263edf3cdb6eef389b5117761aaa168a24841f69765000580e58338L64-L65): Removed `TEMPORARY_MAINNET_SUBGRAPH` and `TEMPORARY_MAINNET_RPC` environment variables from the workflow configuration. [[1]](diffhunk://#diff-ca4314a98263edf3cdb6eef389b5117761aaa168a24841f69765000580e58338L64-L65) [[2]](diffhunk://#diff-ca4314a98263edf3cdb6eef389b5117761aaa168a24841f69765000580e58338L182-L183)

### Server-Side Logic Updates:
* [`apps/earn-protocol/app/api/rpcGateway/route.ts`](diffhunk://#diff-80347c2298f6e3e6b2cae3074707a97fe5baddd61c17987d028803fdf9e805fdL18-R21): Removed the check for `TEMPORARY_MAINNET_RPC` environment variable and updated the logic to conditionally use this variable only if it is set.
* [`apps/earn-protocol/app/server-handlers/position-history/index.ts`](diffhunk://#diff-7f9ff4f3a09405261f2a4cc7df238e4a6d15400e383f73c0690ceb164b72a789L32-R40): Removed the mandatory check for `TEMPORARY_MAINNET_SUBGRAPH` environment variable and updated the GraphQL client initialization to use this variable if available, otherwise fall back to a default URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed temporary environment variables related to mainnet RPC and subgraph
	- Simplified RPC gateway and GraphQL client configuration
	- Updated GitHub Actions workflow for deployment

- **Refactor**
	- Streamlined error handling and configuration logic in RPC and GraphQL client initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->