### PR TITLE
Add env variable to lambdas workflow

### DIFF
--- a/.github/workflows/deploy-lambda-functions-production.yaml
+++ b/.github/workflows/deploy-lambda-functions-production.yaml
@@ -41,7 +41,7 @@ jobs:
       CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
       SDK_API_URL: ${{ secrets.SDK_API_URL }}
-
+      EARN_PROTOCOL_DB_CONNECTION_STRING: ${{ secrets.EARN_PROTOCOL_DB_CONNECTION_STRING }}
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-lambda-functions-staging.yaml
+++ b/.github/workflows/deploy-lambda-functions-staging.yaml
@@ -43,6 +43,7 @@ jobs:
       CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
       SDK_API_URL: ${{ secrets.SDK_API_URL }}
+      EARN_PROTOCOL_DB_CONNECTION_STRING: ${{ secrets.EARN_PROTOCOL_DB_CONNECTION_STRING }}
 
     steps:
       - name: Git clone the repository


### PR DESCRIPTION
## Description
This PR adds the EARN Protocol database connection string as an environment variable to both staging and production Lambda deployment workflows.

## Changes
- Added `EARN_PROTOCOL_DB_CONNECTION_STRING` environment variable to production Lambda deployment workflow
- Added `EARN_PROTOCOL_DB_CONNECTION_STRING` environment variable to staging Lambda deployment workflow

## Benefits
1. Enables Lambda functions to connect to the EARN Protocol database in both environments
2. Maintains consistency between staging and production environments
3. Ensures secure handling of database credentials through GitHub secrets

## Testing
- Verify Lambda deployments complete successfully in staging environment
- Confirm database connections work in staging environment
- Ensure production deployment workflow runs without issues
- Test database connectivity in production after deployment

## Next steps
- Monitor database connection performance in Lambda functions
- Consider adding connection pooling if needed
- Document the new environment variable in relevant documentation

## Additional Notes
This change is required for Lambda functions that need to interact with the EARN Protocol database. The connection string is stored securely in GitHub secrets for both environments.

Please review and provide any feedback or suggestions for improvement.