### PR TITLE
Add debug ping handler to SDKAppRouter

### DIFF
--- a/sdk/sdk-server/src/SDKAppRouter.ts
+++ b/sdk/sdk-server/src/SDKAppRouter.ts
@@ -53,7 +53,7 @@ import { getUnstakeTx } from './armada-protocol-handlers/users/getUnstakeTx'
 import { getUserEarnedRewards } from './armada-protocol-handlers/users/getUserEarnedRewards'
 import { getUserBalance } from './armada-protocol-handlers/users/getUserBalance'
 import { getSummerToken } from './armada-protocol-handlers/users/getSummerToken'
-import { pong } from 'src/handlers/debugPong'
+import { pong } from './handlers/debugPong'
 
 /**
  * Server

--- a/sdk/sdk-server/src/SDKAppRouter.ts
+++ b/sdk/sdk-server/src/SDKAppRouter.ts
@@ -53,11 +53,15 @@ import { getUnstakeTx } from './armada-protocol-handlers/users/getUnstakeTx'
 import { getUserEarnedRewards } from './armada-protocol-handlers/users/getUserEarnedRewards'
 import { getUserBalance } from './armada-protocol-handlers/users/getUserBalance'
 import { getSummerToken } from './armada-protocol-handlers/users/getSummerToken'
+import { pong } from 'src/handlers/debugPong'
 
 /**
  * Server
  */
 export const sdkAppRouter = router({
+  debug: {
+    ping: pong,
+  },
   protocols: {
     getPosition: getPosition,
     getLendingPool: getLendingPool,

--- a/sdk/sdk-server/src/handlers/debugPong.ts
+++ b/sdk/sdk-server/src/handlers/debugPong.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+import { publicProcedure } from '../SDKTRPC'
+
+export const pong = publicProcedure.input(z.any()).query(async (): Promise<string> => {
+  return 'pong'
+})


### PR DESCRIPTION
This pull request introduces a new debug endpoint to the SDK server. The most important changes include adding a new import for the `pong` handler and defining the `pong` handler itself.

New debug endpoint:

* [`sdk/sdk-server/src/SDKAppRouter.ts`](diffhunk://#diff-9a82b484634d3d2498f86d8bd51ade526c9eee9df57c2437a498e779984fbd49R56-R64): Added import for `pong` from `src/handlers/debugPong` and included a new `debug` section in the `sdkAppRouter` with a `ping` method that uses `pong`.
* [`sdk/sdk-server/src/handlers/debugPong.ts`](diffhunk://#diff-a3f25d2810fff66fe74fd1734f8932ea203c0292535feb8d918ed83cb31540b5R1-R6): Defined the `pong` handler using `publicProcedure` from `SDKTRPC` that returns the string 'pong'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a public debug endpoint that lets users verify connectivity. When accessed, it provides a simple confirmation response, enhancing troubleshooting and diagnostics without affecting current functionality.
  - Added a `debug` property to the `sdkAppRouter`, featuring a `ping` method that references the new `pong` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->