### PR TITLE
Fix strategy filter on rebalance activity page

### DIFF
--- a/apps/earn-protocol/features/rebalance-activity/table/filters/filters.ts
+++ b/apps/earn-protocol/features/rebalance-activity/table/filters/filters.ts
@@ -1,4 +1,9 @@
-import type { SDKGlobalRebalancesType, SDKGlobalRebalanceType } from '@summerfi/app-types'
+import { getUniqueVaultId } from '@summerfi/app-earn-ui'
+import type {
+  SDKGlobalRebalancesType,
+  SDKGlobalRebalanceType,
+  SDKVaultishType,
+} from '@summerfi/app-types'
 
 import { getProtocolLabel } from '@/helpers/get-protocol-label'
 
@@ -25,7 +30,11 @@ const rebalanceFilterStrategies = ({
 }: {
   strategyFilter: string[]
   rebalance: SDKGlobalRebalanceType
-}) => !strategyFilter.length || strategyFilter.includes(rebalance.vault.id)
+}) =>
+  !strategyFilter.length ||
+  // type casting is slightly hacky here since rebalance.vault doesn't contain
+  // all info from SDKVaultishType, but contains enough to get the unique vault id
+  strategyFilter.includes(getUniqueVaultId(rebalance.vault as SDKVaultishType))
 
 const rebalanceFilterTokens = ({
   tokenFilter,

--- a/apps/earn-protocol/features/rebalance-activity/table/filters/mappers.ts
+++ b/apps/earn-protocol/features/rebalance-activity/table/filters/mappers.ts
@@ -1,4 +1,4 @@
-import type { GenericMultiselectOption } from '@summerfi/app-earn-ui'
+import { type GenericMultiselectOption, getUniqueVaultId } from '@summerfi/app-earn-ui'
 import { type SDKVaultsListType, type TokenSymbolsList } from '@summerfi/app-types'
 
 import { networkIconByNetworkName } from '@/constants/networkIcons'
@@ -50,7 +50,7 @@ const mapStrategiesToMultiselectOptions = (
     label: vault.inputToken.symbol,
     token: vault.inputToken.symbol as TokenSymbolsList,
     networkIcon: networkIconByNetworkName[vault.protocol.network],
-    value: vault.id,
+    value: getUniqueVaultId(vault),
   }))
 
 const mapTokensToMultiselectOptions = (


### PR DESCRIPTION
## Description
Update vault ID handling in rebalance activity filters

## Changes
- Added getUniqueVaultId usage in rebalance filters
- Updated strategy filter to use unique vault IDs
- Fixed type casting for rebalance vault data
- Enhanced vault mapping to use consistent ID generation
- Added proper type imports from app-earn-ui

## Benefits
1. Consistent vault identification across rebalance features
2. Better type safety with proper SDK types
3. More reliable strategy filtering

## Testing
- Verify strategy filters work with unique vault IDs
- Test rebalance activity with multiple vaults
- Confirm type casting works correctly
- Check filter options display properly

## Next steps
- Monitor filter performance with large datasets
- Consider adding filter presets
- Add analytics for filter usage

## Additional Notes
This PR improves vault identification consistency in rebalance activity filters using unique vault IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering of vault strategies in the rebalance activity, resulting in more precise matching.
  - Updated selection options to consistently display unique identifiers for each vault, improving overall reliability in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->