### PR TITLE
Integrate vault APY fetching in management views

### DIFF
--- a/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
@@ -109,7 +109,7 @@ const EarnVaultManagePage = async ({ params }: EarnVaultManagePageProps) => {
     vault,
   })
 
-  const [positionHistory, positionForecastResponse, vaultsApyList] = await Promise.all([
+  const [positionHistory, positionForecastResponse, vaultApyRaw] = await Promise.all([
     getPositionHistory({
       network: parsedNetwork,
       address: walletAddress.toLowerCase(),
@@ -129,7 +129,7 @@ const EarnVaultManagePage = async ({ params }: EarnVaultManagePageProps) => {
   ])
 
   const vaultApy =
-    vaultsApyList[`${vaultWithConfig.id}-${subgraphNetworkToId(vaultWithConfig.protocol.network)}`]
+    vaultApyRaw[`${vaultWithConfig.id}-${subgraphNetworkToId(vaultWithConfig.protocol.network)}`]
 
   if (!positionForecastResponse.ok) {
     throw new Error('Failed to fetch forecast data')

--- a/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
@@ -90,7 +90,18 @@ const EarnVaultManagePage = async ({ params }: EarnVaultManagePageProps) => {
 
   const allVaultsWithConfig = decorateVaultsWithConfig({ vaults, systemConfig })
 
-  const [arkInterestRatesMap, vaultInterestRates] = await Promise.all([
+  const { netValue } = getPositionValues({
+    position,
+    vault,
+  })
+
+  const [
+    arkInterestRatesMap,
+    vaultInterestRates,
+    positionHistory,
+    positionForecastResponse,
+    vaultApyRaw,
+  ] = await Promise.all([
     getInterestRates({
       network: parsedNetwork,
       arksList: vault.arks,
@@ -102,14 +113,6 @@ const EarnVaultManagePage = async ({ params }: EarnVaultManagePageProps) => {
         chainId: subgraphNetworkToId(network),
       })),
     }),
-  ])
-
-  const { netValue } = getPositionValues({
-    position,
-    vault,
-  })
-
-  const [positionHistory, positionForecastResponse, vaultApyRaw] = await Promise.all([
     getPositionHistory({
       network: parsedNetwork,
       address: walletAddress.toLowerCase(),

--- a/apps/earn-protocol/app/[network]/position/[vaultId]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/page.tsx
@@ -14,6 +14,7 @@ import { getVaultDetails } from '@/app/server-handlers/sdk/get-vault-details'
 import { getVaultsList } from '@/app/server-handlers/sdk/get-vaults-list'
 import systemConfigHandler from '@/app/server-handlers/system-config'
 import { getVaultsHistoricalApy } from '@/app/server-handlers/vault-historical-apy'
+import { getVaultsApy } from '@/app/server-handlers/vaults-apy'
 import { VaultOpenView } from '@/components/layout/VaultOpenView/VaultOpenView'
 import { getArkHistoricalChartData } from '@/helpers/chart-helpers/get-ark-historical-data'
 import { mapArkLatestInterestRates } from '@/helpers/map-ark-interest-rates'
@@ -59,7 +60,7 @@ const EarnVaultOpenPage = async ({ params }: EarnVaultOpenPageProps) => {
       })
     : []
 
-  const [arkInterestRatesMap, vaultInterestRates] = await Promise.all([
+  const [arkInterestRatesMap, vaultInterestRates, vaultApyRaw] = await Promise.all([
     vault?.arks
       ? getInterestRates({
           network: parsedNetwork,
@@ -68,6 +69,12 @@ const EarnVaultOpenPage = async ({ params }: EarnVaultOpenPageProps) => {
       : Promise.resolve({}),
     getVaultsHistoricalApy({
       // just the vault displayed
+      fleets: [vaultWithConfig].map(({ id, protocol: { network } }) => ({
+        fleetAddress: id,
+        chainId: subgraphNetworkToId(network),
+      })),
+    }),
+    getVaultsApy({
       fleets: [vaultWithConfig].map(({ id, protocol: { network } }) => ({
         fleetAddress: id,
         chainId: subgraphNetworkToId(network),
@@ -92,6 +99,7 @@ const EarnVaultOpenPage = async ({ params }: EarnVaultOpenPageProps) => {
   })
 
   const arksInterestRates = mapArkLatestInterestRates(arkInterestRatesMap)
+  const vaultApy = vaultApyRaw[`${vault.id}-${subgraphNetworkToId(vault.protocol.network)}`]
 
   return (
     <VaultOpenView
@@ -102,6 +110,7 @@ const EarnVaultOpenPage = async ({ params }: EarnVaultOpenPageProps) => {
       medianDefiYield={medianDefiYield}
       arksHistoricalChartData={arksHistoricalChartData}
       arksInterestRates={arksInterestRates}
+      vaultApy={vaultApy}
     />
   )
 }

--- a/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.module.scss
+++ b/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.module.scss
@@ -4,4 +4,8 @@
   flex-direction: column;
   padding: unset;
   width: 100%;
+
+  @media (min-width: 768px) {
+    padding: 0 64px;
+  }
 }

--- a/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.module.scss
+++ b/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.module.scss
@@ -4,8 +4,4 @@
   flex-direction: column;
   padding: unset;
   width: 100%;
-
-  @media (min-width: 768px) {
-    padding: 0 64px;
-  }
 }

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageView.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageView.tsx
@@ -25,6 +25,7 @@ export const VaultManageView = ({
   performanceChartData,
   arksHistoricalChartData,
   arksInterestRates,
+  vaultApy,
 }: {
   vault: SDKVaultType | SDKVaultishType
   vaults: SDKVaultsListType
@@ -35,11 +36,13 @@ export const VaultManageView = ({
   performanceChartData: PerformanceChartData
   arksHistoricalChartData: ArksHistoricalChartData
   arksInterestRates?: { [key: string]: number }
+  vaultApy?: number
 }) => {
   return (
     <SDKContextProvider value={{ apiURL: sdkApiUrl }}>
       <VaultManageViewComponent
         vault={vault}
+        vaultApy={vaultApy}
         vaults={vaults}
         position={position}
         userActivity={userActivity}

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
@@ -77,6 +77,7 @@ export const VaultManageViewComponent = ({
   performanceChartData,
   arksHistoricalChartData,
   arksInterestRates,
+  vaultApy,
 }: {
   vault: SDKVaultType | SDKVaultishType
   vaults: SDKVaultsListType
@@ -87,6 +88,7 @@ export const VaultManageViewComponent = ({
   performanceChartData: PerformanceChartData
   arksHistoricalChartData: ArksHistoricalChartData
   arksInterestRates?: { [key: string]: number }
+  vaultApy?: number
 }) => {
   const user = useUser()
   const { userWalletAddress, isLoadingAccount } = useUserWallet()
@@ -375,13 +377,13 @@ export const VaultManageViewComponent = ({
       <NonOwnerPositionBanner isOwner={ownerView} walletStateLoaded={!isLoadingAccount} />
       <VaultManageGrid
         vault={vault}
+        vaultApy={vaultApy}
         vaults={vaults}
         position={position}
         onRefresh={revalidatePositionData}
         viewWalletAddress={viewWalletAddress}
         connectedWalletAddress={user?.address}
         displaySimulationGraph={displaySimulationGraph}
-        arksInterestRates={arksInterestRates}
         simulationGraph={
           <VaultSimulationGraph
             vault={vault}

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenView.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenView.tsx
@@ -21,6 +21,7 @@ export const VaultOpenView = ({
   medianDefiYield,
   arksHistoricalChartData,
   arksInterestRates,
+  vaultApy,
 }: {
   vault: SDKVaultType | SDKVaultishType
   vaults: SDKVaultsListType
@@ -29,6 +30,7 @@ export const VaultOpenView = ({
   medianDefiYield?: number
   arksHistoricalChartData: ArksHistoricalChartData
   arksInterestRates?: { [key: string]: number }
+  vaultApy?: number
 }) => {
   return (
     <SDKContextProvider value={{ apiURL: sdkApiUrl }}>
@@ -40,6 +42,7 @@ export const VaultOpenView = ({
         medianDefiYield={medianDefiYield}
         arksHistoricalChartData={arksHistoricalChartData}
         arksInterestRates={arksInterestRates}
+        vaultApy={vaultApy}
       />
     </SDKContextProvider>
   )

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -70,6 +70,7 @@ type VaultOpenViewComponentProps = {
   medianDefiYield?: number
   arksHistoricalChartData: ArksHistoricalChartData
   arksInterestRates?: { [key: string]: number }
+  vaultApy?: number
 }
 
 export const VaultOpenViewComponent = ({
@@ -80,6 +81,7 @@ export const VaultOpenViewComponent = ({
   medianDefiYield,
   arksHistoricalChartData,
   arksInterestRates,
+  vaultApy,
 }: VaultOpenViewComponentProps) => {
   const { getStorageOnce } = useLocalStorageOnce<string>({
     key: `${vault.id}-amount`,
@@ -354,7 +356,7 @@ export const VaultOpenViewComponent = ({
       displaySimulationGraph={displaySimulationGraph}
       sumrPrice={estimatedSumrPrice}
       onRefresh={revalidatePositionData}
-      arksInterestRates={arksInterestRates}
+      vaultApy={vaultApy}
       simulationGraph={
         <VaultSimulationGraph
           vault={vault}

--- a/apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx
@@ -15,7 +15,7 @@ import {
   type SDKVaultsListType,
   type TokenSymbolsList,
 } from '@summerfi/app-types'
-import { formatCryptoBalance, formatFiatBalance } from '@summerfi/app-utils'
+import { formatCryptoBalance, formatFiatBalance, subgraphNetworkToId } from '@summerfi/app-utils'
 import Link from 'next/link'
 
 import { type GetVaultsApyResponse } from '@/app/server-handlers/vaults-apy'
@@ -152,6 +152,11 @@ export const PortfolioOverview = ({
                       getDisplayToken(position.vault.inputToken.symbol) as TokenSymbolsList
                     }
                   />
+                }
+                apy={
+                  vaultsApyByNetworkMap[
+                    `${position.vault.id}-${subgraphNetworkToId(position.vault.protocol.network)}`
+                  ]
                 }
                 sumrPrice={estimatedSumrPrice}
               />

--- a/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
@@ -5,7 +5,6 @@ import { type SDKVaultishType, type SDKVaultsListType } from '@summerfi/app-type
 import {
   formatCryptoBalance,
   formatDecimalAsPercent,
-  getArksWeightedApy,
   sdkNetworkToHumanNetwork,
 } from '@summerfi/app-utils'
 import { type IArmadaPositionStandalone as IArmadaPosition } from '@summerfi/armada-protocol-common'
@@ -44,11 +43,12 @@ interface VaultManageGridProps {
   simulationGraph: ReactNode
   sumrPrice?: number
   onRefresh?: (chainName?: string, vaultId?: string, walletAddress?: string) => void
-  arksInterestRates?: { [key: string]: number }
+  vaultApy?: number
 }
 
 export const VaultManageGrid: FC<VaultManageGridProps> = ({
   vault,
+  vaultApy,
   vaults,
   detailsContent,
   sidebarContent,
@@ -60,7 +60,6 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
   displaySimulationGraph,
   sumrPrice,
   onRefresh,
-  arksInterestRates,
 }) => {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [displaySimulationGraphStaggered, setDisplaySimulationGraphStaggered] =
@@ -71,7 +70,7 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
     : false
 
   const apr30d = formatDecimalAsPercent(new BigNumber(vault.apr30d).div(100))
-  const aprCurrent = formatDecimalAsPercent(getArksWeightedApy(vault, arksInterestRates))
+  const aprCurrent = formatDecimalAsPercent(vaultApy ?? 0)
 
   const noOfDeposits = position.deposits.length.toString()
 

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
@@ -5,7 +5,6 @@ import { type SDKVaultishType, type SDKVaultsListType } from '@summerfi/app-type
 import {
   formatCryptoBalance,
   formatDecimalAsPercent,
-  getArksWeightedApy,
   sdkNetworkToHumanNetwork,
   ten,
 } from '@summerfi/app-utils'
@@ -42,7 +41,7 @@ interface VaultOpenGridProps {
   medianDefiYield?: number
   sumrPrice?: number
   onRefresh?: (chainName?: string, vaultId?: string, walletAddress?: string) => void
-  arksInterestRates?: { [key: string]: number }
+  vaultApy?: number
 }
 
 export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
@@ -56,7 +55,7 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
   medianDefiYield,
   sumrPrice,
   onRefresh,
-  arksInterestRates,
+  vaultApy,
 }) => {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [displaySimulationGraphStaggered, setDisplaySimulationGraphStaggered] =
@@ -68,7 +67,7 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
   const apr30d = isVaultAtLeast30dOld
     ? formatDecimalAsPercent(new BigNumber(vault.apr30d).div(100))
     : 'New strategy'
-  const aprCurrent = formatDecimalAsPercent(getArksWeightedApy(vault, arksInterestRates))
+  const aprCurrent = formatDecimalAsPercent(vaultApy ?? 0)
   const totalValueLockedUSDParsed = formatCryptoBalance(new BigNumber(vault.totalValueLockedUSD))
   const totalValueLockedTokenParsed = formatCryptoBalance(
     new BigNumber(vault.inputTokenBalance.toString()).div(ten.pow(vault.inputToken.decimals)),

--- a/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx
+++ b/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import { type IArmadaPosition, type SDKVaultishType } from '@summerfi/app-types'
-import { formatDecimalAsPercent, getArksWeightedApy } from '@summerfi/app-utils'
+import { formatDecimalAsPercent } from '@summerfi/app-utils'
 import BigNumber from 'bignumber.js'
 import dayjs from 'dayjs'
 import Link from 'next/link'
@@ -23,6 +23,7 @@ type PortfolioPositionProps = {
   }
   positionGraph: ReactNode
   sumrPrice?: number
+  apy?: number
 }
 
 const PortfolioPositionHeaderValue = ({
@@ -48,6 +49,7 @@ export const PortfolioPosition = ({
   portfolioPosition,
   positionGraph,
   sumrPrice,
+  apy,
 }: PortfolioPositionProps) => {
   const {
     inputToken,
@@ -72,7 +74,7 @@ export const PortfolioPosition = ({
   const isVaultAtLeast30dOld = createdTimestamp
     ? dayjs().diff(dayjs(Number(createdTimestamp) * 1000), 'day') > 30
     : false
-  const currentApr = formatDecimalAsPercent(getArksWeightedApy(portfolioPosition.vault))
+  const currentApr = formatDecimalAsPercent(apy ?? 0)
   const apr30dParsed = isVaultAtLeast30dOld
     ? formatDecimalAsPercent(new BigNumber(apr30d).div(100))
     : 'New Strategy'


### PR DESCRIPTION
This pull request introduces several updates to the `earn-protocol` application, primarily focusing on integrating and displaying the APY (Annual Percentage Yield) for vaults across different parts of the application. The changes include modifications to various components and pages to fetch, calculate, and display the APY data.

### APY Integration:

* `apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx`: Added `getVaultsApy` import and included the APY data in the `EarnVaultManagePage` function. The APY is fetched alongside position history and forecast data, and passed to the `VaultManageView` component. ([apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsxR24](diffhunk://#diff-0165553f1d4864b81002ff0ea23b003d62361c7c8d7c49e5e1e3f4e6826fc5f0R24), [apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsxL111-R133](diffhunk://#diff-0165553f1d4864b81002ff0ea23b003d62361c7c8d7c49e5e1e3f4e6826fc5f0L111-R133), [apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsxR160](diffhunk://#diff-0165553f1d4864b81002ff0ea23b003d62361c7c8d7c49e5e1e3f4e6826fc5f0R160))
* `apps/earn-protocol/app/[network]/position/[vaultId]/page.tsx`: Added `getVaultsApy` import and included the APY data in the `EarnVaultOpenPage` function. The APY is fetched alongside interest rates and passed to the `VaultOpenView` component. ([apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxR17](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5R17), [apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxL62-R63](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5L62-R63), [apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxR77-R82](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5R77-R82), [apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxR102](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5R102), [apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxR113](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5R113))

### Component Updates:

* [`apps/earn-protocol/components/layout/VaultManageView/VaultManageView.tsx`](diffhunk://#diff-180e4453ecde0323c93bedc67a55441498ddf30fa5f732446fd12cc2dc575ba9R28): Updated to accept and pass the `vaultApy` prop to its child components. [[1]](diffhunk://#diff-180e4453ecde0323c93bedc67a55441498ddf30fa5f732446fd12cc2dc575ba9R28) [[2]](diffhunk://#diff-180e4453ecde0323c93bedc67a55441498ddf30fa5f732446fd12cc2dc575ba9R39-R45)
* [`apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx`](diffhunk://#diff-093401e3ee1390c1d36183263365baea6f0df465c9bc2cdafe8c6205c965caccR80): Updated to accept and use the `vaultApy` prop. [[1]](diffhunk://#diff-093401e3ee1390c1d36183263365baea6f0df465c9bc2cdafe8c6205c965caccR80) [[2]](diffhunk://#diff-093401e3ee1390c1d36183263365baea6f0df465c9bc2cdafe8c6205c965caccR91) [[3]](diffhunk://#diff-093401e3ee1390c1d36183263365baea6f0df465c9bc2cdafe8c6205c965caccR380-L384)
* [`apps/earn-protocol/components/layout/VaultOpenView/VaultOpenView.tsx`](diffhunk://#diff-a40498ddbf1bf5830448800c7d93442c21fc90a4f6c4eed0b672478679ce71a9R24): Updated to accept and pass the `vaultApy` prop to its child components. [[1]](diffhunk://#diff-a40498ddbf1bf5830448800c7d93442c21fc90a4f6c4eed0b672478679ce71a9R24) [[2]](diffhunk://#diff-a40498ddbf1bf5830448800c7d93442c21fc90a4f6c4eed0b672478679ce71a9R33) [[3]](diffhunk://#diff-a40498ddbf1bf5830448800c7d93442c21fc90a4f6c4eed0b672478679ce71a9R45)
* [`apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx`](diffhunk://#diff-af80e33b59ddc7605e3d3e1491d67643a7110bc68039c4d1cf0bac4460249f8fR73): Updated to accept and use the `vaultApy` prop. [[1]](diffhunk://#diff-af80e33b59ddc7605e3d3e1491d67643a7110bc68039c4d1cf0bac4460249f8fR73) [[2]](diffhunk://#diff-af80e33b59ddc7605e3d3e1491d67643a7110bc68039c4d1cf0bac4460249f8fR84) [[3]](diffhunk://#diff-af80e33b59ddc7605e3d3e1491d67643a7110bc68039c4d1cf0bac4460249f8fL357-R359)

### Grid Component Updates:

* [`packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx`](diffhunk://#diff-62b334c3ac2273d4b9e789fabd67803823011b27a1b7d32c1f4e241f568ad7a2L8): Removed `arksInterestRates` and added `vaultApy` prop to display the current APY. [[1]](diffhunk://#diff-62b334c3ac2273d4b9e789fabd67803823011b27a1b7d32c1f4e241f568ad7a2L8) [[2]](diffhunk://#diff-62b334c3ac2273d4b9e789fabd67803823011b27a1b7d32c1f4e241f568ad7a2L47-R51) [[3]](diffhunk://#diff-62b334c3ac2273d4b9e789fabd67803823011b27a1b7d32c1f4e241f568ad7a2L63) [[4]](diffhunk://#diff-62b334c3ac2273d4b9e789fabd67803823011b27a1b7d32c1f4e241f568ad7a2L74-R73)
* [`packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx`](diffhunk://#diff-776aed55e6785a60d25c6079f47a872188d0bcce78795f91ea2f08ff71d0e613L8): Removed `arksInterestRates` and added `vaultApy` prop to display the current APY. [[1]](diffhunk://#diff-776aed55e6785a60d25c6079f47a872188d0bcce78795f91ea2f08ff71d0e613L8) [[2]](diffhunk://#diff-776aed55e6785a60d25c6079f47a872188d0bcce78795f91ea2f08ff71d0e613L45-R44) [[3]](diffhunk://#diff-776aed55e6785a60d25c6079f47a872188d0bcce78795f91ea2f08ff71d0e613L59-R58) [[4]](diffhunk://#diff-776aed55e6785a60d25c6079f47a872188d0bcce78795f91ea2f08ff71d0e613L71-R70)

### Portfolio Component Updates:

* [`packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx`](diffhunk://#diff-a2613b09eb392e920e7bebc800d972601a4d47cd5eab6b630f5b78d022d947fbL3-R3): Added `apy` prop to display the APY in the portfolio position component. [[1]](diffhunk://#diff-a2613b09eb392e920e7bebc800d972601a4d47cd5eab6b630f5b78d022d947fbL3-R3) [[2]](diffhunk://#diff-a2613b09eb392e920e7bebc800d972601a4d47cd5eab6b630f5b78d022d947fbR26) [[3]](diffhunk://#diff-a2613b09eb392e920e7bebc800d972601a4d47cd5eab6b630f5b78d022d947fbR52)
* [`apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx`](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01L18-R18): Added `subgraphNetworkToId` import and included APY data in the `PortfolioOverview` component. [[1]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01L18-R18) [[2]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R156-R160)

### Styling Update:

* [`apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.module.scss`](diffhunk://#diff-da8c7237b60affc270ac57b7b36992d9e3470df4e47b00d48d8ad68bac9964beL7-L10): Removed media query padding for better layout consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Vault management and portfolio components now display annual yield data for improved clarity on performance metrics.
  - Yield calculations have been integrated across multiple views, providing users with updated and accurate yield values.

- **Style**
  - Portfolio page layout now features consistent spacing across all screen sizes, ensuring a uniform viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->