### PR TITLE
Optimize bulk interest rates fetching

### DIFF
--- a/apps/earn-protocol-landing-page/app/page.tsx
+++ b/apps/earn-protocol-landing-page/app/page.tsx
@@ -1,6 +1,6 @@
 import { BigGradientBox, HighestQualityYieldsDisclaimer } from '@summerfi/app-earn-ui'
-import { type IconNamesList } from '@summerfi/app-types'
-import { parseServerResponseToClient } from '@summerfi/app-utils'
+import { type IconNamesList, type SDKNetwork } from '@summerfi/app-types'
+import { aggregateArksPerNetwork, parseServerResponseToClient } from '@summerfi/app-utils'
 
 import { getProtocolTvl } from '@/app/server-handlers/defillama/get-protocol-tvl'
 import { getVaultsList } from '@/app/server-handlers/sdk/get-vaults-list'
@@ -128,11 +128,14 @@ export default async function HomePage() {
 
   const { config } = parseServerResponseToClient(systemConfig)
 
-  const interestRatesPromises = vaults.map((vault) =>
-    getInterestRates({
-      network: vault.protocol.network,
-      arksList: vault.arks,
-    }),
+  const aggregatedArksPerNetwork = aggregateArksPerNetwork(vaults)
+
+  const interestRatesPromises = Object.entries(aggregatedArksPerNetwork).map(
+    ([network, { arks }]) =>
+      getInterestRates({
+        network: network as SDKNetwork,
+        arksList: arks,
+      }),
   )
 
   const interestRatesResults = await Promise.all(interestRatesPromises)

--- a/apps/earn-protocol/app/page.tsx
+++ b/apps/earn-protocol/app/page.tsx
@@ -1,4 +1,5 @@
-import { parseServerResponseToClient } from '@summerfi/app-utils'
+import { type SDKNetwork } from '@summerfi/app-types'
+import { aggregateArksPerNetwork, parseServerResponseToClient } from '@summerfi/app-utils'
 import { redirect } from 'next/navigation'
 
 import { getVaultsList } from '@/app/server-handlers/sdk/get-vaults-list'
@@ -17,11 +18,14 @@ const EarnAllVaultsPage = async () => {
   const [{ vaults }, configRaw] = await Promise.all([getVaultsList(), systemConfigHandler()])
   const { config: systemConfig } = parseServerResponseToClient(configRaw)
 
-  const interestRatesPromises = vaults.map((vault) =>
-    getInterestRates({
-      network: vault.protocol.network,
-      arksList: vault.arks,
-    }),
+  const aggregatedArksPerNetwork = aggregateArksPerNetwork(vaults)
+
+  const interestRatesPromises = Object.entries(aggregatedArksPerNetwork).map(
+    ([network, { arks }]) =>
+      getInterestRates({
+        network: network as SDKNetwork,
+        arksList: arks,
+      }),
   )
 
   const interestRatesResults = await Promise.all(interestRatesPromises)

--- a/apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx
@@ -1,4 +1,5 @@
-import { parseServerResponseToClient } from '@summerfi/app-utils'
+import { type SDKNetwork } from '@summerfi/app-types'
+import { aggregateArksPerNetwork, parseServerResponseToClient } from '@summerfi/app-utils'
 import { type IArmadaPosition } from '@summerfi/sdk-client'
 
 import { getInterestRates } from '@/app/server-handlers/interest-rates'
@@ -62,11 +63,14 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { vaults } = vaultsData
   const { rebalances } = rebalancesData
 
-  const interestRatesPromises = vaults.map((vault) =>
-    getInterestRates({
-      network: vault.protocol.network,
-      arksList: vault.arks,
-    }),
+  const aggregatedArksPerNetwork = aggregateArksPerNetwork(vaults)
+
+  const interestRatesPromises = Object.entries(aggregatedArksPerNetwork).map(
+    ([network, { arks }]) =>
+      getInterestRates({
+        network: network as SDKNetwork,
+        arksList: arks,
+      }),
   )
 
   const interestRatesResults = await Promise.all(interestRatesPromises)

--- a/packages/app-utils/src/helpers/aggregate-arks-per-network.ts
+++ b/packages/app-utils/src/helpers/aggregate-arks-per-network.ts
@@ -1,0 +1,23 @@
+import { type SDKNetwork, type SDKVaultishType } from '@summerfi/app-types'
+
+type ArksAggregatedByNetwork = { [key in SDKNetwork]: { arks: SDKVaultishType['arks'] } }
+
+/**
+ * Aggregates arks from multiple vaults by their network, ensuring uniqueness of arks within each network
+ * @param vaults - Array of vault objects containing protocol and arks information
+ * @returns Object with networks as keys and their unique arks as values
+ */
+export const aggregateArksPerNetwork = (vaults: SDKVaultishType[]) => {
+  return vaults.reduce<ArksAggregatedByNetwork>((acc, vault) => {
+    const { network } = vault.protocol
+
+    if (!acc[network]) {
+      acc[network] = { arks: [] }
+    }
+    // Use Set to ensure uniqueness when adding new arks
+    acc[network].arks = [...new Set([...acc[network].arks, ...vault.arks])]
+
+    return acc
+    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+  }, {} as ArksAggregatedByNetwork)
+}

--- a/packages/app-utils/src/index.ts
+++ b/packages/app-utils/src/index.ts
@@ -80,3 +80,5 @@ export {
   getArkProductIdList,
   getArkByProductId,
 } from './helpers/get-ark-product-id'
+
+export { aggregateArksPerNetwork } from './helpers/aggregate-arks-per-network'


### PR DESCRIPTION
## Description
Optimize interest rates fetching by aggregating ARKs per network

## Changes
- Added aggregateArksPerNetwork helper to combine ARKs by network
- Updated interest rates fetching to batch requests by network
- Removed duplicate ARK requests across vaults
- Enhanced type safety with SDKNetwork types
- Implemented Set-based ARK deduplication

## Benefits
1. Reduced number of interest rate API calls
2. Better network request optimization
3. Elimination of duplicate ARK queries

## Testing
- Verify interest rates fetch correctly with aggregated ARKs
- Test ARK deduplication across multiple vaults
- Confirm network-specific batching works
- Check interest rate data consistency

## Next steps
- Monitor API performance improvements
- Consider adding request caching
- Add analytics for network request patterns

## Additional Notes
This PR optimizes interest rate fetching by aggregating ARKs by network, reducing redundant API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced interest rate displays across pages by grouping network data, resulting in more reliable and consistent calculations.
  
- **Refactor**
  - Streamlined the underlying data aggregation process, improving overall efficiency and maintainability without affecting the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->