### PR TITLE
Revert landing page workflow back to staging, update prod from staging to prod

### DIFF
--- a/.github/workflows/deploy-earn-protocol-landing-page-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-production.yaml
@@ -9,10 +9,10 @@ jobs:
   build-earn-protocol-landing-page:
     name: Build and deploy Earn Protocol App
     runs-on: ubuntu-22.04
-    environment: staging
+    environment: production
     env:
       AWS_REGION: us-east-1
-      ENVIRONMENT_TAG: staging
+      ENVIRONMENT_TAG: production
       SERVICE_NAME: earn-protocol-lp-2
       CLUSTER_NAME: summer-fi-earn-protocol-landing-page-staging
       CONFIG_URL: ${{ secrets.CONFIG_URL }}
@@ -24,7 +24,7 @@ jobs:
       SUBGRAPH_BASE: ${{ secrets.SUBGRAPH_BASE }}
       NEXT_TELEMETRY_DISABLED: ${{ secrets.NEXT_TELEMETRY_DISABLED }}
       FORECAST_API_URL: ${{ secrets.FORECAST_API_URL }}
-      SDK_API_URL: ${{ secrets.SDK_API_URL_PROD }}
+      SDK_API_URL: ${{ secrets.SDK_API_URL }}
       NEWSLETTER_API_KEY: ${{ secrets.NEWSLETTER_API_KEY }}
       NEWSLETTER_PUBLICATION_ID: ${{ secrets.NEWSLETTER_PUBLICATION_ID }}
       NEWSLETTER_ENDPOINT: ${{ secrets.NEWSLETTER_ENDPOINT }}
@@ -104,7 +104,7 @@ jobs:
                        --build-arg NEXT_PUBLIC_EARN_MIXPANEL_KEY=${{ secrets.NEXT_PUBLIC_EARN_MIXPANEL_KEY }} \
                        --build-arg NEXT_TELEMETRY_DISABLED=${{ secrets.NEXT_TELEMETRY_DISABLED }} \
                        --build-arg FORECAST_API_URL=${{ secrets.FORECAST_API_URL }} \
-                       --build-arg SDK_API_URL=${{ secrets.SDK_API_URL_PROD }} \
+                       --build-arg SDK_API_URL=${{ secrets.SDK_API_URL }} \
                        --build-arg FUNCTIONS_API_URL=${{ secrets.FUNCTIONS_API_URL }} \
                        --build-arg NEWSLETTER_API_KEY=${{ secrets.NEWSLETTER_API_KEY }} \
                        --build-arg NEWSLETTER_PUBLICATION_ID=${{ secrets.NEWSLETTER_PUBLICATION_ID }} \

--- a/.github/workflows/deploy-earn-protocol-landing-page-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-staging.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-    environment: production
+    environment: staging
     needs: changes
     if: ${{ needs.changes.outputs.build-earn-protocol-landing-page == 'true' }}
     env:


### PR DESCRIPTION
## Description
This PR fixes environment configuration mismatches in both production and staging workflows for the EARN Protocol landing page deployment.

## Changes
- Production workflow:
  - Changed environment from `staging` to `production`
  - Updated `ENVIRONMENT_TAG` from `staging` to `production`
  - Changed `SDK_API_URL` to use standard secret instead of `SDK_API_URL_PROD`
- Staging workflow:
  - Changed environment from `production` to `staging`

## Benefits
1. Ensures correct environment configuration for both staging and production deployments
2. Aligns SDK API URL configuration with standard secret naming convention
3. Maintains proper separation between staging and production environments

## Testing
- Verify staging deployment workflow runs with staging environment
- Confirm production deployment workflow runs with production environment
- Test SDK API connectivity in both environments
- Ensure environment-specific variables are correctly loaded

## Next steps
- Monitor next deployments in both environments
- Consider adding environment validation checks to prevent future misconfigurations
- Update documentation to reflect the correct environment configurations

## Additional Notes
This PR resolves environment configuration inconsistencies that had production and staging environments mixed up in their respective workflows. It also standardizes the SDK API URL secret naming.

Please review and provide any feedback or suggestions for improvement.