### PR TITLE
Hide arks with deposit cap 0

### DIFF
--- a/apps/earn-protocol/app/server-handlers/interest-rates/index.ts
+++ b/apps/earn-protocol/app/server-handlers/interest-rates/index.ts
@@ -80,12 +80,14 @@ export async function getInterestRates({ network, arksList }: GetInterestRatesPa
     throw new Error(`getInterestRates: No endpoint found for network: ${network}`)
   }
 
-  const arkNamesList = arksList.map((ark) =>
+  const filteredArksWithCapHigherThanZero = arksList.filter((ark) => Number(ark.depositCap) > 0)
+
+  const arkNamesList = filteredArksWithCapHigherThanZero.map((ark) =>
     ark.name ? ark.name : getArkProductId(ark) || 'NOT FOUND',
   )
 
   const response = await Promise.all(
-    arksList.map(async (ark) => {
+    filteredArksWithCapHigherThanZero.map(async (ark) => {
       const productId = getArkProductId(ark)
 
       if (productId === false) {

--- a/apps/earn-protocol/features/vault-exposure/table/filters/filters.ts
+++ b/apps/earn-protocol/features/vault-exposure/table/filters/filters.ts
@@ -10,11 +10,14 @@ export const vaultExposureFilter = ({
   allocationType: VaultExposureFilterType
 }) => ({
   ...vault,
-  arks: vault.arks.filter((item) =>
-    allocationType === VaultExposureFilterType.ALL
-      ? true
-      : allocationType === VaultExposureFilterType.UNALLOCATED
-        ? Number(item.inputTokenBalance) === 0
-        : Number(item.inputTokenBalance) > 0,
+  arks: vault.arks.filter(
+    (item) =>
+      // First check if depositCap is greater than 0
+      Number(item.depositCap) > 0 &&
+      (allocationType === VaultExposureFilterType.ALL
+        ? true
+        : allocationType === VaultExposureFilterType.UNALLOCATED
+          ? Number(item.inputTokenBalance) === 0
+          : Number(item.inputTokenBalance) > 0),
   ),
 })


### PR DESCRIPTION
## Description
Add deposit cap filtering for interest rates and vault exposure

## Changes
- Added deposit cap validation to filter out vaults with zero cap
- Updated interest rates fetching to skip zero-cap ARKs
- Enhanced vault exposure filters to check deposit cap
- Improved filtering logic for allocated/unallocated states
- Added proper number type casting for cap checks

## Benefits
1. More accurate interest rate calculations by excluding inactive vaults
2. Better vault exposure data with only active ARKs
3. Improved data consistency across features

## Testing
- Verify interest rates only show for ARKs with non-zero caps
- Test vault exposure filters with different cap values
- Confirm allocation filtering works with cap checks
- Check number casting for deposit cap values

## Next steps
- Monitor impact on vault exposure calculations
- Consider adding deposit cap threshold configuration
- Add analytics for filtered vaults

## Additional Notes
This PR improves data accuracy by filtering out inactive vaults based on deposit cap values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced interest rates processing so that only eligible entries are considered, leading to improved performance and more accurate results.
  - Refined vault allocation filtering to display data more precisely by using stricter criteria for entry selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->