### PR TITLE
Verify risk on all networks

### DIFF
--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateClaimStep/ClaimDelegateClaimStep.tsx
@@ -106,9 +106,13 @@ export const ClaimDelegateClaimStep: FC<ClaimDelegateClaimStepProps> = ({
       return
     }
 
-    await checkRisk()
-
     dispatch({ type: 'update-claim-status', payload: ClaimDelegateTxStatuses.PENDING })
+
+    const risk = await checkRisk()
+
+    if (risk.isRisky) {
+      return
+    }
 
     await claimSumrTransaction().catch((err) => {
       // eslint-disable-next-line no-console

--- a/apps/earn-protocol/hooks/use-risk-verification.ts
+++ b/apps/earn-protocol/hooks/use-risk-verification.ts
@@ -11,7 +11,7 @@ import { useUserWallet } from './use-user-wallet'
  * If a wallet is flagged as risky, the user will be logged out and notified.
  *
  * @returns {Object} Object containing the checkRisk function
- * @returns {() => Promise<void>} checkRisk - Async function to perform the risk verification
+ * @returns {() => Promise<RiskDataResponse>} checkRisk - Async function to perform the risk verification
  */
 export const useRiskVerification = () => {
   const { logout } = useLogout()
@@ -23,7 +23,7 @@ export const useRiskVerification = () => {
       // eslint-disable-next-line no-console
       console.error('Missing required parameters for risk check')
 
-      return
+      return { isRisky: false }
     }
 
     try {
@@ -41,9 +41,13 @@ export const useRiskVerification = () => {
           'Your wallet has been flagged by our automated risk tools, and as such your access to lazy.summer.fi restricted. If you believe this to be incorrect, please reach out to support@summer.fi',
         )
       }
+
+      return risk
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to perform risk check:', error)
+
+      return { isRisky: false }
     }
   }, [clientChainId, logout, userWalletAddress])
 

--- a/packages/app-risk/src/server/helpers/check-if-risky.ts
+++ b/packages/app-risk/src/server/helpers/check-if-risky.ts
@@ -6,6 +6,7 @@ import { getTrmRisk } from '@/server/helpers/get-trm-risk'
  *
  * @param address - The address to be checked for risk.
  * @param apiKey - The API key for accessing the TRM risk assessment service.
+ * @param chainId - The chain id to be checked for risk.
  * @returns A promise that resolves to a boolean indicating whether the address is risky.
  *
  * @remarks
@@ -14,9 +15,17 @@ import { getTrmRisk } from '@/server/helpers/get-trm-risk'
  * The function logs the TRM response data for auditing purposes and handles any errors that may occur during the process.
  * If an error occurs during the TRM check, it logs the error and rethrows it.
  */
-export const checkIfRisky = async ({ address, apiKey }: { address: string; apiKey: string }) => {
+export const checkIfRisky = async ({
+  address,
+  apiKey,
+  chainId,
+}: {
+  address: string
+  apiKey: string
+  chainId: number
+}) => {
   try {
-    const trmData = await getTrmRisk({ address, apiKey })
+    const trmData = await getTrmRisk({ address, apiKey, chainId })
 
     try {
       console.info(`TRM_LOG ${address} check, payload ${JSON.stringify(trmData)}`)

--- a/packages/app-risk/src/server/helpers/get-trm-risk.ts
+++ b/packages/app-risk/src/server/helpers/get-trm-risk.ts
@@ -1,10 +1,18 @@
 import { type RiskDataResponse } from '@/types'
 
+const chainIdToTrmNetwork: { [key: number]: string } = {
+  1: 'ethereum',
+  8453: 'base',
+  42161: 'arbitrum',
+  10: 'optimism',
+}
+
 /**
  * Fetch the risk data for a given address using the TRM Labs API.
  *
  * @param address - The address to be screened for risk.
  * @param apiKey - The API key for accessing the TRM Labs API.
+ * @param chainId - The chain id to be checked for risk.
  * @returns A promise that resolves to a RiskDataResponse object containing the risk data.
  *
  * @remarks
@@ -16,10 +24,18 @@ import { type RiskDataResponse } from '@/types'
 export const getTrmRisk = async ({
   address,
   apiKey,
+  chainId,
 }: {
   address: string
   apiKey: string
+  chainId: number
 }): Promise<RiskDataResponse> => {
+  const chain = chainIdToTrmNetwork[chainId]
+
+  if (!chain) {
+    throw new Error(`Unsupported chain id: ${chainId}`)
+  }
+
   return fetch('https://api.trmlabs.com/public/v2/screening/addresses', {
     method: 'POST',
     headers: {
@@ -29,7 +45,7 @@ export const getTrmRisk = async ({
     body: JSON.stringify([
       {
         address,
-        chain: 'ethereum',
+        chain,
         accountExternalId: 'oazo',
       },
     ]),


### PR DESCRIPTION
## Description
Add multi-chain risk verification support and improve error handling

## Changes
- Added chain-specific risk verification for Base, Arbitrum, and Optimism
- Updated risk check to return response object instead of void
- Enhanced risk verification error handling and logging
- Added chainId to TRM API requests with network mapping
- Improved claim flow to handle risky wallet states

## Benefits
1. Risk verification now works across all supported chains
2. Better error handling and risk check responses
3. More reliable claim flow with proper risk checks

## Testing
- Verify risk checks work on all supported networks
- Test claim flow with both risky and safe wallets
- Confirm error handling for unsupported chains
- Check TRM API responses for different networks

## Next steps
- Monitor risk check performance across chains
- Consider adding risk check caching
- Add analytics for risk check results

## Additional Notes
This PR extends risk verification to support multiple chains while improving the overall robustness of the risk checking system.