### PR TITLE
Added getDelegationChainLength

### DIFF
--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerGovernance.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerGovernance.ts
@@ -111,7 +111,7 @@ export interface IArmadaManagerGovernance {
    *
    * @param user The user
    *
-   * @returns The transaction information
+   * @returns The length of the delegation chain
    */
   getDelegationChainLength: (params: { user: IUser }) => Promise<number>
 }

--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerGovernance.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerGovernance.ts
@@ -104,4 +104,14 @@ export interface IArmadaManagerGovernance {
    * @returns The transaction information
    */
   getUnstakeTx: (params: { amount: bigint }) => Promise<[UnstakeTransactionInfo]>
+
+  /**
+   * @method getDelegationChainLength
+   * @description Returns the length of the delegation chain
+   *
+   * @param user The user
+   *
+   * @returns The transaction information
+   */
+  getDelegationChainLength: (params: { user: IUser }) => Promise<number>
 }

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerGovernance.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerGovernance.ts
@@ -237,4 +237,20 @@ export class ArmadaManagerGovernance implements IArmadaManagerGovernance {
       },
     ]
   }
+
+  async getDelegationChainLength(
+    params: Parameters<IArmadaManagerGovernance['getDelegationChainLength']>[0],
+  ): ReturnType<IArmadaManagerGovernance['getDelegationChainLength']> {
+    const client = this._blockchainClientProvider.getBlockchainClient({
+      chainInfo: this._hubChainInfo,
+    })
+
+    const length = await client.readContract({
+      abi: SummerTokenAbi,
+      address: this._hubChainSummerTokenAddress.value,
+      functionName: 'getDelegationChainLength',
+      args: [params.user.wallet.address.value],
+    })
+    return Number(length.toString())
+  }
 }

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerGovernance.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerGovernance.ts
@@ -251,6 +251,10 @@ export class ArmadaManagerGovernance implements IArmadaManagerGovernance {
       functionName: 'getDelegationChainLength',
       args: [params.user.wallet.address.value],
     })
-    return Number(length.toString())
+    const num = Number(length.toString())
+    if (!Number.isSafeInteger(num)) {
+      throw new Error('Delegation chain length exceeds safe integer limits')
+    }
+    return num
   }
 }

--- a/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
@@ -183,4 +183,10 @@ export class ArmadaManagerUsersClient extends IRPCClient implements IArmadaManag
   ): ReturnType<IArmadaManagerUsersClient['getUnstakeTx']> {
     return this.rpcClient.armada.users.getUnstakeTX.query(params)
   }
+
+  async getDelegationChainLength(
+    params: Parameters<IArmadaManagerUsersClient['getDelegationChainLength']>[0],
+  ): ReturnType<IArmadaManagerUsersClient['getDelegationChainLength']> {
+    return this.rpcClient.armada.users.getDelegationChainLength.query(params)
+  }
 }

--- a/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
@@ -332,4 +332,14 @@ export interface IArmadaManagerUsersClient {
    * @returns The transaction information
    */
   getUnstakeTx(params: { amount: bigint }): Promise<[UnstakeTransactionInfo]>
+
+  /**
+   * @method getDelegationChainLength
+   * @description Returns the length of the delegation chain
+   *
+   * @param user The user
+   *
+   * @returns The length of the delegation
+   */
+  getDelegationChainLength: (params: { user: IUser }) => Promise<number>
 }

--- a/sdk/sdk-server/src/SDKAppRouter.ts
+++ b/sdk/sdk-server/src/SDKAppRouter.ts
@@ -53,6 +53,7 @@ import { getUnstakeTx } from './armada-protocol-handlers/users/getUnstakeTx'
 import { getUserEarnedRewards } from './armada-protocol-handlers/users/getUserEarnedRewards'
 import { getUserBalance } from './armada-protocol-handlers/users/getUserBalance'
 import { getSummerToken } from './armada-protocol-handlers/users/getSummerToken'
+import { getDelegationChainLength } from './armada-protocol-handlers/users/getDelegationChainLength'
 
 /**
  * Server
@@ -108,6 +109,7 @@ export const sdkAppRouter = router({
       getUnstakeTX: getUnstakeTx,
       getUserBalance: getUserBalance,
       getSummerToken: getSummerToken,
+      getDelegationChainLength: getDelegationChainLength,
     },
     keepers: {
       rebalance: rebalance,

--- a/sdk/sdk-server/src/armada-protocol-handlers/users/getDelegationChainLength.ts
+++ b/sdk/sdk-server/src/armada-protocol-handlers/users/getDelegationChainLength.ts
@@ -11,8 +11,8 @@ export const getDelegationChainLength = publicProcedure
   .query(async (opts) => {
     try {
       return await opts.ctx.armadaManager.governance.getDelegationChainLength(opts.input)
-    } catch (error) {
-      console.error(`Failed to get delegation chain length: ${error}`)
-      throw new Error(`Failed to get delegation chain length: ${error}`)
+    } catch (error: unknown) {
+      console.error(`Failed to get delegation chain length for user ${opts.input.user}: ${error}`)
+      throw error instanceof Error ? error : new Error(String(error))
     }
   })

--- a/sdk/sdk-server/src/armada-protocol-handlers/users/getDelegationChainLength.ts
+++ b/sdk/sdk-server/src/armada-protocol-handlers/users/getDelegationChainLength.ts
@@ -9,5 +9,10 @@ export const getDelegationChainLength = publicProcedure
     }),
   )
   .query(async (opts) => {
-    return await opts.ctx.armadaManager.governance.getDelegationChainLength(opts.input)
+    try {
+      return await opts.ctx.armadaManager.governance.getDelegationChainLength(opts.input)
+    } catch (error) {
+      console.error(`Failed to get delegation chain length: ${error}`)
+      throw new Error(`Failed to get delegation chain length: ${error}`)
+    }
   })

--- a/sdk/sdk-server/src/armada-protocol-handlers/users/getDelegationChainLength.ts
+++ b/sdk/sdk-server/src/armada-protocol-handlers/users/getDelegationChainLength.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { publicProcedure } from '../../SDKTRPC'
+import { isUser, type IUser } from '@summerfi/sdk-common'
+
+export const getDelegationChainLength = publicProcedure
+  .input(
+    z.object({
+      user: z.custom<IUser>(isUser),
+    }),
+  )
+  .query(async (opts) => {
+    return await opts.ctx.armadaManager.governance.getDelegationChainLength(opts.input)
+  })


### PR DESCRIPTION
Added getDelegationChainLength

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new method to retrieve the delegation chain length for a user across multiple components of the SDK.
	- Introduced functionality to query the length of a user's delegation chain through various interfaces and implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->