### PR TITLE
Add GitHub Actions workflow for Earn apps release process

### DIFF
--- a/.github/workflows/release-earn-apps.yaml
+++ b/.github/workflows/release-earn-apps.yaml
@@ -1,0 +1,54 @@
+name: Release the Earn Kraken! 🐙
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type, major | minor | patch'
+        default: 'minor'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.19.1
+      - name: 'Determine Release Type'
+        run: |
+          if ${{ contains(github.event.inputs.release_type, 'major') }}; then
+            echo "RELEASE_TYPE=major" >> $GITHUB_ENV
+          elif ${{ contains(github.event.inputs.release_type, 'minor') }}; then
+            echo "RELEASE_TYPE=minor" >> $GITHUB_ENV
+          elif ${{ contains(github.event.inputs.release_type, 'patch') }}; then
+            echo "RELEASE_TYPE=patch" >> $GITHUB_ENV
+          else
+            echo "NOTE: There was no release type specified in the commit message, and therefore no release will be published."
+            exit 1
+          fi
+      - name: 'Release Type'
+        run: echo ${{ env.RELEASE_TYPE }}
+      - name: git config
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: release version
+        run: npx release-it -- ${{ env.RELEASE_TYPE }} --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+      - name: Merge dev -> main
+        run: |
+          git status
+          git pull
+          git fetch
+          git checkout main
+          git rebase dev
+          git push origin main
+          git status

--- a/.github/workflows/release-earn-apps.yaml
+++ b/.github/workflows/release-earn-apps.yaml
@@ -41,22 +41,24 @@ jobs:
 
       - name: Make an earn-apps release
         working-directory: ./apps/earn-protocol
-        run: npx release-it -- ${{ env.RELEASE_TYPE }} --ci
+        run:
+          npx release-it --ci --no-npm --dry-run --git.tagName="Earn App" -- ${{ env.RELEASE_TYPE }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Make an earn-apps-lp release
         working-directory: ./apps/earn-protocol-landing-page
-        run: npx release-it -- ${{ env.RELEASE_TYPE }} --ci
+        run:
+          npx release-it --ci --no-npm --dry-run --git.tagName="Earn LP" -- ${{ env.RELEASE_TYPE }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
 
-      - name: Merge dev -> main
-        run: |
-          git status
-          git pull
-          git fetch
-          git checkout main
-          git rebase dev
-          git push origin main
-          git status
+      # - name: Merge dev -> main
+      #   run: |
+      #     git status
+      #     git pull
+      #     git fetch
+      #     git checkout main
+      #     git rebase dev
+      #     git push origin main
+      #     git status

--- a/.github/workflows/release-earn-apps.yaml
+++ b/.github/workflows/release-earn-apps.yaml
@@ -1,4 +1,4 @@
-name: Release the Earn Kraken! 🐙
+name: Release Earn apps! 🐙
 
 on:
   workflow_dispatch:
@@ -39,10 +39,18 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: release version
+      - name: Make an earn-apps release
+        working-directory: ./apps/earn-protocol
         run: npx release-it -- ${{ env.RELEASE_TYPE }} --ci
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
+
+      - name: Make an earn-apps-lp release
+        working-directory: ./apps/earn-protocol-landing-page
+        run: npx release-it -- ${{ env.RELEASE_TYPE }} --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+
       - name: Merge dev -> main
         run: |
           git status

--- a/.github/workflows/release-earn-apps.yaml
+++ b/.github/workflows/release-earn-apps.yaml
@@ -42,14 +42,16 @@ jobs:
       - name: Make an earn-apps release
         working-directory: ./apps/earn-protocol
         run:
-          npx release-it --ci --no-npm --dry-run --git.tagName="Earn App" -- ${{ env.RELEASE_TYPE }}
+          npx release-it --ci --no-npm --dry-run --git.commitMessage='Release Earn App ${version}'
+          --git.tagAnnotation='Earn App' -- ${{ env.RELEASE_TYPE }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Make an earn-apps-lp release
         working-directory: ./apps/earn-protocol-landing-page
         run:
-          npx release-it --ci --no-npm --dry-run --git.tagName="Earn LP" -- ${{ env.RELEASE_TYPE }}
+          npx release-it --ci --no-npm --dry-run --git.commitMessage='Release Earn LP ${version}'
+          --git.tagAnnotation='Earn LP' -- ${{ env.RELEASE_TYPE }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
 


### PR DESCRIPTION
Implement a GitHub Actions workflow to streamline the release process for Earn apps, including options for dry-run and custom tag names.