### PR TITLE
Add debug logging and enhance withdrawal calculations in ArmadaManager

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -1094,8 +1094,7 @@ export class ArmadaManager implements IArmadaManager {
     // FIXME: hardcoded to false because fleet rewards manager was not whitleilsted
     const claimRewards = false
 
-    // if the reques
-    // ted amount is close to all staked shares, we should withdraw all
+    // if the requested amount is close to all staked shares, we make assumption to withdraw all
     // threshold is set to 0.99999 to avoid rounding errors
     const withdrawThreshold = 0.9999
     const shouldWithdrawAll =

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -1095,10 +1095,11 @@ export class ArmadaManager implements IArmadaManager {
     const claimRewards = false
 
     // if the requested amount is close to all staked shares, we make assumption to withdraw all
-    // threshold is set to 0.99999 to avoid rounding errors
-    const withdrawThreshold = 0.9999
+    // withdraw all assumption threshold is set to 0.9999
+    const withdrawAllThreshold = 0.9999
     const shouldWithdrawAll =
-      params.shares.toSolidityValue() / params.stakedShares.toSolidityValue() >= withdrawThreshold
+      params.shares.toSolidityValue() / params.stakedShares.toSolidityValue() >=
+      withdrawAllThreshold
     const withdrawSharesAmount = shouldWithdrawAll ? 0n : params.shares.toSolidityValue()
 
     const calldata = encodeFunctionData({

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -1097,9 +1097,9 @@ export class ArmadaManager implements IArmadaManager {
     // if the requested amount is close to all staked shares, we make assumption to withdraw all
     // withdraw all assumption threshold is set to 0.9999
     const withdrawAllThreshold = 0.9999
-    const shouldWithdrawAll =
-      params.shares.toSolidityValue() / params.stakedShares.toSolidityValue() >=
-      withdrawAllThreshold
+    const shouldWithdrawAll = new BigNumber(params.shares.toSolidityValue().toString())
+      .div(params.stakedShares.toSolidityValue().toString())
+      .gte(withdrawAllThreshold)
     const withdrawSharesAmount = shouldWithdrawAll ? 0n : params.shares.toSolidityValue()
 
     const calldata = encodeFunctionData({

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerClaims.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerClaims.ts
@@ -254,8 +254,6 @@ export class ArmadaManagerClaims implements IArmadaManagerClaims {
         )
       })
 
-    LoggingService.debug(`Read protocol rewards on ` + chainInfo.toString(), perFleet)
-
     return {
       total: Object.values(perFleet).reduce((acc, rewards) => acc + rewards, 0n),
       perFleet: perFleet,

--- a/sdk/swap-service/src/implementation/oneinch/OneInchSwapProvider.ts
+++ b/sdk/swap-service/src/implementation/oneinch/OneInchSwapProvider.ts
@@ -86,6 +86,8 @@ export class OneInchSwapProvider
       slippage: params.slippage,
     })
 
+    LoggingService.debug('OneInchSwapUrl', swapUrl)
+
     const authHeader = this._getOneInchAuthHeader()
 
     const response = await fetch(swapUrl, {
@@ -219,8 +221,12 @@ export class OneInchSwapProvider
       this._excludedSwapProtocols.length > 0
         ? '&excludedProtocols=' + this._excludedSwapProtocols.join(',')
         : ''
+    const excludeProtocolsParam =
+      this._excludedSwapProtocols.length > 0
+        ? '&excludeProtocols=' + this._excludedSwapProtocols.join(',')
+        : ''
 
-    return `${this._apiUrl}/swap/${this._version}/${chainId}/swap?fromTokenAddress=${fromTokenAddress}&toTokenAddress=${toTokenAddress}&amount=${fromAmount}&fromAddress=${recipient}&slippage=${params.slippage.value}&disableEstimate=${disableEstimate}&allowPartialFill=${allowPartialFill}${protocolsParam}${excludedProtocolsParam}`
+    return `${this._apiUrl}/swap/${this._version}/${chainId}/swap?fromTokenAddress=${fromTokenAddress}&toTokenAddress=${toTokenAddress}&amount=${fromAmount}&fromAddress=${recipient}&slippage=${params.slippage.value}&disableEstimate=${disableEstimate}&allowPartialFill=${allowPartialFill}${protocolsParam}${excludedProtocolsParam}${excludeProtocolsParam}`
   }
 
   /**


### PR DESCRIPTION
Introduce debug logging in OneInchSwapProvider and fix the excluded protocols parameter. Enhance ArmadaManager to account for staked shares in withdrawal calculations. Remove unnecessary debug logging from ArmadaManagerClaims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced withdrawal processing now considers additional account shares, ensuring smoother and more reliable transaction handling.
  - Updated swap operations with flexible protocol options, improving the reliability of trade execution.

- **Refactor**
  - Streamlined protocol rewards processing by removing redundant internal logging for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->