### PR TITLE
Add getClaimableAggregatedRewards procedure for user rewards

### DIFF
--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerClaims.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerClaims.ts
@@ -42,13 +42,13 @@ export interface IArmadaManagerClaims {
   }>
 
   /**
-   * @name getClaimableAggregateRewards
+   * @name getClaimableAggregatedRewards
    * @description Returns the claimable amount a user is eligible to claim cross-chain
    * @param params.user The user
    * @returns Promise<number>
    * @throws Error
    */
-  getClaimableAggregateRewards: (params: { user: IUser }) => Promise<{
+  getClaimableAggregatedRewards: (params: { user: IUser }) => Promise<{
     total: bigint
     perChain: Record<number, bigint>
   }>

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerClaims.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerClaims.ts
@@ -298,9 +298,9 @@ export class ArmadaManagerClaims implements IArmadaManagerClaims {
     }
   }
 
-  async getClaimableAggregateRewards(
-    params: Parameters<IArmadaManagerClaims['getClaimableAggregateRewards']>[0],
-  ): ReturnType<IArmadaManagerClaims['getClaimableAggregateRewards']> {
+  async getClaimableAggregatedRewards(
+    params: Parameters<IArmadaManagerClaims['getClaimableAggregatedRewards']>[0],
+  ): ReturnType<IArmadaManagerClaims['getClaimableAggregatedRewards']> {
     const [merkleDistributionRewards, voteDelegationRewards] = await Promise.all([
       this.getMerkleDistributionRewards(params.user),
       this.getVoteDelegationRewards(params.user),

--- a/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
@@ -126,9 +126,9 @@ export class ArmadaManagerUsersClient extends IRPCClient implements IArmadaManag
     return this.rpcClient.armada.users.getAggregatedRewards.query(params)
   }
 
-  async getClaimableAggregateRewards(
-    params: Parameters<IArmadaManagerUsersClient['getClaimableAggregateRewards']>[0],
-  ): ReturnType<IArmadaManagerUsersClient['getClaimableAggregateRewards']> {
+  async getClaimableAggregatedRewards(
+    params: Parameters<IArmadaManagerUsersClient['getClaimableAggregatedRewards']>[0],
+  ): ReturnType<IArmadaManagerUsersClient['getClaimableAggregatedRewards']> {
     return this.rpcClient.armada.users.getClaimableAggregatedRewards.query(params)
   }
 

--- a/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/implementation/ArmadaManager/ArmadaManagerUsersClient.ts
@@ -126,6 +126,12 @@ export class ArmadaManagerUsersClient extends IRPCClient implements IArmadaManag
     return this.rpcClient.armada.users.getAggregatedRewards.query(params)
   }
 
+  async getClaimableAggregateRewards(
+    params: Parameters<IArmadaManagerUsersClient['getClaimableAggregateRewards']>[0],
+  ): ReturnType<IArmadaManagerUsersClient['getClaimableAggregateRewards']> {
+    return this.rpcClient.armada.users.getClaimableAggregatedRewards.query(params)
+  }
+
   async getAggregatedClaimsForChainTX(
     params: Parameters<IArmadaManagerUsersClient['getAggregatedClaimsForChainTX']>[0],
   ): ReturnType<IArmadaManagerUsersClient['getAggregatedClaimsForChainTX']> {

--- a/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
@@ -229,14 +229,14 @@ export interface IArmadaManagerUsersClient {
   }>
 
   /**
-   * @method getClaimableAggregateRewards
+   * @method getClaimableAggregatedRewards
    * @description Returns the claimable aggregated rewards of a user in a Fleet
    *
    * @param user Address of the user to check the rewards for
    *
    * @returns The claimable aggregated rewards of the user in the Fleet
    */
-  getClaimableAggregateRewards(params: { user: IUser }): Promise<{
+  getClaimableAggregatedRewards(params: { user: IUser }): Promise<{
     total: bigint
     perChain: Record<number, bigint>
   }>

--- a/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
+++ b/sdk/sdk-client/src/interfaces/ArmadaManager/IArmadaManagerUsersClient.ts
@@ -217,13 +217,26 @@ export interface IArmadaManagerUsersClient {
 
   /**
    * @method getAggregatedRewards
-   * @description Returns the aggregated rewards of a user in a Fleet
+   * @description Returns the total aggregated rewards of a user in a Fleet
    *
    * @param user Address of the user to check the rewards for
    *
    * @returns The aggregated rewards of the user in the Fleet
    */
   getAggregatedRewards(params: { user: IUser }): Promise<{
+    total: bigint
+    perChain: Record<number, bigint>
+  }>
+
+  /**
+   * @method getClaimableAggregateRewards
+   * @description Returns the claimable aggregated rewards of a user in a Fleet
+   *
+   * @param user Address of the user to check the rewards for
+   *
+   * @returns The claimable aggregated rewards of the user in the Fleet
+   */
+  getClaimableAggregateRewards(params: { user: IUser }): Promise<{
     total: bigint
     perChain: Record<number, bigint>
   }>

--- a/sdk/sdk-server/src/SDKAppRouter.ts
+++ b/sdk/sdk-server/src/SDKAppRouter.ts
@@ -55,6 +55,7 @@ import { getUserBalance } from './armada-protocol-handlers/users/getUserBalance'
 import { getSummerToken } from './armada-protocol-handlers/users/getSummerToken'
 import { getDelegationChainLength } from './armada-protocol-handlers/users/getDelegationChainLength'
 import { pong } from './handlers/debugPong'
+import { getClaimableAggregatedRewards } from './armada-protocol-handlers/users/getClaimableAggregatedRewards'
 
 /**
  * Server
@@ -102,6 +103,7 @@ export const sdkAppRouter = router({
       getStakedBalance: getStakedBalance,
       getTotalBalance: getTotalBalance,
       getAggregatedRewards: getAggregatedRewards,
+      getClaimableAggregatedRewards: getClaimableAggregatedRewards,
       getAggregatedClaimsForChainTX: getAggregatedClaimsForChainTX,
       getUserDelegatee: getUserDelegatee,
       getDelegateTX: getDelegateTx,

--- a/sdk/sdk-server/src/armada-protocol-handlers/users/getClaimableAggregatedRewards.ts
+++ b/sdk/sdk-server/src/armada-protocol-handlers/users/getClaimableAggregatedRewards.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { publicProcedure } from '../../SDKTRPC'
+import { isUser, type IUser } from '@summerfi/sdk-common'
+
+export const getClaimableAggregatedRewards = publicProcedure
+  .input(
+    z.object({
+      user: z.custom<IUser>(isUser),
+    }),
+  )
+  .query(async (opts) => {
+    return opts.ctx.armadaManager.claims.getClaimableAggregateRewards(opts.input)
+  })

--- a/sdk/sdk-server/src/armada-protocol-handlers/users/getClaimableAggregatedRewards.ts
+++ b/sdk/sdk-server/src/armada-protocol-handlers/users/getClaimableAggregatedRewards.ts
@@ -9,5 +9,5 @@ export const getClaimableAggregatedRewards = publicProcedure
     }),
   )
   .query(async (opts) => {
-    return opts.ctx.armadaManager.claims.getClaimableAggregateRewards(opts.input)
+    return opts.ctx.armadaManager.claims.getClaimableAggregatedRewards(opts.input)
   })


### PR DESCRIPTION
Introduce a new procedure to retrieve claimable aggregated rewards for users in a Fleet, enhancing the rewards management functionality. Update the interface and related imports accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option for users to retrieve claimable aggregated rewards with a detailed breakdown, including total rewards and per-chain values.
  - Enhanced the reward information display for clearer and more comprehensive insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->