### PR TITLE
fix: resolve TypeScript type warning in bridge transaction hook

### DIFF
--- a/apps/earn-protocol/features/bridge/hooks/use-bridge-transaction.ts
+++ b/apps/earn-protocol/features/bridge/hooks/use-bridge-transaction.ts
@@ -45,7 +45,8 @@ interface BridgeTransactionDetails {
   /** Prepares the bridge transaction with optional override amount */
   prepareTransaction: (overrideAmount?: string) => void
   /** Executes the prepared bridge transaction */
-  executeBridgeTransaction: () => Promise<SendUserOperationWithEOA<unknown> | undefined>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  executeBridgeTransaction: () => Promise<SendUserOperationWithEOA<any> | undefined>
   /** Clears the current transaction state */
   clearTransaction: () => void
   /** Current transaction details */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the transaction processing interface to support a broader range of response types without altering overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->