### PR TITLE
Refactor subgraphsMap initialization for clarity and consistency

### DIFF
--- a/apps/earn-protocol/app/server-handlers/position-history/index.ts
+++ b/apps/earn-protocol/app/server-handlers/position-history/index.ts
@@ -28,17 +28,11 @@ export async function getPositionHistory({ network, address, vault }: GetPositio
       },
     })
 
-  const subgraphsMap = process.env.NEXT_PUBLIC_IS_PRE_LAUNCH_VERSION
-    ? {
-        [SDKNetwork.Mainnet]: `${process.env.SUBGRAPH_BASE}/summer-protocol`,
-        [SDKNetwork.Base]: `${process.env.SUBGRAPH_BASE}/summer-protocol-base`,
-        [SDKNetwork.ArbitrumOne]: `${process.env.SUBGRAPH_BASE}/summer-protocol-arbitrum`,
-      }
-    : {
-        [SDKNetwork.Mainnet]: `${process.env.SUBGRAPH_BASE}/summer-protocol/version/1.0.0-test-deployment/api`,
-        [SDKNetwork.Base]: `${process.env.SUBGRAPH_BASE}/summer-protocol-base/version/1.0.0-test-deployment/api`,
-        [SDKNetwork.ArbitrumOne]: `${process.env.SUBGRAPH_BASE}/summer-protocol-arbitrum/version/1.0.0-test-deployment/api`,
-      }
+  const subgraphsMap = {
+    [SDKNetwork.Mainnet]: `${process.env.SUBGRAPH_BASE}/summer-protocol`,
+    [SDKNetwork.Base]: `${process.env.SUBGRAPH_BASE}/summer-protocol-base`,
+    [SDKNetwork.ArbitrumOne]: `${process.env.SUBGRAPH_BASE}/summer-protocol-arbitrum`,
+  }
 
   const isProperNetwork = (net: string): net is keyof typeof subgraphsMap => net in subgraphsMap
 


### PR DESCRIPTION
Simplify the initialization of the subgraphsMap for better readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the network endpoint configuration for supported networks (Mainnet, Base, and ArbitrumOne), ensuring a consistent and simplified setup across environments without altering user-facing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->