### PR TITLE
Update GitHub Actions workflows for Earn Protocol App deployment

### DIFF
--- a/.github/workflows/deploy-earn-protocol-app-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-app-production.yaml
@@ -9,10 +9,10 @@ jobs:
   build-earn-protocol:
     name: Build and deploy Earn Protocol App
     runs-on: ubuntu-22.04
-    environment: staging
+    environment: production
     env:
       AWS_REGION: us-east-1
-      ENVIRONMENT_TAG: staging
+      ENVIRONMENT_TAG: production
       SERVICE_NAME: summer-fi-earn-protocol-staging
       CLUSTER_NAME: summer-fi-earn-protocol-staging
       CONFIG_URL: ${{ secrets.CONFIG_URL }}

--- a/.github/workflows/deploy-earn-protocol-app-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-app-staging.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-    environment: production
+    environment: staging
     needs: changes
     if: ${{ needs.changes.outputs.build-earn-protocol == 'true' }}
     env:


### PR DESCRIPTION
## Description
This PR fixes environment configuration mismatches in both production and staging workflows for the EARN Protocol app deployment.

## Changes
- Production workflow:
  - Changed environment from `staging` to `production`
  - Updated `ENVIRONMENT_TAG` from `staging` to `production`
- Staging workflow:
  - Changed environment from `production` to `staging`

## Benefits
1. Ensures correct environment configuration for both staging and production deployments
2. Prevents accidental deployment to wrong environments
3. Maintains proper separation between staging and production environments

## Testing
- Verify staging deployment workflow runs with staging environment
- Confirm production deployment workflow runs with production environment
- Ensure environment-specific variables are correctly loaded
- Test deployments in both environments

## Next steps
- Monitor next deployments in both environments
- Consider adding environment validation checks to prevent future misconfigurations
- Update documentation to reflect the correct environment configurations

## Additional Notes
This PR resolves environment configuration inconsistencies where production and staging environments were incorrectly set in their respective workflows.

Please review and provide any feedback or suggestions for improvement.