### PR TITLE
Update interest rates request to handle just latest apy

### DIFF
--- a/apps/earn-protocol-landing-page/app/page.tsx
+++ b/apps/earn-protocol-landing-page/app/page.tsx
@@ -135,6 +135,7 @@ export default async function HomePage() {
       getInterestRates({
         network: network as SDKNetwork,
         arksList: arks,
+        justLatestRates: true,
       }),
   )
 

--- a/apps/earn-protocol-landing-page/app/server-handlers/interest-rates/index.ts
+++ b/apps/earn-protocol-landing-page/app/server-handlers/interest-rates/index.ts
@@ -121,6 +121,11 @@ export async function getInterestRates({
         const data = await apiResponse.json()
 
         if (justLatestRates) {
+          if (!data.interestRates?.length) {
+            return noInterestRates
+          }
+
+          // map response from rates endpoint to match the expected format
           return {
             ...noInterestRates,
             latestInterestRate: [{ rate: [data.interestRates[0]] }],

--- a/apps/earn-protocol/app/page.tsx
+++ b/apps/earn-protocol/app/page.tsx
@@ -19,6 +19,7 @@ const EarnAllVaultsPage = async () => {
       getInterestRates({
         network: network as SDKNetwork,
         arksList: arks,
+        justLatestRates: true,
       }),
   )
 

--- a/apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx
@@ -70,6 +70,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
       getInterestRates({
         network: network as SDKNetwork,
         arksList: arks,
+        justLatestRates: true,
       }),
   )
 

--- a/apps/earn-protocol/app/server-handlers/interest-rates/index.ts
+++ b/apps/earn-protocol/app/server-handlers/interest-rates/index.ts
@@ -121,6 +121,10 @@ export async function getInterestRates({
         const data = await apiResponse.json()
 
         if (justLatestRates) {
+          if (!data.interestRates?.length) {
+            return noInterestRates
+          }
+
           // map response from rates endpoint to match the expected format
           return {
             ...noInterestRates,

--- a/apps/earn-protocol/app/server-handlers/interest-rates/index.ts
+++ b/apps/earn-protocol/app/server-handlers/interest-rates/index.ts
@@ -1,14 +1,14 @@
 'use server'
 
+import { REVALIDATION_TIMES } from '@summerfi/app-earn-ui'
 import { SDKNetwork, type SDKVaultishType, type SDKVaultType } from '@summerfi/app-types'
+import { getArkProductId } from '@summerfi/app-utils'
 import { GraphQLClient } from 'graphql-request'
 
-import { REVALIDATION_TIMES } from '@/constants/revalidations'
 import {
   GetInterestRatesDocument,
   type GetInterestRatesQuery,
 } from '@/graphql/clients/rates/client'
-import { getArkProductId } from '@/helpers/prepare-product-id'
 
 type GetInterestRatesParams = {
   network: SDKNetwork
@@ -16,6 +16,7 @@ type GetInterestRatesParams = {
   hourlyCount?: number
   weeklyCount?: number
   arksList: SDKVaultishType['arks'] | SDKVaultType['arks']
+  justLatestRates?: boolean
 }
 
 const noInterestRates: GetInterestRatesQuery = {
@@ -67,15 +68,25 @@ if (!process.env.FUNCTIONS_API_URL) {
   throw new Error('FUNCTIONS_API_URL is not set')
 }
 
-const apiUrls = {
+const apiHistoricalRatesUrls = {
   [SDKNetwork.Mainnet]: `${process.env.FUNCTIONS_API_URL}/api/historicalRates/1`,
   [SDKNetwork.Base]: `${process.env.FUNCTIONS_API_URL}/api/historicalRates/8453`,
   [SDKNetwork.ArbitrumOne]: `${process.env.FUNCTIONS_API_URL}/api/historicalRates/42161`,
 }
 
+const apiRatesUrls = {
+  [SDKNetwork.Mainnet]: `${process.env.FUNCTIONS_API_URL}/api/rates/1`,
+  [SDKNetwork.Base]: `${process.env.FUNCTIONS_API_URL}/api/rates/8453`,
+  [SDKNetwork.ArbitrumOne]: `${process.env.FUNCTIONS_API_URL}/api/rates/42161`,
+}
+
 const isProperNetwork = (network: string): network is keyof typeof clients => network in clients
 
-export async function getInterestRates({ network, arksList }: GetInterestRatesParams) {
+export async function getInterestRates({
+  network,
+  arksList,
+  justLatestRates = false,
+}: GetInterestRatesParams) {
   if (!isProperNetwork(network)) {
     throw new Error(`getInterestRates: No endpoint found for network: ${network}`)
   }
@@ -95,9 +106,12 @@ export async function getInterestRates({ network, arksList }: GetInterestRatesPa
       }
 
       try {
-        // Try primary source first
-        const apiUrl = `${apiUrls[network]}?productId=${productId}`
+        const resolvedUrl = justLatestRates
+          ? apiRatesUrls[network]
+          : apiHistoricalRatesUrls[network]
 
+        // Try primary source first
+        const apiUrl = `${resolvedUrl}?productId=${productId}`
         const apiResponse = await fetch(apiUrl)
 
         if (!apiResponse.ok) {
@@ -105,6 +119,14 @@ export async function getInterestRates({ network, arksList }: GetInterestRatesPa
         }
 
         const data = await apiResponse.json()
+
+        if (justLatestRates) {
+          // map response from rates endpoint to match the expected format
+          return {
+            ...noInterestRates,
+            latestInterestRate: [{ rate: [data.interestRates[0]] }],
+          }
+        }
 
         return data
       } catch (error) {


### PR DESCRIPTION
## Description
Add optimized interest rates fetching with latest-only option

## Changes
- Added justLatestRates flag to optimize rate fetching
- Created separate endpoints for historical and latest rates
- Updated interest rates handler to support both rate types
- Added rate endpoint mapping per network
- Implemented optimized response mapping for latest rates

## Benefits
1. Reduced data transfer for components needing only latest rates
2. Better performance with network-specific endpoints
3. Backwards compatibility with historical rate fetching

## Testing
- Verify latest rates fetch correctly across all networks
- Test historical rates still work when needed
- Confirm rate mapping works for both endpoint types
- Check error handling for both endpoints

## Next steps
- Monitor API performance improvements
- Consider adding rate caching
- Add analytics for endpoint usage patterns

## Additional Notes
This PR optimizes interest rate fetching by adding a latest-only option while maintaining full historical data support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the interest rates display across the application to show only the most recent rates.
  - Enhanced data retrieval ensures users consistently see up-to-date interest rate information in various sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->