### PR TITLE
Add vault parsing functionality for WETH to ETH conversion

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -45,10 +45,11 @@ import { parseGetUserPositionQuery } from './extensions/parseGetUserPositionQuer
 import { parseGetUserPositionsQuery } from './extensions/parseGetUserPositionsQuery'
 import type { IBlockchainClientProvider } from '@summerfi/blockchain-client-common'
 import type { ISwapManager } from '@summerfi/swap-common'
-import BigNumber from 'bignumber.js'
+import { BigNumber } from 'bignumber.js'
 import type { IOracleManager } from '@summerfi/oracle-common'
 import { ArmadaManagerClaims } from './ArmadaManagerClaims'
 import { ArmadaManagerGovernance } from './ArmadaManagerGovernance'
+import { parseVault, parseVaults } from './extensions/parseVaults'
 
 /**
  * @name ArmadaManager
@@ -149,15 +150,19 @@ export class ArmadaManager implements IArmadaManager {
 
   /** @see IArmadaManager.getVaultsRaw */
   async getVaultsRaw(params: Parameters<IArmadaManager['getVaultsRaw']>[0]) {
-    return await this._subgraphManager.getVaults({ chainId: params.chainInfo.chainId })
+    return await this._subgraphManager
+      .getVaults({ chainId: params.chainInfo.chainId })
+      .then((vaults) => parseVaults(vaults))
   }
 
   /** @see IArmadaManager.getVaultRaw */
   async getVaultRaw(params: Parameters<IArmadaManager['getVaultRaw']>[0]) {
-    return this._subgraphManager.getVault({
-      chainId: params.vaultId.chainInfo.chainId,
-      vaultId: params.vaultId.fleetAddress.value,
-    })
+    return this._subgraphManager
+      .getVault({
+        chainId: params.vaultId.chainInfo.chainId,
+        vaultId: params.vaultId.fleetAddress.value,
+      })
+      .then((vault) => parseVault(vault))
   }
 
   /** @see IArmadaManager.getGlobalRebalancesRaw */

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/parseVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/parseVaults.ts
@@ -1,0 +1,26 @@
+import { GetVaultsQuery, GetVaultQuery } from '@summerfi/subgraph-manager-common'
+
+// changes ETH to WETH for the vault token symbols
+const changeWethToEth = (vault: GetVaultsQuery['vaults'][number] | GetVaultQuery['vault']) => {
+  return vault
+    ? {
+        ...vault,
+        inputToken: {
+          ...vault.inputToken,
+          symbol: vault.inputToken.symbol === 'WETH' ? 'ETH' : vault.inputToken.symbol,
+        },
+      }
+    : {}
+}
+
+export const parseVaults = ({ vaults }: GetVaultsQuery) => {
+  return {
+    vaults: vaults.map(changeWethToEth),
+  } as GetVaultsQuery
+}
+
+export const parseVault = (vault: GetVaultQuery) => {
+  return {
+    vault: changeWethToEth(vault.vault),
+  } as GetVaultQuery
+}


### PR DESCRIPTION
Introduce functionality to parse vault data, converting WETH token symbols to ETH. This enhancement improves the handling of token symbols in the vault management process.