### PR TITLE
Remove "resolutions" in package.json, change one context name

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,23 +85,5 @@
     "bignumber.js": "^9.1.2",
     "viem": "2.21.55",
     "zod": "^3.22.4"
-  },
-  "resolutions": {
-    "@emotion/react": "11.11.1",
-    "bn.js": "5.2.1",
-    "@walletconnect/ethereum-provider": "2.9.1",
-    "@ethersproject/abstract-provider": "5.7.0",
-    "@ethersproject/signing-key": "5.7.0",
-    "acorn": "8.5.0",
-    "debug": "4.3.4",
-    "eccrypto": "npm:@toruslabs/eccrypto@2.2.1",
-    "ethereumjs-util": "7.1.5",
-    "mime-db": "1.51.0",
-    "mime-types": "2.1.34",
-    "query-string": "7.1.3",
-    "tslib": "2.2.0",
-    "type-fest": "0.20.2",
-    "webpack": "5",
-    "yargs-parser": "20.2.2"
   }
 }

--- a/packages/app-earn-ui/src/contexts/LocalConfigContext/LocalConfigContext.tsx
+++ b/packages/app-earn-ui/src/contexts/LocalConfigContext/LocalConfigContext.tsx
@@ -30,7 +30,7 @@ export const defaultLocalConfig: LocalConfigState = {
   },
 }
 
-const DeviceContext = createContext<LocalConfigType>({
+const LocalConfigContext = createContext<LocalConfigType>({
   state: defaultLocalConfig,
   dispatch: () => {},
 })
@@ -55,9 +55,13 @@ export const LocalConfigContextProvider: FC<{
   }
   const [state, dispatch] = useReducer(localConfigReducer, resolvedInitialState)
 
-  return <DeviceContext.Provider value={{ state, dispatch }}>{children}</DeviceContext.Provider>
+  return (
+    <LocalConfigContext.Provider value={{ state, dispatch }}>
+      {children}
+    </LocalConfigContext.Provider>
+  )
 }
 
 export const useLocalConfig = () => {
-  return useContext(DeviceContext)
+  return useContext(LocalConfigContext)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,24 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@emotion/react': 11.11.1
-  bn.js: 5.2.1
-  '@walletconnect/ethereum-provider': 2.9.1
-  '@ethersproject/abstract-provider': 5.7.0
-  '@ethersproject/signing-key': 5.7.0
-  acorn: 8.5.0
-  debug: 4.3.4
-  eccrypto: npm:@toruslabs/eccrypto@2.2.1
-  ethereumjs-util: 7.1.5
-  mime-db: 1.51.0
-  mime-types: 2.1.34
-  query-string: 7.1.3
-  tslib: 2.2.0
-  type-fest: 0.20.2
-  webpack: '5'
-  yargs-parser: 20.2.2
-
 importers:
 
   .:
@@ -487,10 +469,10 @@ importers:
         version: 2.9.1(react@18.3.1)(typescript@5.6.2)(zod@3.22.4)
       '@web3-onboard/trezor':
         specifier: ^2.4.6
-        version: 2.4.6(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.2.0)(typescript@5.6.2)(zod@3.22.4)
+        version: 2.4.6(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.8.1)(typescript@5.6.2)(zod@3.22.4)
       '@web3-onboard/walletconnect':
         specifier: 2.4.6
-        version: 2.4.6(react@18.3.1)(typescript@5.6.2)(zod@3.22.4)
+        version: 2.4.6(@types/react@18.3.1)(react@18.3.1)(typescript@5.6.2)(zod@3.22.4)
       '@web3-onboard/web3auth':
         specifier: ^2.3.1
         version: 2.3.1(@babel/runtime@7.24.7)(@walletconnect/client@1.8.0)(@walletconnect/types@1.8.0)(react@18.3.1)(typescript@5.6.2)(zod@3.22.4)
@@ -4528,7 +4510,7 @@ packages:
     dependencies:
       '@aws-crypto/util': 3.0.0
       '@aws-sdk/types': 3.731.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@aws-crypto/crc32@5.2.0:
@@ -4537,7 +4519,7 @@ packages:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.731.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-crypto/crc32c@5.2.0:
@@ -4545,13 +4527,13 @@ packages:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.731.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-crypto/ie11-detection@3.0.0:
     resolution: {integrity: sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@aws-crypto/sha1-browser@5.2.0:
@@ -4562,7 +4544,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@aws-sdk/util-locate-window': 3.535.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-crypto/sha256-browser@3.0.0:
@@ -4575,7 +4557,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@aws-sdk/util-locate-window': 3.535.0
       '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@aws-crypto/sha256-browser@5.2.0:
@@ -4587,7 +4569,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@aws-sdk/util-locate-window': 3.535.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-crypto/sha256-js@3.0.0:
@@ -4595,7 +4577,7 @@ packages:
     dependencies:
       '@aws-crypto/util': 3.0.0
       '@aws-sdk/types': 3.731.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@aws-crypto/sha256-js@5.2.0:
@@ -4604,19 +4586,19 @@ packages:
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.731.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-crypto/supports-web-crypto@3.0.0:
     resolution: {integrity: sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@aws-crypto/supports-web-crypto@5.2.0:
     resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-crypto/util@3.0.0:
@@ -4624,7 +4606,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.731.0
       '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@aws-crypto/util@5.2.0:
@@ -4632,7 +4614,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.731.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-lambda-powertools/commons@1.18.1:
@@ -4757,7 +4739,7 @@ packages:
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
       '@smithy/util-waiter': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
@@ -4806,7 +4788,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -4855,7 +4837,7 @@ packages:
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
       '@smithy/util-waiter': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
@@ -4904,7 +4886,7 @@ packages:
       '@smithy/util-endpoints': 1.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -4953,7 +4935,7 @@ packages:
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
       '@smithy/util-waiter': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5002,7 +4984,7 @@ packages:
       '@smithy/util-retry': 2.2.0
       '@smithy/util-stream': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5050,7 +5032,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
@@ -5104,7 +5086,7 @@ packages:
       '@smithy/util-stream': 2.2.0
       '@smithy/util-utf8': 2.3.0
       '@smithy/util-waiter': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5153,7 +5135,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5217,7 +5199,7 @@ packages:
       '@smithy/util-stream': 4.0.2
       '@smithy/util-utf8': 4.0.0
       '@smithy/util-waiter': 4.0.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5266,7 +5248,7 @@ packages:
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
       '@smithy/util-waiter': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
@@ -5317,7 +5299,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5365,7 +5347,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sts'
       - aws-crt
@@ -5412,7 +5394,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5458,7 +5440,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5504,7 +5486,7 @@ packages:
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-retry': 4.0.1
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5553,7 +5535,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5601,7 +5583,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5612,7 +5594,7 @@ packages:
     deprecated: This package has moved to @smithy/config-resolver
     dependencies:
       '@smithy/config-resolver': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/core@3.554.0:
@@ -5625,7 +5607,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       fast-xml-parser: 4.2.5
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/core@3.567.0:
@@ -5638,7 +5620,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       fast-xml-parser: 4.2.5
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/core@3.731.0:
@@ -5655,7 +5637,7 @@ packages:
       '@smithy/types': 4.1.0
       '@smithy/util-middleware': 4.0.1
       fast-xml-parser: 4.4.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-cognito-identity@3.554.0:
@@ -5666,7 +5648,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5678,7 +5660,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-env@3.568.0:
@@ -5688,7 +5670,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-env@3.731.0:
@@ -5699,7 +5681,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/property-provider': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-http@3.552.0:
@@ -5714,7 +5696,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-stream': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-http@3.568.0:
@@ -5729,7 +5711,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-stream': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-http@3.731.0:
@@ -5745,7 +5727,7 @@ packages:
       '@smithy/smithy-client': 4.1.2
       '@smithy/types': 4.1.0
       '@smithy/util-stream': 4.0.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-ini@3.554.0(@aws-sdk/credential-provider-node@3.554.0):
@@ -5762,7 +5744,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5784,7 +5766,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
@@ -5806,7 +5788,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5826,7 +5808,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5846,7 +5828,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@aws-sdk/client-sts'
@@ -5868,7 +5850,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5881,7 +5863,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-process@3.568.0:
@@ -5892,7 +5874,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-process@3.731.0:
@@ -5904,7 +5886,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-sso@3.554.0(@aws-sdk/credential-provider-node@3.554.0):
@@ -5917,7 +5899,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5933,7 +5915,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
@@ -5950,7 +5932,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -5963,7 +5945,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -5979,7 +5961,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-web-identity@3.731.1:
@@ -5991,7 +5973,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/property-provider': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -6015,7 +5997,7 @@ packages:
       '@smithy/credential-provider-imds': 2.3.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -6030,7 +6012,7 @@ packages:
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
       '@smithy/util-config-provider': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-expect-continue@3.731.0:
@@ -6040,7 +6022,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-flexible-checksums@3.732.0:
@@ -6059,7 +6041,7 @@ packages:
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-stream': 4.0.2
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-host-header@3.535.0:
@@ -6069,7 +6051,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-host-header@3.567.0:
@@ -6079,7 +6061,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-host-header@3.731.0:
@@ -6089,7 +6071,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-location-constraint@3.731.0:
@@ -6098,7 +6080,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.731.0
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-logger@3.535.0:
@@ -6107,7 +6089,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-logger@3.568.0:
@@ -6116,7 +6098,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.567.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-logger@3.731.0:
@@ -6125,7 +6107,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.731.0
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-recursion-detection@3.535.0:
@@ -6135,7 +6117,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-recursion-detection@3.567.0:
@@ -6145,7 +6127,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-recursion-detection@3.731.0:
@@ -6155,7 +6137,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-retry@3.374.0:
@@ -6164,7 +6146,7 @@ packages:
     deprecated: This package has moved to @smithy/middleware-retry
     dependencies:
       '@smithy/middleware-retry': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 8.3.2
     dev: true
 
@@ -6180,7 +6162,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-sdk-s3@3.731.0:
@@ -6200,7 +6182,7 @@ packages:
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-stream': 4.0.2
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-signing@3.552.0:
@@ -6213,7 +6195,7 @@ packages:
       '@smithy/signature-v4': 2.3.0
       '@smithy/types': 2.12.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-ssec@3.731.0:
@@ -6222,7 +6204,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.731.0
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-user-agent@3.540.0:
@@ -6233,7 +6215,7 @@ packages:
       '@aws-sdk/util-endpoints': 3.540.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-user-agent@3.567.0:
@@ -6244,7 +6226,7 @@ packages:
       '@aws-sdk/util-endpoints': 3.567.0
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-user-agent@3.731.0:
@@ -6257,7 +6239,7 @@ packages:
       '@smithy/core': 3.1.1
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/nested-clients@3.731.1:
@@ -6301,7 +6283,7 @@ packages:
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-retry': 4.0.1
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -6315,7 +6297,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/region-config-resolver@3.567.0:
@@ -6327,7 +6309,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/region-config-resolver@3.731.0:
@@ -6339,7 +6321,7 @@ packages:
       '@smithy/types': 4.1.0
       '@smithy/util-config-provider': 4.0.0
       '@smithy/util-middleware': 4.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/signature-v4-crt@3.552.0:
@@ -6354,7 +6336,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-middleware': 2.2.0
       aws-crt: 1.21.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6371,7 +6353,7 @@ packages:
       '@smithy/protocol-http': 3.3.0
       '@smithy/signature-v4': 2.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/signature-v4-multi-region@3.731.0:
@@ -6383,7 +6365,7 @@ packages:
       '@smithy/protocol-http': 5.0.1
       '@smithy/signature-v4': 5.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/smithy-client@3.374.0:
@@ -6392,7 +6374,7 @@ packages:
     deprecated: This package has moved to @smithy/smithy-client
     dependencies:
       '@smithy/smithy-client': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/token-providers@3.554.0(@aws-sdk/credential-provider-node@3.554.0):
@@ -6404,7 +6386,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
@@ -6421,7 +6403,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/token-providers@3.731.1:
@@ -6433,7 +6415,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -6443,7 +6425,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/types@3.567.0:
@@ -6451,7 +6433,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/types@3.731.0:
@@ -6459,20 +6441,20 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
 
   /@aws-sdk/util-arn-parser@3.535.0:
     resolution: {integrity: sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-arn-parser@3.723.0:
     resolution: {integrity: sha512-ZhEfvUwNliOQROcAk34WJWVYTlTa4694kSVhDSjW6lE1bMataPnIN8A0ycukEzBXmd8ZSoBcQLn6lKGl7XIJ5w==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-endpoints@3.540.0:
@@ -6482,7 +6464,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
       '@smithy/util-endpoints': 1.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-endpoints@3.567.0:
@@ -6492,7 +6474,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/types': 2.12.0
       '@smithy/util-endpoints': 1.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-endpoints@3.731.0:
@@ -6502,14 +6484,14 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/types': 4.1.0
       '@smithy/util-endpoints': 3.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-locate-window@3.535.0:
     resolution: {integrity: sha512-PHJ3SL6d2jpcgbqdgiPxkXpu7Drc2PYViwxSIqvvMKhDwzSB1W3mMvtpzwKM4IE7zLFodZo0GKjJ9AsoXndXhA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-browser@3.535.0:
@@ -6518,7 +6500,7 @@ packages:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
       bowser: 2.11.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-browser@3.567.0:
@@ -6527,7 +6509,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/types': 2.12.0
       bowser: 2.11.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-browser@3.731.0:
@@ -6536,7 +6518,7 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/types': 4.1.0
       bowser: 2.11.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-node@3.535.0(aws-crt@1.21.2):
@@ -6552,7 +6534,7 @@ packages:
       '@smithy/node-config-provider': 2.3.0
       '@smithy/types': 2.12.0
       aws-crt: 1.21.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-node@3.568.0:
@@ -6567,7 +6549,7 @@ packages:
       '@aws-sdk/types': 3.567.0
       '@smithy/node-config-provider': 2.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-node@3.731.0:
@@ -6583,13 +6565,13 @@ packages:
       '@aws-sdk/types': 3.731.0
       '@smithy/node-config-provider': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-utf8-browser@3.259.0:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/xml-builder@3.723.0:
@@ -6597,7 +6579,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@babel/code-frame@7.10.4:
@@ -8514,7 +8496,7 @@ packages:
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
     requiresBuild: true
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -8600,7 +8582,7 @@ packages:
   /@emotion/styled@11.11.5(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==}
     peerDependencies:
-      '@emotion/react': 11.11.1
+      '@emotion/react': ^11.0.0-rc.0
       '@types/react': '*'
       react: '>=16.8.0'
     peerDependenciesMeta:
@@ -8652,13 +8634,13 @@ packages:
     resolution: {integrity: sha512-06t1xCPXq6QFN7W1JUEf68aCwYN0OUDNAIoJe7bAqhaoa2vn7NCcuX1VHkJ/OWpmElUgCsRO6RiBbIru1in0Ig==}
     dependencies:
       '@envelop/types': 3.0.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@envelop/types@3.0.2:
     resolution: {integrity: sha512-pOFea9ha0EkURWxJ/35axoH9fDGP5S2cUu/5Mmo9pb8zUf+TaEot8vB670XXihFEn/92759BMjLJNWBKmNhyng==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@envelop/validation-cache@5.1.3(@envelop/core@3.0.6)(graphql@16.8.2):
@@ -8671,7 +8653,7 @@ packages:
       graphql: 16.8.2
       hash-it: 6.0.0
       lru-cache: 6.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@esbuild/aix-ppc64@0.19.12:
@@ -9615,6 +9597,30 @@ packages:
       '@ethersproject/properties': 5.7.0
       '@ethersproject/strings': 5.7.0
 
+  /@ethersproject/abstract-provider@5.5.1:
+    resolution: {integrity: sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+    dev: false
+
+  /@ethersproject/abstract-provider@5.6.0:
+    resolution: {integrity: sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+    dev: false
+
   /@ethersproject/abstract-provider@5.7.0:
     resolution: {integrity: sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==}
     dependencies:
@@ -9726,7 +9732,7 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-      bn.js: 5.2.1
+      bn.js: 4.12.1
     dev: false
 
   /@ethersproject/bignumber@5.6.0:
@@ -9734,7 +9740,7 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-      bn.js: 5.2.1
+      bn.js: 4.12.1
     dev: false
 
   /@ethersproject/bignumber@5.7.0:
@@ -10231,6 +10237,28 @@ packages:
       '@ethersproject/logger': 5.7.0
       hash.js: 1.1.7
 
+  /@ethersproject/signing-key@5.5.0:
+    resolution: {integrity: sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      bn.js: 4.12.1
+      elliptic: 6.5.4
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/signing-key@5.6.0:
+    resolution: {integrity: sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      bn.js: 4.12.1
+      elliptic: 6.5.4
+      hash.js: 1.1.7
+    dev: false
+
   /@ethersproject/signing-key@5.7.0:
     resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
     dependencies:
@@ -10678,7 +10706,7 @@ packages:
     dependencies:
       application-config-path: 0.1.1
       command-exists: 1.2.9
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 3.2.7
       eol: 0.9.1
       get-port: 3.2.0
       glob: 7.2.3
@@ -10688,7 +10716,7 @@ packages:
       rimraf: 2.7.1
       sudo-prompt: 8.2.5
       tmp: 0.0.33
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10918,7 +10946,7 @@ packages:
     resolution: {integrity: sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==}
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/fast-memoize@1.2.1:
@@ -10930,7 +10958,7 @@ packages:
   /@formatjs/fast-memoize@2.2.0:
     resolution: {integrity: sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/icu-messageformat-parser@2.1.0:
@@ -10946,7 +10974,7 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/icu-skeleton-parser': 1.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/icu-skeleton-parser@1.3.6:
@@ -10960,7 +10988,7 @@ packages:
     resolution: {integrity: sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==}
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@formatjs/intl-localematcher@0.2.25:
@@ -10972,7 +11000,7 @@ packages:
   /@formatjs/intl-localematcher@0.5.4:
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@graphql-codegen/add@5.0.2(graphql@16.8.2):
@@ -10982,7 +11010,7 @@ packages:
     dependencies:
       '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-codegen/cli@5.0.2(@types/node@20.12.7)(graphql@16.8.2)(typescript@5.6.2):
@@ -11028,7 +11056,7 @@ packages:
       shell-quote: 1.8.1
       string-env-interpolation: 1.0.1
       ts-log: 2.2.5
-      tslib: 2.2.0
+      tslib: 2.8.1
       yaml: 2.4.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -11085,7 +11113,7 @@ packages:
       shell-quote: 1.8.1
       string-env-interpolation: 1.0.1
       ts-log: 2.2.5
-      tslib: 2.2.0
+      tslib: 2.8.1
       yaml: 2.4.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -11117,7 +11145,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11132,7 +11160,7 @@ packages:
       '@graphql-tools/schema': 10.0.3(graphql@16.8.2)
       '@graphql-tools/utils': 10.1.3(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-codegen/gql-tag-operations@4.0.6(graphql@16.8.2):
@@ -11145,7 +11173,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       auto-bind: 4.0.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11162,7 +11190,7 @@ packages:
       graphql: 16.8.2
       import-from: 4.0.0
       lodash: 4.17.21
-      tslib: 2.2.0
+      tslib: 2.4.1
     dev: true
 
   /@graphql-codegen/plugin-helpers@3.1.2(graphql@16.8.2):
@@ -11176,7 +11204,7 @@ packages:
       graphql: 16.8.2
       import-from: 4.0.0
       lodash: 4.17.21
-      tslib: 2.2.0
+      tslib: 2.4.1
     dev: true
 
   /@graphql-codegen/plugin-helpers@5.0.3(graphql@16.8.2):
@@ -11190,7 +11218,7 @@ packages:
       graphql: 16.8.2
       import-from: 4.0.0
       lodash: 4.17.21
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-codegen/plugin-helpers@5.0.4(graphql@16.8.2):
@@ -11204,7 +11232,7 @@ packages:
       graphql: 16.8.2
       import-from: 4.0.0
       lodash: 4.17.21
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-codegen/schema-ast@4.0.2(graphql@16.8.2):
@@ -11215,7 +11243,7 @@ packages:
       '@graphql-codegen/plugin-helpers': 5.0.4(graphql@16.8.2)
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-codegen/typed-document-node@5.0.6(graphql@16.8.2):
@@ -11228,7 +11256,7 @@ packages:
       auto-bind: 4.0.0
       change-case-all: 1.0.15
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11248,7 +11276,7 @@ packages:
       graphql: 16.8.2
       graphql-request: 6.1.0(graphql@16.8.2)
       graphql-tag: 2.12.6(graphql@16.8.2)
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11264,7 +11292,7 @@ packages:
       '@graphql-codegen/visitor-plugin-common': 5.1.0(graphql@16.8.2)
       auto-bind: 4.0.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11280,7 +11308,7 @@ packages:
       '@graphql-codegen/visitor-plugin-common': 5.1.0(graphql@16.8.2)
       auto-bind: 4.0.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11296,7 +11324,7 @@ packages:
       '@graphql-codegen/visitor-plugin-common': 5.3.1(graphql@16.8.2)
       auto-bind: 4.0.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11317,7 +11345,7 @@ packages:
       graphql: 16.8.2
       graphql-tag: 2.12.6(graphql@16.8.2)
       parse-filepath: 1.0.2
-      tslib: 2.2.0
+      tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11338,7 +11366,7 @@ packages:
       graphql: 16.8.2
       graphql-tag: 2.12.6(graphql@16.8.2)
       parse-filepath: 1.0.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11359,7 +11387,7 @@ packages:
       graphql: 16.8.2
       graphql-tag: 2.12.6(graphql@16.8.2)
       parse-filepath: 1.0.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11375,7 +11403,7 @@ packages:
       '@graphql-tools/utils': 10.1.3(graphql@16.8.2)
       '@whatwg-node/fetch': 0.9.17
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -11389,7 +11417,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       dataloader: 2.2.2
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11403,7 +11431,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       globby: 11.1.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       unixify: 1.0.0
     transitivePeerDependencies:
       - supports-color
@@ -11421,7 +11449,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       dataloader: 2.2.2
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/delegate@10.0.4(graphql@16.8.2):
@@ -11436,7 +11464,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       dataloader: 2.2.2
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/documents@1.0.0(graphql@16.8.2):
@@ -11447,7 +11475,7 @@ packages:
     dependencies:
       graphql: 16.8.2
       lodash.sortby: 4.7.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/executor-graphql-ws@1.1.2(graphql@16.8.2):
@@ -11461,7 +11489,7 @@ packages:
       graphql: 16.8.2
       graphql-ws: 5.16.0(graphql@16.8.2)
       isomorphic-ws: 5.0.0(ws@8.18.0)
-      tslib: 2.2.0
+      tslib: 2.8.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -11480,7 +11508,7 @@ packages:
       extract-files: 11.0.0
       graphql: 16.8.2
       meros: 1.3.0(@types/node@20.12.7)
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -11498,7 +11526,7 @@ packages:
       extract-files: 11.0.0
       graphql: 16.8.2
       meros: 1.3.0(@types/node@20.14.2)
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -11514,7 +11542,7 @@ packages:
       '@types/ws': 8.5.10
       graphql: 16.8.2
       isomorphic-ws: 5.0.0(ws@8.18.0)
-      tslib: 2.2.0
+      tslib: 2.8.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -11530,7 +11558,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.2)
       '@repeaterjs/repeater': 3.0.4
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11544,7 +11572,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.2)
       '@repeaterjs/repeater': 3.0.5
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11559,7 +11587,7 @@ packages:
       graphql: 16.8.2
       is-glob: 4.0.3
       micromatch: 4.0.7
-      tslib: 2.2.0
+      tslib: 2.8.1
       unixify: 1.0.0
     transitivePeerDependencies:
       - supports-color
@@ -11577,7 +11605,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       '@whatwg-node/fetch': 0.9.17
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -11597,7 +11625,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       '@whatwg-node/fetch': 0.9.17
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -11615,7 +11643,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       globby: 11.1.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       unixify: 1.0.0
     dev: true
 
@@ -11632,7 +11660,7 @@ packages:
       '@babel/types': 7.26.0
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11646,7 +11674,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
       resolve-from: 5.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/json-file-loader@8.0.1(graphql@16.8.2):
@@ -11658,7 +11686,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       globby: 11.1.0
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       unixify: 1.0.0
     dev: true
 
@@ -11672,7 +11700,7 @@ packages:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
       p-limit: 3.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/merge@8.4.2(graphql@16.8.2):
@@ -11682,7 +11710,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/merge@9.0.3(graphql@16.8.2):
@@ -11693,7 +11721,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/optimize@1.4.0(graphql@16.8.2):
@@ -11702,7 +11730,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/optimize@2.0.0(graphql@16.8.2):
@@ -11712,7 +11740,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/prisma-loader@8.0.3(@types/node@20.12.7)(graphql@16.8.2):
@@ -11738,7 +11766,7 @@ packages:
       json-stable-stringify: 1.1.1
       lodash: 4.17.21
       scuid: 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
       - '@types/node'
@@ -11771,7 +11799,7 @@ packages:
       json-stable-stringify: 1.1.1
       lodash: 4.17.21
       scuid: 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
       - '@types/node'
@@ -11789,7 +11817,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@16.8.2)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11804,7 +11832,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@16.8.2)
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11819,7 +11847,7 @@ packages:
       '@graphql-tools/merge': 9.0.3(graphql@16.8.2)
       '@graphql-tools/utils': 10.1.3(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11832,7 +11860,7 @@ packages:
       '@graphql-tools/merge': 9.0.3(graphql@16.8.2)
       '@graphql-tools/utils': 10.3.2(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11844,7 +11872,7 @@ packages:
       '@graphql-tools/merge': 8.4.2(graphql@16.8.2)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11865,7 +11893,7 @@ packages:
       '@whatwg-node/fetch': 0.9.17
       graphql: 16.8.2
       isomorphic-ws: 5.0.0(ws@8.18.0)
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
       ws: 8.18.0
     transitivePeerDependencies:
@@ -11892,7 +11920,7 @@ packages:
       '@whatwg-node/fetch': 0.9.17
       graphql: 16.8.2
       isomorphic-ws: 5.0.0(ws@8.18.0)
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
       ws: 8.18.0
     transitivePeerDependencies:
@@ -11912,7 +11940,7 @@ packages:
       cross-inspect: 1.0.0
       dset: 3.1.3
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/utils@10.3.2(graphql@16.8.2):
@@ -11925,7 +11953,7 @@ packages:
       cross-inspect: 1.0.0
       dset: 3.1.4
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/utils@8.13.1(graphql@16.8.2):
@@ -11934,7 +11962,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/utils@9.2.1(graphql@16.8.2):
@@ -11944,7 +11972,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.6.3
     dev: true
 
   /@graphql-tools/wrap@10.0.5(graphql@16.8.2):
@@ -11957,7 +11985,7 @@ packages:
       '@graphql-tools/schema': 10.0.3(graphql@16.8.2)
       '@graphql-tools/utils': 10.1.3(graphql@16.8.2)
       graphql: 16.8.2
-      tslib: 2.2.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
     dev: true
 
@@ -11987,7 +12015,7 @@ packages:
   /@graphql-yoga/logger@0.0.1:
     resolution: {integrity: sha512-6npFz7eZz33mXgSm1waBLMjUNG0D5hTc/p5Hcs1mojkT3KsLpCOFokzTEKboNsBhKevYcaVa/xeA7WBj4UYMLg==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-yoga/subscription@3.1.0:
@@ -11996,14 +12024,14 @@ packages:
       '@graphql-yoga/typed-event-target': 1.0.0
       '@repeaterjs/repeater': 3.0.5
       '@whatwg-node/events': 0.0.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@graphql-yoga/typed-event-target@1.0.0:
     resolution: {integrity: sha512-Mqni6AEvl3VbpMtKw+TIjc9qS9a8hKhiAjFtqX488yq5oJtj9TkNlFTIacAVS3vnPiswNsmDiQqvwUOcJgi1DA==}
     dependencies:
       '@repeaterjs/repeater': 3.0.5
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@hapi/hoek@9.3.0:
@@ -12720,7 +12748,7 @@ packages:
       '@lifi/sdk': 2.5.2
       '@safe-global/safe-apps-provider': 0.18.3(typescript@5.6.2)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.6.2)(zod@3.22.4)
-      '@walletconnect/ethereum-provider': 2.9.1(@walletconnect/modal@2.6.2)
+      '@walletconnect/ethereum-provider': 2.18.0(@types/react@18.3.1)(react@18.3.1)
       '@walletconnect/modal': 2.6.2(@types/react@18.3.1)(react@18.3.1)
       events: 3.3.0
       react: 18.3.1
@@ -12880,7 +12908,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       ethereumjs-abi: 0.6.8
-      ethereumjs-util: 7.1.5
+      ethereumjs-util: 6.2.1
       ethjs-util: 0.1.6
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
@@ -12891,7 +12919,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@ethereumjs/util': 8.1.0
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       ethereum-cryptography: 2.2.0
       ethjs-util: 0.1.6
       tweetnacl: 1.0.3
@@ -13322,7 +13350,7 @@ packages:
       '@motionone/easing': 10.17.0
       '@motionone/types': 10.17.0
       '@motionone/utils': 10.17.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@motionone/dom@10.17.0:
@@ -13333,14 +13361,14 @@ packages:
       '@motionone/types': 10.17.0
       '@motionone/utils': 10.17.0
       hey-listen: 1.0.8
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@motionone/easing@10.17.0:
     resolution: {integrity: sha512-Bxe2wSuLu/qxqW4rBFS5m9tMLOw+QBh8v5A7Z5k4Ul4sTj5jAOfZG5R0bn5ywmk+Fs92Ij1feZ5pmC4TeXA8Tg==}
     dependencies:
       '@motionone/utils': 10.17.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@motionone/generators@10.17.0:
@@ -13348,14 +13376,14 @@ packages:
     dependencies:
       '@motionone/types': 10.17.0
       '@motionone/utils': 10.17.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@motionone/svelte@10.16.4:
     resolution: {integrity: sha512-zRVqk20lD1xqe+yEDZhMYgftsuHc25+9JSo+r0a0OWUJFocjSV9D/+UGhX4xgJsuwB9acPzXLr20w40VnY2PQA==}
     dependencies:
       '@motionone/dom': 10.17.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@motionone/types@10.17.0:
@@ -13367,7 +13395,7 @@ packages:
     dependencies:
       '@motionone/types': 10.17.0
       hey-listen: 1.0.8
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@motionone/vue@10.16.4:
@@ -13375,7 +13403,7 @@ packages:
     deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
     dependencies:
       '@motionone/dom': 10.17.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@mui/base@5.0.0-beta.40(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1):
@@ -13426,7 +13454,7 @@ packages:
     resolution: {integrity: sha512-0bDVECGmrNjd3+bLdcLiwYZ0O4HP5j5WSQm5DV6iA/Z9kr8O6AnvZ1bv9ImQbbX7Gj3pX4o43EKwCutj3EQxQg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@emotion/react': 11.11.1
+      '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
       '@mui/material': '>=5.15.0'
       '@types/react': ^17.0.0 || ^18.0.0
@@ -13459,7 +13487,7 @@ packages:
     resolution: {integrity: sha512-tVq3l4qoXx/NxUgIx/x3lZiPn/5xDbdTE8VrLczNpfblLYZzlrbxA7kb9mI8NoBF6+w9WE9IrxWnKK5KlPI2bg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@emotion/react': 11.11.1
+      '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
@@ -13512,7 +13540,7 @@ packages:
     resolution: {integrity: sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@emotion/react': 11.11.1
+      '@emotion/react': ^11.4.1
       '@emotion/styled': ^11.3.0
       react: ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
@@ -13534,7 +13562,7 @@ packages:
     resolution: {integrity: sha512-LoMq4IlAAhxzL2VNUDBTQxAb4chnBe8JvRINVNDiMtHE2PiPOoHlhOPutSxEbaL5mkECPVWSv6p8JEV+uykwIA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@emotion/react': 11.11.1
+      '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
@@ -13694,6 +13722,11 @@ packages:
     resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
     dev: false
 
+  /@noble/ciphers@1.2.1:
+    resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}
+    engines: {node: ^14.21.3 || >=16}
+    dev: false
+
   /@noble/curves@1.2.0:
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
     dependencies:
@@ -13715,6 +13748,20 @@ packages:
     engines: {node: ^14.21.3 || >=16}
     dependencies:
       '@noble/hashes': 1.6.0
+    dev: false
+
+  /@noble/curves@1.8.0:
+    resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
+    engines: {node: ^14.21.3 || >=16}
+    dependencies:
+      '@noble/hashes': 1.7.0
+    dev: false
+
+  /@noble/curves@1.8.1:
+    resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
+    engines: {node: ^14.21.3 || >=16}
+    dependencies:
+      '@noble/hashes': 1.7.1
     dev: false
 
   /@noble/hashes@1.2.0:
@@ -13741,6 +13788,16 @@ packages:
   /@noble/hashes@1.6.1:
     resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
     engines: {node: ^14.21.3 || >=16}
+
+  /@noble/hashes@1.7.0:
+    resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
+    engines: {node: ^14.21.3 || >=16}
+    dev: false
+
+  /@noble/hashes@1.7.1:
+    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
+    dev: false
 
   /@noble/secp256k1@1.7.1:
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -14253,14 +14310,14 @@ packages:
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.5
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@peculiar/json-schema@1.1.12:
     resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@peculiar/webcrypto@1.4.6:
@@ -14270,7 +14327,7 @@ packages:
       '@peculiar/asn1-schema': 2.3.8
       '@peculiar/json-schema': 1.1.12
       pvtsutils: 1.3.5
-      tslib: 2.2.0
+      tslib: 2.8.1
       webcrypto-core: 1.7.9
     dev: true
 
@@ -15065,7 +15122,7 @@ packages:
       '@rnx-kit/chromium-edge-launcher': 1.0.0
       chrome-launcher: 0.15.2
       connect: 3.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       node-fetch: 2.7.0
       nullthrows: 1.1.1
       open: 7.4.2
@@ -15089,7 +15146,7 @@ packages:
       '@rnx-kit/chromium-edge-launcher': 1.0.0
       chrome-launcher: 0.15.2
       connect: 3.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       node-fetch: 2.7.0
       nullthrows: 1.1.1
       open: 7.4.2
@@ -15113,7 +15170,7 @@ packages:
       '@rnx-kit/chromium-edge-launcher': 1.0.0
       chrome-launcher: 0.15.2
       connect: 3.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       node-fetch: 2.7.0
       nullthrows: 1.1.1
       open: 7.4.2
@@ -15736,13 +15793,13 @@ packages:
       '@lukeed/uuid': 2.0.1
       '@segment/analytics-generic-utils': 1.2.0
       dset: 3.1.4
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@segment/analytics-generic-utils@1.2.0:
     resolution: {integrity: sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@segment/analytics-next@1.75.0:
@@ -15756,7 +15813,7 @@ packages:
       dset: 3.1.4
       js-cookie: 3.0.1
       node-fetch: 2.7.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       unfetch: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -15802,7 +15859,7 @@ packages:
       '@sentry/minimal': 5.30.0
       '@sentry/types': 5.30.0
       '@sentry/utils': 5.30.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@sentry/hub@5.30.0:
@@ -15811,7 +15868,7 @@ packages:
     dependencies:
       '@sentry/types': 5.30.0
       '@sentry/utils': 5.30.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@sentry/minimal@5.30.0:
@@ -15820,7 +15877,7 @@ packages:
     dependencies:
       '@sentry/hub': 5.30.0
       '@sentry/types': 5.30.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@sentry/node@5.30.0:
@@ -15835,7 +15892,7 @@ packages:
       cookie: 0.4.2
       https-proxy-agent: 5.0.1
       lru_map: 0.3.3
-      tslib: 2.2.0
+      tslib: 1.14.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15848,7 +15905,7 @@ packages:
       '@sentry/minimal': 5.30.0
       '@sentry/types': 5.30.0
       '@sentry/utils': 5.30.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@sentry/types@5.30.0:
@@ -15861,7 +15918,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       '@sentry/types': 5.30.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: true
 
   /@sideway/address@4.1.5:
@@ -15900,7 +15957,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 1.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/abort-controller@2.2.0:
@@ -15908,7 +15965,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/abort-controller@4.0.1:
@@ -15916,7 +15973,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/chunked-blob-reader-native@4.0.0:
@@ -15924,14 +15981,14 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/util-base64': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/chunked-blob-reader@5.0.0:
     resolution: {integrity: sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/config-resolver@1.1.0:
@@ -15941,7 +15998,7 @@ packages:
       '@smithy/types': 1.2.0
       '@smithy/util-config-provider': 1.1.0
       '@smithy/util-middleware': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/config-resolver@2.2.0:
@@ -15952,7 +16009,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-config-provider': 2.3.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/config-resolver@4.0.1:
@@ -15963,7 +16020,7 @@ packages:
       '@smithy/types': 4.1.0
       '@smithy/util-config-provider': 4.0.0
       '@smithy/util-middleware': 4.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/core@1.4.2:
@@ -15977,7 +16034,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/core@3.1.1:
@@ -15991,7 +16048,7 @@ packages:
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-stream': 4.0.2
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/credential-provider-imds@2.3.0:
@@ -16002,7 +16059,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
       '@smithy/url-parser': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/credential-provider-imds@4.0.1:
@@ -16013,7 +16070,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/types': 4.1.0
       '@smithy/url-parser': 4.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-codec@2.2.0:
@@ -16022,7 +16079,7 @@ packages:
       '@aws-crypto/crc32': 3.0.0
       '@smithy/types': 2.12.0
       '@smithy/util-hex-encoding': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-codec@4.0.1:
@@ -16032,7 +16089,7 @@ packages:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.1.0
       '@smithy/util-hex-encoding': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-browser@2.2.0:
@@ -16041,7 +16098,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-browser@4.0.1:
@@ -16050,7 +16107,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-config-resolver@2.2.0:
@@ -16058,7 +16115,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-config-resolver@4.0.1:
@@ -16066,7 +16123,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-node@2.2.0:
@@ -16075,7 +16132,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-node@4.0.1:
@@ -16084,7 +16141,7 @@ packages:
     dependencies:
       '@smithy/eventstream-serde-universal': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-universal@2.2.0:
@@ -16093,7 +16150,7 @@ packages:
     dependencies:
       '@smithy/eventstream-codec': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/eventstream-serde-universal@4.0.1:
@@ -16102,7 +16159,7 @@ packages:
     dependencies:
       '@smithy/eventstream-codec': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/fetch-http-handler@1.1.0:
@@ -16112,7 +16169,7 @@ packages:
       '@smithy/querystring-builder': 1.1.0
       '@smithy/types': 1.2.0
       '@smithy/util-base64': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/fetch-http-handler@2.5.0:
@@ -16122,7 +16179,7 @@ packages:
       '@smithy/querystring-builder': 2.2.0
       '@smithy/types': 2.12.0
       '@smithy/util-base64': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/fetch-http-handler@5.0.1:
@@ -16133,7 +16190,7 @@ packages:
       '@smithy/querystring-builder': 4.0.1
       '@smithy/types': 4.1.0
       '@smithy/util-base64': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/hash-blob-browser@4.0.1:
@@ -16143,7 +16200,7 @@ packages:
       '@smithy/chunked-blob-reader': 5.0.0
       '@smithy/chunked-blob-reader-native': 4.0.0
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/hash-node@2.2.0:
@@ -16153,7 +16210,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/hash-node@4.0.1:
@@ -16163,7 +16220,7 @@ packages:
       '@smithy/types': 4.1.0
       '@smithy/util-buffer-from': 4.0.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/hash-stream-node@4.0.1:
@@ -16172,14 +16229,14 @@ packages:
     dependencies:
       '@smithy/types': 4.1.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/invalid-dependency@2.2.0:
     resolution: {integrity: sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/invalid-dependency@4.0.1:
@@ -16187,28 +16244,28 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/is-array-buffer@1.1.0:
     resolution: {integrity: sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/is-array-buffer@2.2.0:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/is-array-buffer@4.0.0:
     resolution: {integrity: sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/md5-js@4.0.1:
@@ -16217,7 +16274,7 @@ packages:
     dependencies:
       '@smithy/types': 4.1.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-content-length@2.2.0:
@@ -16226,7 +16283,7 @@ packages:
     dependencies:
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-content-length@4.0.1:
@@ -16235,7 +16292,7 @@ packages:
     dependencies:
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-endpoint@2.5.1:
@@ -16248,7 +16305,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/url-parser': 2.2.0
       '@smithy/util-middleware': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-endpoint@4.0.2:
@@ -16262,7 +16319,7 @@ packages:
       '@smithy/types': 4.1.0
       '@smithy/url-parser': 4.0.1
       '@smithy/util-middleware': 4.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-retry@1.1.0:
@@ -16274,7 +16331,7 @@ packages:
       '@smithy/types': 1.2.0
       '@smithy/util-middleware': 1.1.0
       '@smithy/util-retry': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 8.3.2
     dev: true
 
@@ -16289,7 +16346,7 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 9.0.1
     dev: true
 
@@ -16304,7 +16361,7 @@ packages:
       '@smithy/types': 4.1.0
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-retry': 4.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
       uuid: 9.0.1
     dev: true
 
@@ -16313,7 +16370,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-serde@4.0.1:
@@ -16321,14 +16378,14 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-stack@1.1.0:
     resolution: {integrity: sha512-XynYiIvXNea2BbLcppvpNK0zu8o2woJqgnmxqYTn4FWagH/Hr2QIk8LOsUz7BIJ4tooFhmx8urHKCdlPbbPDCA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-stack@2.2.0:
@@ -16336,7 +16393,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/middleware-stack@4.0.1:
@@ -16344,7 +16401,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/node-config-provider@2.3.0:
@@ -16354,7 +16411,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/node-config-provider@4.0.1:
@@ -16364,7 +16421,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/shared-ini-file-loader': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/node-http-handler@1.1.0:
@@ -16375,7 +16432,7 @@ packages:
       '@smithy/protocol-http': 1.2.0
       '@smithy/querystring-builder': 1.1.0
       '@smithy/types': 1.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/node-http-handler@2.5.0:
@@ -16386,7 +16443,7 @@ packages:
       '@smithy/protocol-http': 3.3.0
       '@smithy/querystring-builder': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/node-http-handler@4.0.2:
@@ -16397,7 +16454,7 @@ packages:
       '@smithy/protocol-http': 5.0.1
       '@smithy/querystring-builder': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/property-provider@2.2.0:
@@ -16405,7 +16462,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/property-provider@4.0.1:
@@ -16413,7 +16470,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/protocol-http@1.2.0:
@@ -16421,7 +16478,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 1.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/protocol-http@3.3.0:
@@ -16429,7 +16486,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/protocol-http@5.0.1:
@@ -16437,7 +16494,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/querystring-builder@1.1.0:
@@ -16446,7 +16503,7 @@ packages:
     dependencies:
       '@smithy/types': 1.2.0
       '@smithy/util-uri-escape': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/querystring-builder@2.2.0:
@@ -16455,7 +16512,7 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       '@smithy/util-uri-escape': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/querystring-builder@4.0.1:
@@ -16464,7 +16521,7 @@ packages:
     dependencies:
       '@smithy/types': 4.1.0
       '@smithy/util-uri-escape': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/querystring-parser@2.2.0:
@@ -16472,7 +16529,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/querystring-parser@4.0.1:
@@ -16480,7 +16537,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/service-error-classification@1.1.0:
@@ -16506,7 +16563,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/shared-ini-file-loader@4.0.1:
@@ -16514,7 +16571,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/signature-v4@2.3.0:
@@ -16527,7 +16584,7 @@ packages:
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-uri-escape': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/signature-v4@5.0.1:
@@ -16541,7 +16598,7 @@ packages:
       '@smithy/util-middleware': 4.0.1
       '@smithy/util-uri-escape': 4.0.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/smithy-client@1.1.0:
@@ -16551,7 +16608,7 @@ packages:
       '@smithy/middleware-stack': 1.1.0
       '@smithy/types': 1.2.0
       '@smithy/util-stream': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/smithy-client@2.5.1:
@@ -16563,7 +16620,7 @@ packages:
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
       '@smithy/util-stream': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/smithy-client@4.1.2:
@@ -16576,34 +16633,34 @@ packages:
       '@smithy/protocol-http': 5.0.1
       '@smithy/types': 4.1.0
       '@smithy/util-stream': 4.0.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/types@1.2.0:
     resolution: {integrity: sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/types@2.12.0:
     resolution: {integrity: sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
 
   /@smithy/types@4.1.0:
     resolution: {integrity: sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
 
   /@smithy/url-parser@2.2.0:
     resolution: {integrity: sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==}
     dependencies:
       '@smithy/querystring-parser': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/url-parser@4.0.1:
@@ -16612,7 +16669,7 @@ packages:
     dependencies:
       '@smithy/querystring-parser': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-base64@1.1.0:
@@ -16620,7 +16677,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-base64@2.3.0:
@@ -16629,7 +16686,7 @@ packages:
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-base64@4.0.0:
@@ -16638,34 +16695,34 @@ packages:
     dependencies:
       '@smithy/util-buffer-from': 4.0.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-body-length-browser@2.2.0:
     resolution: {integrity: sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-body-length-browser@4.0.0:
     resolution: {integrity: sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-body-length-node@2.3.0:
     resolution: {integrity: sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-body-length-node@4.0.0:
     resolution: {integrity: sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-buffer-from@1.1.0:
@@ -16673,7 +16730,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/is-array-buffer': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-buffer-from@2.2.0:
@@ -16681,7 +16738,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-buffer-from@4.0.0:
@@ -16689,28 +16746,28 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/is-array-buffer': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-config-provider@1.1.0:
     resolution: {integrity: sha512-rQ47YpNmF6Is4I9GiE3T3+0xQ+r7RKRKbmHYyGSbyep/0cSf9kteKcI0ssJTvveJ1K4QvwrxXj1tEFp/G2UqxQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-config-provider@2.3.0:
     resolution: {integrity: sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-config-provider@4.0.0:
     resolution: {integrity: sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-defaults-mode-browser@2.2.1:
@@ -16721,7 +16778,7 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       bowser: 2.11.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-defaults-mode-browser@4.0.3:
@@ -16732,7 +16789,7 @@ packages:
       '@smithy/smithy-client': 4.1.2
       '@smithy/types': 4.1.0
       bowser: 2.11.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-defaults-mode-node@2.3.1:
@@ -16745,7 +16802,7 @@ packages:
       '@smithy/property-provider': 2.2.0
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-defaults-mode-node@4.0.3:
@@ -16758,7 +16815,7 @@ packages:
       '@smithy/property-provider': 4.0.1
       '@smithy/smithy-client': 4.1.2
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-endpoints@1.2.0:
@@ -16767,7 +16824,7 @@ packages:
     dependencies:
       '@smithy/node-config-provider': 2.3.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-endpoints@3.0.1:
@@ -16776,35 +16833,35 @@ packages:
     dependencies:
       '@smithy/node-config-provider': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-hex-encoding@1.1.0:
     resolution: {integrity: sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-hex-encoding@2.2.0:
     resolution: {integrity: sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-hex-encoding@4.0.0:
     resolution: {integrity: sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-middleware@1.1.0:
     resolution: {integrity: sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-middleware@2.2.0:
@@ -16812,7 +16869,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-middleware@4.0.1:
@@ -16820,7 +16877,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-retry@1.1.0:
@@ -16828,7 +16885,7 @@ packages:
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@smithy/service-error-classification': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-retry@2.2.0:
@@ -16837,7 +16894,7 @@ packages:
     dependencies:
       '@smithy/service-error-classification': 2.1.5
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-retry@4.0.1:
@@ -16846,7 +16903,7 @@ packages:
     dependencies:
       '@smithy/service-error-classification': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-stream@1.1.0:
@@ -16860,7 +16917,7 @@ packages:
       '@smithy/util-buffer-from': 1.1.0
       '@smithy/util-hex-encoding': 1.1.0
       '@smithy/util-utf8': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-stream@2.2.0:
@@ -16874,7 +16931,7 @@ packages:
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-hex-encoding': 2.2.0
       '@smithy/util-utf8': 2.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-stream@4.0.2:
@@ -16888,28 +16945,28 @@ packages:
       '@smithy/util-buffer-from': 4.0.0
       '@smithy/util-hex-encoding': 4.0.0
       '@smithy/util-utf8': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-uri-escape@1.1.0:
     resolution: {integrity: sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-uri-escape@2.2.0:
     resolution: {integrity: sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-uri-escape@4.0.0:
     resolution: {integrity: sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-utf8@1.1.0:
@@ -16917,7 +16974,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 1.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-utf8@2.3.0:
@@ -16925,7 +16982,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-utf8@4.0.0:
@@ -16933,7 +16990,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/util-buffer-from': 4.0.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-waiter@2.2.0:
@@ -16942,7 +16999,7 @@ packages:
     dependencies:
       '@smithy/abort-controller': 2.2.0
       '@smithy/types': 2.12.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@smithy/util-waiter@4.0.2:
@@ -16951,7 +17008,7 @@ packages:
     dependencies:
       '@smithy/abort-controller': 4.0.1
       '@smithy/types': 4.1.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@socket.io/component-emitter@3.1.2:
@@ -17381,7 +17438,7 @@ packages:
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
     dependencies:
       '@swc/counter': 0.1.3
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@swc/types@0.1.12:
@@ -17751,17 +17808,17 @@ packages:
     dependencies:
       events: 3.3.0
       pako: 2.1.0
-      query-string: 7.1.3
+      query-string: 8.2.0
     dev: false
 
-  /@trezor/analytics@1.0.16(expo@51.0.14)(tslib@2.2.0):
+  /@trezor/analytics@1.0.16(expo@51.0.14)(tslib@2.8.1):
     resolution: {integrity: sha512-LT6hRf33EqaCyBMdjMXzclcKNuT4+IL97FQyHdnqug4wpYABQn31Djh2oCE97j2vjLcywKRoLXTezrAwrG1wHQ==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/env-utils': 1.0.15(expo@51.0.14)(tslib@2.2.0)
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
-      tslib: 2.2.0
+      '@trezor/env-utils': 1.0.15(expo@51.0.14)(tslib@2.8.1)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
+      tslib: 2.8.1
     transitivePeerDependencies:
       - expo
       - expo-localization
@@ -17769,16 +17826,16 @@ packages:
       - supports-color
     dev: false
 
-  /@trezor/blockchain-link-types@1.0.15(tslib@2.2.0):
+  /@trezor/blockchain-link-types@1.0.15(tslib@2.8.1):
     resolution: {integrity: sha512-zNHNKySOFKbk210dWDT5riNazpu36wOybryUzuOz6owk0irlBcGoB0Q3uxqfCaHjFakRKenQVpG+jVeL8zfCwg==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
       '@solana/web3.js': 1.91.8
       '@trezor/type-utils': 1.0.5
-      '@trezor/utxo-lib': 2.0.8(tslib@2.2.0)
+      '@trezor/utxo-lib': 2.0.8(tslib@2.8.1)
       socks-proxy-agent: 6.1.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -17786,39 +17843,39 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@trezor/blockchain-link-utils@1.0.16(tslib@2.2.0):
+  /@trezor/blockchain-link-utils@1.0.16(tslib@2.8.1):
     resolution: {integrity: sha512-ZxqcKDEE9RxS9dK5iS2A4nJWuERXLnRMu9+L6ahQZO82bUngVcWH9gZKS+wFWenZP2AA7EXAlO9Rg7nlOkEfKA==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
       '@mobily/ts-belt': 3.13.1
       '@solana/web3.js': 1.91.8
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
       bignumber.js: 9.1.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
     dev: false
 
-  /@trezor/blockchain-link@2.1.28(tslib@2.2.0):
+  /@trezor/blockchain-link@2.1.28(tslib@2.8.1):
     resolution: {integrity: sha512-7iH7kFsAwxMjulPCFf6d6YBTuS1HhPCpNJoLmF0w1agNZf3EvuBlbeizfpzGshSvzEhLSHbBPR5ZtUQdUfJhDQ==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.91.8
-      '@trezor/blockchain-link-types': 1.0.15(tslib@2.2.0)
-      '@trezor/blockchain-link-utils': 1.0.16(tslib@2.2.0)
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
-      '@trezor/utxo-lib': 2.0.8(tslib@2.2.0)
+      '@trezor/blockchain-link-types': 1.0.15(tslib@2.8.1)
+      '@trezor/blockchain-link-utils': 1.0.16(tslib@2.8.1)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
+      '@trezor/utxo-lib': 2.0.8(tslib@2.8.1)
       '@types/web': 0.0.138
       bignumber.js: 9.1.2
       events: 3.3.0
       ripple-lib: 1.10.1
       socks-proxy-agent: 6.1.1
-      tslib: 2.2.0
+      tslib: 2.8.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -17827,13 +17884,13 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@trezor/connect-analytics@1.0.14(expo@51.0.14)(tslib@2.2.0):
+  /@trezor/connect-analytics@1.0.14(expo@51.0.14)(tslib@2.8.1):
     resolution: {integrity: sha512-IAXeOptCg6klHFKYnTmFHLFcPBf7CguWTglmJTGkxWGGcirc8jQY0pu7bFow0J2qL5ClcUIiQd29ExzjiHBwmQ==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/analytics': 1.0.16(expo@51.0.14)(tslib@2.2.0)
-      tslib: 2.2.0
+      '@trezor/analytics': 1.0.16(expo@51.0.14)(tslib@2.8.1)
+      tslib: 2.8.1
     transitivePeerDependencies:
       - expo
       - expo-localization
@@ -17841,14 +17898,14 @@ packages:
       - supports-color
     dev: false
 
-  /@trezor/connect-common@0.0.31(expo@51.0.14)(tslib@2.2.0):
+  /@trezor/connect-common@0.0.31(expo@51.0.14)(tslib@2.8.1):
     resolution: {integrity: sha512-HLK7Zb2/LMWda+ju6TR9+bihDZ45XCsmdYt5SjvSEt1e/EMUvsk5F5rLk8UD0hHyK3ooUDpVzYU28J1pabj0CQ==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/env-utils': 1.0.15(expo@51.0.14)(tslib@2.2.0)
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
-      tslib: 2.2.0
+      '@trezor/env-utils': 1.0.15(expo@51.0.14)(tslib@2.8.1)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
+      tslib: 2.8.1
     transitivePeerDependencies:
       - expo
       - expo-localization
@@ -17856,16 +17913,16 @@ packages:
       - supports-color
     dev: false
 
-  /@trezor/connect-web@9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.2.0):
+  /@trezor/connect-web@9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.8.1):
     resolution: {integrity: sha512-THYlFAt5R3o4rg52dMOrSmfuWzFIxFUu6Oeqj0f9vALzUU4Wzm2nMDIG0Y3MyB5mVzFg70lwmx73tuznx/rfUw==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/connect': 9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.2.0)
-      '@trezor/connect-common': 0.0.31(expo@51.0.14)(tslib@2.2.0)
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
+      '@trezor/connect': 9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.8.1)
+      '@trezor/connect-common': 0.0.31(expo@51.0.14)(tslib@2.8.1)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
       events: 3.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -17877,32 +17934,32 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@trezor/connect@9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.2.0):
+  /@trezor/connect@9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.8.1):
     resolution: {integrity: sha512-JopCr62XISy5KEqcn3MXxUtSrxVTexqloA99+OZ3Tbomuc89yIV88aQi/r3RJ4j1droq3kDoxaMfH1ssBmz2kA==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
       '@babel/preset-typescript': 7.24.7(@babel/core@7.26.0)
       '@ethereumjs/common': 4.3.0
       '@ethereumjs/tx': 5.3.0
       '@fivebinaries/coin-selection': 2.2.1
-      '@trezor/blockchain-link': 2.1.28(tslib@2.2.0)
-      '@trezor/blockchain-link-types': 1.0.15(tslib@2.2.0)
-      '@trezor/connect-analytics': 1.0.14(expo@51.0.14)(tslib@2.2.0)
-      '@trezor/connect-common': 0.0.31(expo@51.0.14)(tslib@2.2.0)
-      '@trezor/protobuf': 1.0.11(tslib@2.2.0)
-      '@trezor/protocol': 1.0.7(tslib@2.2.0)
-      '@trezor/schema-utils': 1.0.3(tslib@2.2.0)
-      '@trezor/transport': 1.1.27(tslib@2.2.0)
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
-      '@trezor/utxo-lib': 2.0.8(tslib@2.2.0)
+      '@trezor/blockchain-link': 2.1.28(tslib@2.8.1)
+      '@trezor/blockchain-link-types': 1.0.15(tslib@2.8.1)
+      '@trezor/connect-analytics': 1.0.14(expo@51.0.14)(tslib@2.8.1)
+      '@trezor/connect-common': 0.0.31(expo@51.0.14)(tslib@2.8.1)
+      '@trezor/protobuf': 1.0.11(tslib@2.8.1)
+      '@trezor/protocol': 1.0.7(tslib@2.8.1)
+      '@trezor/schema-utils': 1.0.3(tslib@2.8.1)
+      '@trezor/transport': 1.1.27(tslib@2.8.1)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
+      '@trezor/utxo-lib': 2.0.8(tslib@2.8.1)
       bignumber.js: 9.1.2
       blakejs: 1.2.1
       bs58: 5.0.0
       bs58check: 3.0.1
       cross-fetch: 4.0.0
       events: 3.3.0
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -17914,12 +17971,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@trezor/env-utils@1.0.15(expo@51.0.14)(tslib@2.2.0):
+  /@trezor/env-utils@1.0.15(expo@51.0.14)(tslib@2.8.1):
     resolution: {integrity: sha512-icD7KC908kfpNAsHBJ3voRkAzqYTblas26Pfu0YYHfhjBadypcRdRo+aIUXLItmjjNqsLFGVB/cWBk4Lwgh7hQ==}
     peerDependencies:
       expo-localization: '*'
       react-native: '*'
-      tslib: 2.2.0
+      tslib: ^2.6.2
     peerDependenciesMeta:
       expo-localization:
         optional: true
@@ -17927,54 +17984,54 @@ packages:
         optional: true
     dependencies:
       expo-constants: 15.4.5(expo@51.0.14)
-      tslib: 2.2.0
+      tslib: 2.8.1
       ua-parser-js: 1.0.37
     transitivePeerDependencies:
       - expo
       - supports-color
     dev: false
 
-  /@trezor/protobuf@1.0.11(tslib@2.2.0):
+  /@trezor/protobuf@1.0.11(tslib@2.8.1):
     resolution: {integrity: sha512-oEgblHJzlb1IrtOk/fl0uLVmnhcMTq+i1Z4aw04OOj9wcrvAyYAFuYgoJJ/30PfzWoq6f1/xwt6pPtoxoN42cg==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/schema-utils': 1.0.3(tslib@2.2.0)
+      '@trezor/schema-utils': 1.0.3(tslib@2.8.1)
       long: 4.0.0
       protobufjs: 7.2.6
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
-  /@trezor/protocol@1.0.7(tslib@2.2.0):
+  /@trezor/protocol@1.0.7(tslib@2.8.1):
     resolution: {integrity: sha512-IYpmureV9cqle7HxSuGkYh4GT5SY1CVbad7zYJn3MgFk1jQpdENQQSK5KpdD2xHoKnoRqyz4TSOHQzhjgqIDLA==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
-  /@trezor/schema-utils@1.0.3(tslib@2.2.0):
+  /@trezor/schema-utils@1.0.3(tslib@2.8.1):
     resolution: {integrity: sha512-P+w0QgsCuzfWYjXmjSMoeYsC0C62aKl9JIsDTIx3WP4nwffzFE2RKEW16rqGx0NGEwcMsckaGi2O9Ngi8dZ1IA==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
       '@sinclair/typebox': 0.31.28
       ts-mixer: 6.0.4
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
-  /@trezor/transport@1.1.27(tslib@2.2.0):
+  /@trezor/transport@1.1.27(tslib@2.8.1):
     resolution: {integrity: sha512-cWMkQ15yG8wJKNnUPY8RVZ5DjA8l+aEZBd7CsI/guBfPNAxZGDkHHiO+WzQzqz9GspbpO9TkFS5+rheY8j9XlQ==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/protobuf': 1.0.11(tslib@2.2.0)
-      '@trezor/protocol': 1.0.7(tslib@2.2.0)
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
+      '@trezor/protobuf': 1.0.11(tslib@2.8.1)
+      '@trezor/protocol': 1.0.7(tslib@2.8.1)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
       json-stable-stringify: 1.1.1
       long: 4.0.0
       protobufjs: 7.2.6
-      tslib: 2.2.0
+      tslib: 2.8.1
       usb: 2.12.1
     dev: false
 
@@ -17982,20 +18039,20 @@ packages:
     resolution: {integrity: sha512-AK8Gg5yoPAMvxqK49LXr8yoop1oxIXRxkOhCuWGV51fDM02/L1dhGNKC04UyCTyG7jZ+H1f5ywuna81BVT/ptQ==}
     dev: false
 
-  /@trezor/utils@9.0.23(tslib@2.2.0):
+  /@trezor/utils@9.0.23(tslib@2.8.1):
     resolution: {integrity: sha512-lxdGo6j2gzSy5PFSyjxEg/1p3cRGLPyhfC+53OGi002PE7q4uUzU8yUFqJxC7zEXmfeY3HkkJEqqois3rWE66w==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
-  /@trezor/utxo-lib@2.0.8(tslib@2.2.0):
+  /@trezor/utxo-lib@2.0.8(tslib@2.8.1):
     resolution: {integrity: sha512-TLBaPdRpFftvVzrhp0A5slnGhoJ8MU98cQCgpY/C/jfcWo8TBnau+jTB21uWFhGO8U0JRQsjUL7uYUdCiE2NZQ==}
     peerDependencies:
-      tslib: 2.2.0
+      tslib: ^2.6.2
     dependencies:
-      '@trezor/utils': 9.0.23(tslib@2.2.0)
+      '@trezor/utils': 9.0.23(tslib@2.8.1)
       bchaddrjs: 0.5.2
       bech32: 2.0.0
       bip66: 1.1.5
@@ -18010,7 +18067,7 @@ packages:
       int64-buffer: 1.0.1
       pushdata-bitcoin: 1.0.1
       tiny-secp256k1: 1.1.6
-      tslib: 2.2.0
+      tslib: 2.8.1
       typeforce: 1.18.0
       varuint-bitcoin: 1.1.2
       wif: 4.0.0
@@ -18282,6 +18339,12 @@ packages:
     resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
     dependencies:
       '@babel/types': 7.25.8
+
+  /@types/bn.js@4.11.6:
+    resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
+    dependencies:
+      '@types/node': 20.14.2
+    dev: true
 
   /@types/bn.js@5.1.1:
     resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
@@ -19207,7 +19270,7 @@ packages:
       '@coinbase/wallet-sdk': 3.9.3
       '@safe-global/safe-apps-provider': 0.18.3(typescript@5.6.2)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.6.2)(zod@3.22.4)
-      '@walletconnect/ethereum-provider': 2.9.1(@walletconnect/modal@2.6.2)
+      '@walletconnect/ethereum-provider': 2.11.0(@types/react@18.3.1)(react@18.3.1)
       '@walletconnect/legacy-provider': 2.0.0
       '@walletconnect/modal': 2.6.2(@types/react@18.3.1)(react@18.3.1)
       '@walletconnect/utils': 2.11.0
@@ -19254,7 +19317,7 @@ packages:
       '@safe-global/safe-apps-provider': 0.18.1(typescript@5.6.2)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.6.2)(zod@3.22.4)
       '@wagmi/core': 2.11.6(@types/react@18.3.1)(immer@9.0.21)(react@18.3.1)(typescript@5.6.2)(viem@2.20.0)(zod@3.22.4)
-      '@walletconnect/ethereum-provider': 2.9.1(@walletconnect/modal@2.6.2)
+      '@walletconnect/ethereum-provider': 2.13.0(@types/react@18.3.1)(react@18.3.1)
       '@walletconnect/modal': 2.6.2(@types/react@18.3.1)(react@18.3.1)
       cbw-sdk: /@coinbase/wallet-sdk@3.9.3
       typescript: 5.6.2
@@ -19301,7 +19364,7 @@ packages:
       '@safe-global/safe-apps-provider': 0.18.3(typescript@5.6.2)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 9.1.0(typescript@5.6.2)(zod@3.22.4)
       '@wagmi/core': 2.13.8(@types/react@18.3.1)(immer@9.0.21)(react@18.3.1)(typescript@5.6.2)(viem@2.20.0)
-      '@walletconnect/ethereum-provider': 2.9.1(@walletconnect/modal@2.7.0)
+      '@walletconnect/ethereum-provider': 2.17.0(@types/react@18.3.1)(react@18.3.1)
       '@walletconnect/modal': 2.7.0(@types/react@18.3.1)(react@18.3.1)
       cbw-sdk: /@coinbase/wallet-sdk@3.9.3
       typescript: 5.6.2
@@ -19456,6 +19519,165 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@walletconnect/core@2.11.0:
+    resolution: {integrity: sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.14
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.10
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.11.0
+      '@walletconnect/utils': 2.11.0
+      events: 3.3.0
+      isomorphic-unfetch: 3.1.0
+      lodash.isequal: 4.5.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/core@2.13.0:
+    resolution: {integrity: sha512-blDuZxQenjeXcVJvHxPznTNl6c/2DO4VNrFnus+qHmO6OtT5lZRowdMtlCaCNb1q0OxzgrmBDcTOCbFcCpio/g==}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.14
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.10
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.13.0
+      '@walletconnect/utils': 2.13.0
+      events: 3.3.0
+      isomorphic-unfetch: 3.1.0
+      lodash.isequal: 4.5.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/core@2.17.0:
+    resolution: {integrity: sha512-On+uSaCfWdsMIQsECwWHZBmUXfrnqmv6B8SXRRuTJgd8tUpEvBkLQH4X7XkSm3zW6ozEkQTCagZ2ox2YPn3kbw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.14
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.17.0
+      '@walletconnect/utils': 2.17.0
+      events: 3.3.0
+      lodash.isequal: 4.5.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/core@2.18.0:
+    resolution: {integrity: sha512-i/olu/IwYtBiWYqyfNUMxq4b6QS5dv+ZVVGmLT2buRwdH6MGETN0Bx3/z6rXJzd1sNd+QL07fxhSFxCekL57tA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.18.0
+      '@walletconnect/utils': 2.18.0
+      '@walletconnect/window-getters': 1.0.1
+      events: 3.3.0
+      lodash.isequal: 4.5.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
   /@walletconnect/core@2.9.1:
     resolution: {integrity: sha512-xyWeP0eLhEEDQAVJSmqs4n/AClKUM+8os2ZFe7BTuw1tFYjeLNVDtKCHziVOSTh8wEChMsKSGKA4zerQoH8mAQ==}
     dependencies:
@@ -19502,21 +19724,162 @@ packages:
       '@walletconnect/randombytes': 1.0.3
       aes-js: 3.1.2
       hash.js: 1.1.7
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/encoding@1.0.2:
     resolution: {integrity: sha512-CrwSBrjqJ7rpGQcTL3kU+Ief+Bcuu9PH6JLOb+wM6NITX1GTxR/MfNwnQfhLKK6xpRAyj2/nM04OOH6wS8Imag==}
     dependencies:
       is-typedarray: 1.0.0
-      tslib: 2.2.0
+      tslib: 1.14.1
       typedarray-to-buffer: 3.1.5
     dev: false
 
   /@walletconnect/environment@1.0.1:
     resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
+    dev: false
+
+  /@walletconnect/ethereum-provider@2.11.0(@types/react@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-YrTeHVjuSuhlUw7SQ6xBJXDuJ6iAC+RwINm9nVhoKYJSHAy3EVSJZOofMKrnecL0iRMtD29nj57mxAInIBRuZA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/modal': 2.7.0(@types/react@18.3.1)(react@18.3.1)
+      '@walletconnect/sign-client': 2.11.0
+      '@walletconnect/types': 2.11.0
+      '@walletconnect/universal-provider': 2.11.0
+      '@walletconnect/utils': 2.11.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/ethereum-provider@2.13.0(@types/react@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-dnpW8mmLpWl1AZUYGYZpaAfGw1HFkL0WSlhk5xekx3IJJKn4pLacX2QeIOo0iNkzNQxZfux1AK4Grl1DvtzZEA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/modal': 2.6.2(@types/react@18.3.1)(react@18.3.1)
+      '@walletconnect/sign-client': 2.13.0
+      '@walletconnect/types': 2.13.0
+      '@walletconnect/universal-provider': 2.13.0
+      '@walletconnect/utils': 2.13.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/ethereum-provider@2.17.0(@types/react@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-b+KTAXOb6JjoxkwpgYQQKPUcTwENGmdEdZoIDLeRicUmZTn/IQKfkMoC2frClB4YxkyoVMtj1oMV2JAax+yu9A==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/modal': 2.7.0(@types/react@18.3.1)(react@18.3.1)
+      '@walletconnect/sign-client': 2.17.0
+      '@walletconnect/types': 2.17.0
+      '@walletconnect/universal-provider': 2.17.0
+      '@walletconnect/utils': 2.17.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/ethereum-provider@2.18.0(@types/react@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-YExNYP/z1qNmkLwMutqVxl/rrGX7RS5PCEOVLYCiGsV+vDB9Z6iHP2FgRWh8kZvnmBv5IVvPnQdE7rTzWeUl1Q==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/modal': 2.7.0(@types/react@18.3.1)(react@18.3.1)
+      '@walletconnect/sign-client': 2.18.0
+      '@walletconnect/types': 2.18.0
+      '@walletconnect/universal-provider': 2.18.0
+      '@walletconnect/utils': 2.18.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - uWebSockets.js
+      - utf-8-validate
     dev: false
 
   /@walletconnect/ethereum-provider@2.9.1(@walletconnect/modal@2.6.1):
@@ -19557,87 +19920,11 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@walletconnect/ethereum-provider@2.9.1(@walletconnect/modal@2.6.2):
-    resolution: {integrity: sha512-JiMatBFVgzJSQrckpbOoOsmQmKnbTn9wzmU10MBPe9W6ZV2mf2JuxW0luWKLpQkuCmM9mL6+nCKX7nfW9V6qrQ==}
-    peerDependencies:
-      '@walletconnect/modal': '>=2'
-    peerDependenciesMeta:
-      '@walletconnect/modal':
-        optional: true
-    dependencies:
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/modal': 2.6.2(@types/react@18.3.1)(react@18.3.1)
-      '@walletconnect/sign-client': 2.9.1
-      '@walletconnect/types': 2.9.1
-      '@walletconnect/universal-provider': 2.9.1
-      '@walletconnect/utils': 2.9.1
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - bufferutil
-      - encoding
-      - ioredis
-      - uWebSockets.js
-      - utf-8-validate
-    dev: false
-
-  /@walletconnect/ethereum-provider@2.9.1(@walletconnect/modal@2.7.0):
-    resolution: {integrity: sha512-JiMatBFVgzJSQrckpbOoOsmQmKnbTn9wzmU10MBPe9W6ZV2mf2JuxW0luWKLpQkuCmM9mL6+nCKX7nfW9V6qrQ==}
-    peerDependencies:
-      '@walletconnect/modal': '>=2'
-    peerDependenciesMeta:
-      '@walletconnect/modal':
-        optional: true
-    dependencies:
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/modal': 2.7.0(@types/react@18.3.1)(react@18.3.1)
-      '@walletconnect/sign-client': 2.9.1
-      '@walletconnect/types': 2.9.1
-      '@walletconnect/universal-provider': 2.9.1
-      '@walletconnect/utils': 2.9.1
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - bufferutil
-      - encoding
-      - ioredis
-      - uWebSockets.js
-      - utf-8-validate
-    dev: false
-
   /@walletconnect/events@1.0.1:
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
     dependencies:
       keyvaluestorage-interface: 1.0.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/heartbeat@1.2.1:
@@ -19645,7 +19932,7 @@ packages:
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/time': 1.0.2
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/heartbeat@1.2.2:
@@ -19680,7 +19967,7 @@ packages:
     dependencies:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/jsonrpc-provider@1.0.14:
@@ -19695,7 +19982,7 @@ packages:
     resolution: {integrity: sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==}
     dependencies:
       keyvaluestorage-interface: 1.0.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/jsonrpc-types@1.0.4:
@@ -19710,7 +19997,7 @@ packages:
     dependencies:
       '@walletconnect/environment': 1.0.1
       '@walletconnect/jsonrpc-types': 1.0.4
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/jsonrpc-ws-connection@1.0.13:
@@ -19719,7 +20006,31 @@ packages:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
       events: 3.3.0
-      tslib: 2.2.0
+      tslib: 1.14.1
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/jsonrpc-ws-connection@1.0.14:
+    resolution: {integrity: sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==}
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/jsonrpc-ws-connection@1.0.16:
+    resolution: {integrity: sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==}
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -19765,7 +20076,7 @@ packages:
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
-      query-string: 7.1.3
+      query-string: 6.14.1
     dev: false
 
   /@walletconnect/legacy-modal@2.0.0:
@@ -19807,7 +20118,7 @@ packages:
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
-      query-string: 7.1.3
+      query-string: 6.14.1
     dev: false
 
   /@walletconnect/logger@2.1.2:
@@ -19930,11 +20241,17 @@ packages:
       '@walletconnect/encoding': 1.0.2
       '@walletconnect/environment': 1.0.1
       randombytes: 2.1.0
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/relay-api@1.0.10:
     resolution: {integrity: sha512-tqrdd4zU9VBNqUaXXQASaexklv6A54yEyQQEXYOCr+Jz8Ket0dmPBDyg19LVSNUN2cipAghQc45/KVmfFJ0cYw==}
+    dependencies:
+      '@walletconnect/jsonrpc-types': 1.0.4
+    dev: false
+
+  /@walletconnect/relay-api@1.0.11:
+    resolution: {integrity: sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==}
     dependencies:
       '@walletconnect/jsonrpc-types': 1.0.4
     dev: false
@@ -19946,7 +20263,17 @@ packages:
       '@stablelib/random': 1.0.2
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      tslib: 2.2.0
+      tslib: 1.14.1
+      uint8arrays: 3.1.1
+    dev: false
+
+  /@walletconnect/relay-auth@1.1.0:
+    resolution: {integrity: sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==}
+    dependencies:
+      '@noble/curves': 1.8.0
+      '@noble/hashes': 1.7.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
       uint8arrays: 3.1.1
     dev: false
 
@@ -19957,7 +20284,134 @@ packages:
   /@walletconnect/safe-json@1.0.2:
     resolution: {integrity: sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
+    dev: false
+
+  /@walletconnect/sign-client@2.11.0:
+    resolution: {integrity: sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==}
+    deprecated: Reliability and performance greatly improved - please see https://github.com/WalletConnect/walletconnect-monorepo/releases
+    dependencies:
+      '@walletconnect/core': 2.11.0
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.11.0
+      '@walletconnect/utils': 2.11.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/sign-client@2.13.0:
+    resolution: {integrity: sha512-En7KSvNUlQFx20IsYGsFgkNJ2lpvDvRsSFOT5PTdGskwCkUfOpB33SQJ6nCrN19gyoKPNvWg80Cy6MJI0TjNYA==}
+    dependencies:
+      '@walletconnect/core': 2.13.0
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.13.0
+      '@walletconnect/utils': 2.13.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/sign-client@2.17.0:
+    resolution: {integrity: sha512-sErYwvSSHQolNXni47L3Bm10ptJc1s1YoJvJd34s5E9h9+d3rj7PrhbiW9X82deN+Dm5oA8X9tC4xty1yIBrVg==}
+    dependencies:
+      '@walletconnect/core': 2.17.0
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.17.0
+      '@walletconnect/utils': 2.17.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/sign-client@2.18.0:
+    resolution: {integrity: sha512-oUjlRIsbHxMSRif2WvMRdvm6tMsQjMj07rl7YVcKVvZ1gF1/9GcbJPjzL/U87fv8qAQkVhIlbEg2vHaVYf6J/g==}
+    dependencies:
+      '@walletconnect/core': 2.18.0
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.18.0
+      '@walletconnect/utils': 2.18.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
     dev: false
 
   /@walletconnect/sign-client@2.9.1:
@@ -20005,7 +20459,7 @@ packages:
   /@walletconnect/time@1.0.2:
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
     dev: false
 
   /@walletconnect/types@1.8.0:
@@ -20065,6 +20519,58 @@ packages:
       - uWebSockets.js
     dev: false
 
+  /@walletconnect/types@2.17.0:
+    resolution: {integrity: sha512-i1pn9URpvt9bcjRDkabuAmpA9K7mzyKoLJlbsAujRVX7pfaG7wur7u9Jz0bk1HxvuABL5LHNncTnVKSXKQ5jZA==}
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - ioredis
+      - uWebSockets.js
+    dev: false
+
+  /@walletconnect/types@2.18.0:
+    resolution: {integrity: sha512-g0jU+6LUuw3E/EPAQfHNK2xK/95IpRfz68tdNAFckLmefZU6kzoE1mIM1SrPJq8rT9kUPp6/APMQE+ReH2OdBA==}
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - ioredis
+      - uWebSockets.js
+    dev: false
+
   /@walletconnect/types@2.9.1:
     resolution: {integrity: sha512-xbGgTPuD6xsb7YMvCESBIH55cjB86QAnnVL50a/ED42YkQzDsOdJ0VGTbrm0tG5cxUOF933rpxZQjxGdP+ovww==}
     dependencies:
@@ -20089,6 +20595,137 @@ packages:
       - '@vercel/kv'
       - ioredis
       - uWebSockets.js
+    dev: false
+
+  /@walletconnect/universal-provider@2.11.0:
+    resolution: {integrity: sha512-zgJv8jDvIMP4Qse/D9oIRXGdfoNqonsrjPZanQ/CHNe7oXGOBiQND2IIeX+tS0H7uNA0TPvctljCLiIN9nw4eA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.11.0
+      '@walletconnect/types': 2.11.0
+      '@walletconnect/utils': 2.11.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/universal-provider@2.13.0:
+    resolution: {integrity: sha512-B5QvO8pnk5Bqn4aIt0OukGEQn2Auk9VbHfhQb9cGwgmSCd1GlprX/Qblu4gyT5+TjHMb1Gz5UssUaZWTWbDhBg==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.13.0
+      '@walletconnect/types': 2.13.0
+      '@walletconnect/utils': 2.13.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/universal-provider@2.17.0:
+    resolution: {integrity: sha512-d3V5Be7AqLrvzcdMZSBS8DmGDRdqnyLk1DWmRKAGgR6ieUWykhhUKlvfeoZtvJrIXrY7rUGYpH1X41UtFkW5Pw==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.17.0
+      '@walletconnect/types': 2.17.0
+      '@walletconnect/utils': 2.17.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/universal-provider@2.18.0:
+    resolution: {integrity: sha512-zF/e1NAipLqYjNNgM+XZTchh94efaxciBmgcDOaLznS97R7S/1bYj5okQCAEDKx9RALhEKqZKoyo9jwn4p3BVA==}
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.18.0
+      '@walletconnect/types': 2.18.0
+      '@walletconnect/utils': 2.18.0
+      events: 3.3.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
     dev: false
 
   /@walletconnect/universal-provider@2.9.1:
@@ -20130,9 +20767,9 @@ packages:
       '@walletconnect/encoding': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/types': 1.8.0
-      bn.js: 5.2.1
+      bn.js: 4.11.8
       js-sha3: 0.8.0
-      query-string: 7.1.3
+      query-string: 6.13.5
     dev: false
 
   /@walletconnect/utils@2.11.0:
@@ -20203,6 +20840,79 @@ packages:
       - uWebSockets.js
     dev: false
 
+  /@walletconnect/utils@2.17.0:
+    resolution: {integrity: sha512-1aeQvjwsXy4Yh9G6g2eGmXrEl+BzkNjHRdCrGdMYqFTFa8ROEJfTGsSH3pLsNDlOY94CoBUvJvM55q/PMoN/FQ==}
+    dependencies:
+      '@stablelib/chacha20poly1305': 1.0.1
+      '@stablelib/hkdf': 1.0.1
+      '@stablelib/random': 1.0.2
+      '@stablelib/sha256': 1.0.1
+      '@stablelib/x25519': 1.0.3
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.17.0
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      elliptic: 6.6.1
+      query-string: 7.1.3
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - ioredis
+      - uWebSockets.js
+    dev: false
+
+  /@walletconnect/utils@2.18.0:
+    resolution: {integrity: sha512-6AUXIcjSxTHGRsTtmUP/oqudtwRILrQqrJsH3jS5T28FFDzZt7+On6fR4mXzi64k4nNYeWg1wMCGLEdtxmGbZQ==}
+    dependencies:
+      '@ethersproject/transactions': 5.7.0
+      '@noble/ciphers': 1.2.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.18.0
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      elliptic: 6.6.1
+      query-string: 7.1.3
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - ioredis
+      - uWebSockets.js
+    dev: false
+
   /@walletconnect/utils@2.9.1:
     resolution: {integrity: sha512-tXeQVebF5oPBvhdmuUyVSkSIBYx/egIi4czav1QrnUpwrUS1LsrFhyWBxSbhN7TXY287ULWkEf6aFpWOHdp5EA==}
     dependencies:
@@ -20250,7 +20960,7 @@ packages:
   /@walletconnect/window-metadata@1.0.0:
     resolution: {integrity: sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==}
     dependencies:
-      '@walletconnect/window-getters': 1.0.0
+      '@walletconnect/window-getters': 1.0.1
     dev: false
 
   /@walletconnect/window-metadata@1.0.1:
@@ -20402,12 +21112,12 @@ packages:
       - zod
     dev: false
 
-  /@web3-onboard/trezor@2.4.6(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.2.0)(typescript@5.6.2)(zod@3.22.4):
+  /@web3-onboard/trezor@2.4.6(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.8.1)(typescript@5.6.2)(zod@3.22.4):
     resolution: {integrity: sha512-cP8krxZcmD6n5mh/xp8h4+6CVLqZmLL2mJrtx64n7bEsWpS3mauhe6ipQHRpMRfhS3VyoELQy7V0r9spYAZJTg==}
     dependencies:
       '@ethereumjs/tx': 3.5.2
       '@ethersproject/providers': 5.7.2
-      '@trezor/connect-web': 9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.2.0)
+      '@trezor/connect-web': 9.2.2(@babel/core@7.26.0)(expo@51.0.14)(tslib@2.8.1)
       '@web3-onboard/common': 2.4.2(typescript@5.6.2)(zod@3.22.4)
       '@web3-onboard/hw-common': 2.3.3(typescript@5.6.2)(zod@3.22.4)
       buffer: 6.0.3
@@ -20428,12 +21138,12 @@ packages:
       - zod
     dev: false
 
-  /@web3-onboard/walletconnect@2.4.6(react@18.3.1)(typescript@5.6.2)(zod@3.22.4):
+  /@web3-onboard/walletconnect@2.4.6(@types/react@18.3.1)(react@18.3.1)(typescript@5.6.2)(zod@3.22.4):
     resolution: {integrity: sha512-HsJHC++1/RSZIbYWGLCKkkmdu+8ITV3hkBeSQxvrnO9bcCBMY//+SBo2N7hPZqqSiRFvv2/UW4r4hELmhR4pdQ==}
     dependencies:
       '@ethersproject/providers': 5.5.0
       '@walletconnect/client': 1.8.0
-      '@walletconnect/ethereum-provider': 2.9.1(@walletconnect/modal@2.6.1)
+      '@walletconnect/ethereum-provider': 2.18.0(@types/react@18.3.1)(react@18.3.1)
       '@walletconnect/modal': 2.6.1(react@18.3.1)
       '@walletconnect/qrcode-modal': 1.8.0
       '@web3-onboard/common': 2.4.2(typescript@5.6.2)(zod@3.22.4)
@@ -20450,6 +21160,7 @@ packages:
       - '@netlify/blobs'
       - '@planetscale/database'
       - '@react-native-async-storage/async-storage'
+      - '@types/react'
       - '@upstash/redis'
       - '@vercel/kv'
       - bufferutil
@@ -20916,7 +21627,7 @@ packages:
       busboy: 1.6.0
       fast-querystring: 1.1.2
       fast-url-parser: 1.1.3
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@whatwg-node/node-fetch@0.5.10:
@@ -20927,14 +21638,14 @@ packages:
       '@whatwg-node/events': 0.1.1
       busboy: 1.6.0
       fast-querystring: 1.1.2
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@whatwg-node/server@0.7.7:
     resolution: {integrity: sha512-aHURgNDFm/48WVV3vhTMfnEKCYwYgdaRdRhZsQZx4UVFjGGkGay7Ys0+AYu9QT/jpoImv2oONkstoTMUprDofg==}
     dependencies:
       '@whatwg-node/fetch': 0.8.8
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /@xmldom/xmldom@0.7.13:
@@ -21101,17 +21812,28 @@ packages:
       mime-types: 2.1.34
       negotiator: 0.6.3
 
-  /acorn-jsx@5.3.2(acorn@8.5.0):
+  /acorn-jsx@5.3.2(acorn@8.14.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
-      acorn: 8.5.0
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.5.0
+      acorn: 8.14.0
     dev: true
 
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
+
+  /acorn@7.1.1:
+    resolution: {integrity: sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
+  /acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   /acorn@8.5.0:
     resolution: {integrity: sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==}
@@ -21283,7 +22005,7 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
     dependencies:
-      type-fest: 0.20.2
+      type-fest: 0.21.3
 
   /ansi-escapes@6.2.1:
     resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
@@ -21554,7 +22276,7 @@ packages:
   /asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
     dev: true
@@ -21562,7 +22284,7 @@ packages:
   /asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
@@ -21574,7 +22296,7 @@ packages:
     dependencies:
       pvtsutils: 1.3.5
       pvutils: 1.1.3
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /assert@2.1.0:
@@ -21642,7 +22364,7 @@ packages:
   /async-mutex@0.4.1:
     resolution: {integrity: sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /async@1.5.2:
@@ -22123,6 +22845,17 @@ packages:
   /blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
 
+  /bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+    dev: true
+
+  /bn.js@4.11.8:
+    resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
+    dev: false
+
+  /bn.js@4.12.1:
+    resolution: {integrity: sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==}
+
   /bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
 
@@ -22141,7 +22874,7 @@ packages:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -22546,7 +23279,6 @@ packages:
   /camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
-    dev: true
 
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
@@ -23138,7 +23870,7 @@ packages:
       accepts: 1.3.8
       bytes: 3.0.0
       compressible: 2.0.18
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
@@ -23209,7 +23941,7 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
@@ -23379,7 +24111,7 @@ packages:
   /create-ecdh@4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       elliptic: 6.5.5
     dev: true
 
@@ -23458,7 +24190,7 @@ packages:
       merge: 2.1.1
       minimatch: 3.1.2
       my-easy-fp: 0.9.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -23483,7 +24215,7 @@ packages:
     resolution: {integrity: sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /cross-spawn@6.0.5:
@@ -23755,6 +24487,26 @@ packages:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
     dev: true
 
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -23766,6 +24518,17 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+
+  /debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
 
   /decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
@@ -23790,6 +24553,11 @@ packages:
   /decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
+    dev: false
+
+  /decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
     dev: false
 
   /dedent@1.5.3:
@@ -24111,7 +24879,7 @@ packages:
   /diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       miller-rabin: 4.0.1
       randombytes: 2.1.0
     dev: true
@@ -24237,6 +25005,17 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
+  /drbg.js@1.0.1:
+    resolution: {integrity: sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==}
+    engines: {node: '>=0.10'}
+    requiresBuild: true
+    dependencies:
+      browserify-aes: 1.2.0
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+    dev: false
+    optional: true
+
   /dset@3.1.3:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
     engines: {node: '>=4'}
@@ -24270,6 +25049,18 @@ packages:
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  /eccrypto@1.1.6:
+    resolution: {integrity: sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==}
+    requiresBuild: true
+    dependencies:
+      acorn: 7.1.1
+      elliptic: 6.5.4
+      es6-promise: 4.2.8
+      nan: 2.14.0
+    optionalDependencies:
+      secp256k1: 3.7.1
+    dev: false
+
   /ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
@@ -24295,7 +25086,7 @@ packages:
   /elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       brorand: 1.1.0
       hash.js: 1.1.7
       hmac-drbg: 1.0.1
@@ -24306,13 +25097,25 @@ packages:
   /elliptic@6.5.5:
     resolution: {integrity: sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       brorand: 1.1.0
       hash.js: 1.1.7
       hmac-drbg: 1.0.1
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  /elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+    dependencies:
+      bn.js: 4.12.1
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /embla-carousel-react@8.3.0(react@18.3.1):
     resolution: {integrity: sha512-P1FlinFDcIvggcErRjNuVqnUR8anyo8vLMIH8Rthgofw7Nj8qTguCa2QjFAbzxAUTQTPNNjNL7yt0BGGinVdFw==}
@@ -25059,7 +25862,7 @@ packages:
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -25134,7 +25937,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.6.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
@@ -25164,7 +25967,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.6.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.18.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
@@ -25180,7 +25983,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
-      tslib: 2.2.0
+      tslib: 2.8.1
       tsutils: 3.21.0(typescript@5.6.2)
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -25213,7 +26016,7 @@ packages:
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -25248,7 +26051,7 @@ packages:
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -25585,8 +26388,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.5.0
-      acorn-jsx: 5.3.2(acorn@8.5.0)
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -25660,7 +26463,7 @@ packages:
       '@babel/runtime': 7.20.13
       '@ethereumjs/tx': 3.5.2
       '@types/bn.js': 5.1.1
-      eccrypto: /@toruslabs/eccrypto@2.2.1
+      eccrypto: 1.1.6
       ethereumjs-util: 7.1.5
       ethers: 5.7.2
       secp256k1: 5.0.0
@@ -25766,8 +26569,20 @@ packages:
   /ethereumjs-abi@0.6.8:
     resolution: {integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==}
     dependencies:
-      bn.js: 5.2.1
-      ethereumjs-util: 7.1.5
+      bn.js: 4.12.1
+      ethereumjs-util: 6.2.1
+    dev: true
+
+  /ethereumjs-util@6.2.1:
+    resolution: {integrity: sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==}
+    dependencies:
+      '@types/bn.js': 4.11.6
+      bn.js: 4.12.1
+      create-hash: 1.2.0
+      elliptic: 6.5.5
+      ethereum-cryptography: 0.1.3
+      ethjs-util: 0.1.6
+      rlp: 2.2.7
     dev: true
 
   /ethereumjs-util@7.1.5:
@@ -25784,7 +26599,7 @@ packages:
     resolution: {integrity: sha512-N9IAXsF8iKhgHIC6pquzRgPBJEzc9auw3JoRkaKe+y4Wl/LFBtDDunNe7YmdomontECAcC5APaAgWZBiu1kirw==}
     dependencies:
       '@ethersproject/abi': 5.5.0
-      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-provider': 5.5.1
       '@ethersproject/abstract-signer': 5.5.0
       '@ethersproject/address': 5.5.0
       '@ethersproject/base64': 5.5.0
@@ -25805,7 +26620,7 @@ packages:
       '@ethersproject/random': 5.5.1
       '@ethersproject/rlp': 5.5.0
       '@ethersproject/sha2': 5.5.0
-      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/signing-key': 5.5.0
       '@ethersproject/solidity': 5.5.0
       '@ethersproject/strings': 5.5.0
       '@ethersproject/transactions': 5.5.0
@@ -25822,7 +26637,7 @@ packages:
     resolution: {integrity: sha512-EzGCbns24/Yluu7+ToWnMca3SXJ1Jk1BvWB7CCmVNxyOeM4LLvw2OLuIHhlkhQk1dtOcj9UMsdkxUh8RiG1dxQ==}
     dependencies:
       '@ethersproject/abi': 5.6.0
-      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-provider': 5.6.0
       '@ethersproject/abstract-signer': 5.6.0
       '@ethersproject/address': 5.6.0
       '@ethersproject/base64': 5.6.0
@@ -25843,7 +26658,7 @@ packages:
       '@ethersproject/random': 5.6.0
       '@ethersproject/rlp': 5.6.0
       '@ethersproject/sha2': 5.6.0
-      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/signing-key': 5.6.0
       '@ethersproject/solidity': 5.6.0
       '@ethersproject/strings': 5.6.0
       '@ethersproject/transactions': 5.6.0
@@ -25902,7 +26717,7 @@ packages:
       '@noble/hashes': 1.3.2
       '@types/node': 18.15.13
       aes-js: 4.0.0-beta.5
-      tslib: 2.2.0
+      tslib: 2.4.0
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25913,7 +26728,7 @@ packages:
     resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.11.6
       number-to-bn: 1.7.0
     dev: true
 
@@ -26163,7 +26978,7 @@ packages:
       content-type: 1.0.5
       cookie: 0.6.0
       cookie-signature: 1.0.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 1.0.2
       escape-html: 1.0.3
@@ -26416,11 +27231,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
+    dev: false
+
   /finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -26435,7 +27255,7 @@ packages:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
     engines: {node: '>= 0.8'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -27131,7 +27951,7 @@ packages:
       jiti: 1.21.0
       minimatch: 4.2.3
       string-env-interpolation: 1.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -27161,7 +27981,7 @@ packages:
       jiti: 1.21.0
       minimatch: 4.2.3
       string-env-interpolation: 1.0.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -27238,7 +28058,7 @@ packages:
       dset: 3.1.4
       graphql: 16.8.2
       lru-cache: 7.18.3
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /graphql@15.8.0:
@@ -27824,7 +28644,7 @@ packages:
       slice-ansi: 6.0.0
       stack-utils: 2.0.6
       string-width: 5.1.2
-      type-fest: 0.20.2
+      type-fest: 0.12.0
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
       ws: 8.18.0
@@ -27911,7 +28731,7 @@ packages:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/fast-memoize': 2.2.0
       '@formatjs/icu-messageformat-parser': 2.7.8
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /intl-messageformat@9.13.0:
@@ -28413,6 +29233,15 @@ packages:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /isomorphic-ws@4.0.1(ws@7.5.9):
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -29586,7 +30415,7 @@ packages:
   /lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       marky: 1.2.5
     transitivePeerDependencies:
       - supports-color
@@ -29991,7 +30820,7 @@ packages:
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /lower-case@1.1.4:
@@ -30305,7 +31134,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       anymatch: 3.1.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
       invariant: 2.2.4
@@ -30422,7 +31251,7 @@ packages:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       denodeify: 1.2.1
       error-stack-parser: 2.1.4
       graceful-fs: 4.2.11
@@ -30487,7 +31316,7 @@ packages:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
     hasBin: true
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       brorand: 1.1.0
     dev: true
 
@@ -30724,7 +31553,7 @@ packages:
   /mlly@1.7.0:
     resolution: {integrity: sha512-U9SDaXGEREBYQgfejV97coK0UL1r+qnF2SyO9A3qcI8MzKnsIFKHNVEkrDyNncQTKQQumsasmeq84eNMdBfsNQ==}
     dependencies:
-      acorn: 8.5.0
+      acorn: 8.14.0
       pathe: 1.1.2
       pkg-types: 1.1.1
       ufo: 1.5.3
@@ -30764,7 +31593,7 @@ packages:
       supports-color: 8.1.1
       workerpool: 6.2.1
       yargs: 16.2.0
-      yargs-parser: 20.2.2
+      yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
     dev: true
 
@@ -30872,6 +31701,9 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -30909,7 +31741,7 @@ packages:
     resolution: {integrity: sha512-uqUYAMPNiRBIzmy6vust9I62HnKIdhHdalDS7kMfMoEv9BYVln0G7DCCZFdV/XiwZno6AFeHyQMSPFqgOntArQ==}
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-      tslib: 2.2.0
+      tslib: 1.11.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -30925,6 +31757,10 @@ packages:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  /nan@2.14.0:
+    resolution: {integrity: sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==}
+    dev: false
 
   /nan@2.19.0:
     resolution: {integrity: sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==}
@@ -31288,7 +32124,7 @@ packages:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.11.6
       strip-hex-prefix: 1.0.0
     dev: true
 
@@ -32584,7 +33420,7 @@ packages:
   /public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       browserify-rsa: 4.1.0
       create-hash: 1.2.0
       parse-asn1: 5.1.7
@@ -32623,7 +33459,7 @@ packages:
   /pvtsutils@1.3.5:
     resolution: {integrity: sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /pvutils@1.1.3:
@@ -32690,6 +33526,25 @@ packages:
       side-channel: 1.0.6
     dev: true
 
+  /query-string@6.13.5:
+    resolution: {integrity: sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==}
+    engines: {node: '>=6'}
+    dependencies:
+      decode-uri-component: 0.2.2
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+    dev: false
+
+  /query-string@6.14.1:
+    resolution: {integrity: sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==}
+    engines: {node: '>=6'}
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+    dev: false
+
   /query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
@@ -32698,6 +33553,15 @@ packages:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
+    dev: false
+
+  /query-string@8.2.0:
+    resolution: {integrity: sha512-tUZIw8J0CawM5wyGBiDOAp7ObdRQh4uBor/fUR9ZjmbZVvw95OD9If4w3MQxr99rg0DJZ/9CIORcpEqU5hQG7g==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
     dev: false
 
   /querystring-es3@0.2.1:
@@ -33231,7 +34095,7 @@ packages:
     dependencies:
       find-up: 4.1.0
       read-pkg: 5.2.0
-      type-fest: 0.20.2
+      type-fest: 0.8.1
     dev: true
 
   /read-pkg@5.2.0:
@@ -33241,7 +34105,7 @@ packages:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
-      type-fest: 0.20.2
+      type-fest: 0.6.0
     dev: true
 
   /read@1.0.7:
@@ -33896,7 +34760,7 @@ packages:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
     engines: {npm: '>=2.0.0'}
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
 
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -34009,6 +34873,22 @@ packages:
     resolution: {integrity: sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==}
     dev: true
 
+  /secp256k1@3.7.1:
+    resolution: {integrity: sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==}
+    engines: {node: '>=4.0.0'}
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      bip66: 1.1.5
+      bn.js: 4.12.1
+      create-hash: 1.2.0
+      drbg.js: 1.0.1
+      elliptic: 6.5.5
+      nan: 2.19.0
+      safe-buffer: 5.2.1
+    dev: false
+    optional: true
+
   /secp256k1@4.0.3:
     resolution: {integrity: sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==}
     engines: {node: '>=10.0.0'}
@@ -34086,7 +34966,7 @@ packages:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -34595,6 +35475,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
+    dev: false
+
   /split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
     dependencies:
@@ -34620,7 +35505,7 @@ packages:
   /sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /sprintf-js@1.0.3:
@@ -34763,7 +35648,7 @@ packages:
     resolution: {integrity: sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==}
     engines: {node: '>=6'}
     dependencies:
-      type-fest: 0.20.2
+      type-fest: 0.7.1
 
   /statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -35067,7 +35952,7 @@ packages:
   /strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
-      acorn: 8.5.0
+      acorn: 8.14.0
     dev: true
 
   /strnum@1.0.5:
@@ -35245,7 +36130,7 @@ packages:
   /swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /sync-request@6.1.0:
@@ -35268,7 +36153,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /synckit@0.9.0:
@@ -35276,7 +36161,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /system-architecture@0.1.0:
@@ -35375,7 +36260,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       temp-dir: 1.0.0
-      type-fest: 0.20.2
+      type-fest: 0.3.1
       unique-string: 1.0.0
     dev: false
 
@@ -35386,7 +36271,7 @@ packages:
       del: 6.1.1
       is-stream: 2.0.1
       temp-dir: 2.0.0
-      type-fest: 0.20.2
+      type-fest: 0.16.0
       unique-string: 2.0.0
     dev: false
 
@@ -35404,7 +36289,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.5.0
+      acorn: 8.14.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: false
@@ -35508,7 +36393,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      bn.js: 5.2.1
+      bn.js: 4.12.1
       create-hmac: 1.1.7
       elliptic: 6.5.5
       nan: 2.19.0
@@ -35549,7 +36434,7 @@ packages:
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /tmp@0.0.33:
@@ -35650,7 +36535,7 @@ packages:
       make-error: 1.3.6
       semver: 7.6.3
       typescript: 5.6.2
-      yargs-parser: 20.2.2
+      yargs-parser: 21.1.1
     dev: true
 
   /ts-log@2.2.5:
@@ -35811,8 +36696,30 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@1.11.1:
+    resolution: {integrity: sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==}
+    dev: true
+
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   /tslib@2.2.0:
     resolution: {integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==}
+
+  /tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: true
+
+  /tslib@2.4.1:
+    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
+
+  /tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+    dev: true
+
+  /tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   /tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
@@ -35824,7 +36731,7 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
-      tslib: 2.2.0
+      tslib: 1.14.1
       typescript: 5.6.2
     dev: true
 
@@ -35953,9 +36860,43 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
 
+  /type-fest@0.12.0:
+    resolution: {integrity: sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.16.0:
+    resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
+    engines: {node: '>=10'}
+    dev: false
+
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  /type-fest@0.3.1:
+    resolution: {integrity: sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
+
+  /type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -36812,7 +37753,7 @@ packages:
       '@volar/typescript': 2.4.6
       '@vue/language-core': 2.1.6(typescript@5.6.2)
       compare-versions: 6.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.11
@@ -36839,7 +37780,7 @@ packages:
       '@volar/typescript': 2.4.6
       '@vue/language-core': 2.1.6(typescript@5.6.2)
       compare-versions: 6.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.11
@@ -37061,7 +38002,7 @@ packages:
       '@vitest/snapshot': 0.34.6
       '@vitest/spy': 0.34.6
       '@vitest/utils': 0.34.6
-      acorn: 8.5.0
+      acorn: 8.14.0
       acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.4.1
@@ -37257,7 +38198,7 @@ packages:
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.5
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: true
 
   /webextension-polyfill@0.10.0:
@@ -37292,7 +38233,7 @@ packages:
     requiresBuild: true
     dependencies:
       bufferutil: 4.0.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 2.6.9
       es5-ext: 0.10.64
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.10
@@ -37681,9 +38622,28 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
-  /yargs-parser@20.2.2:
-    resolution: {integrity: sha512-XmrpXaTl6noDsf1dKpBuUNCOHqjs0g3jRMXf/ztRxdOmb+er8kE5z5b55Lz3p5u2T8KJ59ENBnASS8/iapVJ5g==}
+  /yargs-parser@13.1.2:
+    resolution: {integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: false
+
+  /yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  /yargs-parser@20.2.4:
+    resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
 
   /yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
@@ -37707,7 +38667,7 @@ packages:
       string-width: 3.1.0
       which-module: 2.0.1
       y18n: 4.0.3
-      yargs-parser: 20.2.2
+      yargs-parser: 13.1.2
     dev: false
 
   /yargs@15.4.1:
@@ -37724,7 +38684,7 @@ packages:
       string-width: 4.2.3
       which-module: 2.0.1
       y18n: 4.0.3
-      yargs-parser: 20.2.2
+      yargs-parser: 18.1.3
 
   /yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
@@ -37736,7 +38696,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.2
+      yargs-parser: 20.2.4
     dev: true
 
   /yargs@17.7.2:
@@ -37749,7 +38709,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.2
+      yargs-parser: 21.1.1
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}


### PR DESCRIPTION
This pull request includes changes to clean up dependencies in `package.json` and to rename the `DeviceContext` to `LocalConfigContext` in the `LocalConfigContext.tsx` file for better clarity and consistency.

Dependency cleanup:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L88-L105): Removed several specific package resolutions that are no longer needed.

Context renaming for clarity:

* [`packages/app-earn-ui/src/contexts/LocalConfigContext/LocalConfigContext.tsx`](diffhunk://#diff-879696a456e902e25eef4b6c4a94bd9bdc6894cdd0c51ebd7baf9974b22aaff3L33-R33): Renamed `DeviceContext` to `LocalConfigContext` and updated the relevant context provider and usage to reflect this change. [[1]](diffhunk://#diff-879696a456e902e25eef4b6c4a94bd9bdc6894cdd0c51ebd7baf9974b22aaff3L33-R33) [[2]](diffhunk://#diff-879696a456e902e25eef4b6c4a94bd9bdc6894cdd0c51ebd7baf9974b22aaff3L58-R66)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to allow flexible version resolution without enforcing strict selections.
- **Refactor**
  - Renamed an internal configuration context to improve clarity, with all functionality remaining consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->