### PR TITLE
Implement NotFoundPage redirection for invalid wallet addresses and networks

### DIFF
--- a/apps/earn-protocol/app/[network]/page.tsx
+++ b/apps/earn-protocol/app/[network]/page.tsx
@@ -5,6 +5,7 @@ import {
   subgraphNetworkToId,
 } from '@summerfi/app-utils'
 
+import NotFoundPage from '@/app/not-found'
 import { getVaultsList } from '@/app/server-handlers/sdk/get-vaults-list'
 import systemConfigHandler from '@/app/server-handlers/system-config'
 import { getVaultsApy } from '@/app/server-handlers/vaults-apy'
@@ -20,6 +21,11 @@ type EarnNetworkVaultsPageProps = {
 const EarnNetworkVaultsPage = async ({ params }: EarnNetworkVaultsPageProps) => {
   const { network: networkParam } = await params
   const parsedNetwork = humanNetworktoSDKNetwork(networkParam)
+
+  if (parsedNetwork === networkParam) {
+    return <NotFoundPage />
+  }
+
   const [{ vaults }, configRaw] = await Promise.all([getVaultsList(), systemConfigHandler()])
   const { config: systemConfig } = parseServerResponseToClient(configRaw)
   const vaultsWithConfig = decorateVaultsWithConfig({ vaults, systemConfig })

--- a/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
@@ -11,6 +11,7 @@ import {
   subgraphNetworkToId,
 } from '@summerfi/app-utils'
 import { type IArmadaPosition } from '@summerfi/sdk-client'
+import { redirect } from 'next/navigation'
 import { isAddress } from 'viem'
 
 import { getInterestRates } from '@/app/server-handlers/interest-rates'
@@ -48,6 +49,13 @@ const EarnVaultManagePage = async ({ params }: EarnVaultManagePageProps) => {
   const parsedVaultId = isAddress(vaultId)
     ? vaultId
     : getVaultIdByVaultCustomName(vaultId, String(parsedNetworkId), systemConfig)
+
+  if (!parsedVaultId && !isAddress(vaultId)) {
+    redirect('/not-found')
+  }
+  if (!isAddress(walletAddress)) {
+    redirect('/not-found')
+  }
 
   const [vault, { vaults }, position, { userActivity, topDepositors }] = await Promise.all([
     getVaultDetails({

--- a/apps/earn-protocol/app/[network]/position/[vaultId]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/page.tsx
@@ -5,6 +5,7 @@ import {
   parseServerResponseToClient,
   subgraphNetworkToId,
 } from '@summerfi/app-utils'
+import { redirect } from 'next/navigation'
 import { isAddress } from 'viem'
 
 import { getMedianDefiYield } from '@/app/server-handlers/defillama/get-median-defi-yield'
@@ -39,6 +40,10 @@ const EarnVaultOpenPage = async ({ params }: EarnVaultOpenPageProps) => {
   const parsedVaultId = isAddress(vaultId)
     ? vaultId
     : getVaultIdByVaultCustomName(vaultId, String(parsedNetworkId), systemConfig)
+
+  if (!parsedVaultId && !isAddress(vaultId)) {
+    redirect('/not-found')
+  }
 
   const [vault, { vaults }, { usersActivity, topDepositors }, medianDefiYield] = await Promise.all([
     getVaultDetails({

--- a/apps/earn-protocol/app/bridge/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/bridge/[walletAddress]/page.tsx
@@ -15,7 +15,7 @@ const BridgePage = async ({ params }: BridgePageProps) => {
   const { walletAddress } = await params
 
   if (!isValidAddress(walletAddress)) {
-    redirect(`/`)
+    redirect('/not-found')
   }
   const [sumrBalances] = await Promise.all([
     getSumrBalances({

--- a/apps/earn-protocol/app/bridge/page.tsx
+++ b/apps/earn-protocol/app/bridge/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 
 const BridgeRedirectPage = () => {
-  redirect(`/`)
+  redirect('/not-found')
 }
 
 export default BridgeRedirectPage

--- a/apps/earn-protocol/app/claim/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/claim/[walletAddress]/page.tsx
@@ -20,7 +20,7 @@ const ClaimPage = async ({ params }: ClaimPageProps) => {
   const { walletAddress } = await params
 
   if (!isValidAddress(walletAddress)) {
-    redirect(`/`)
+    redirect('/not-found')
   }
   const [sumrStakeDelegate, sumrBalances, sumrStakingInfo, sumrDelegates, sumrToClaim] =
     await Promise.all([

--- a/apps/earn-protocol/app/claim/page.tsx
+++ b/apps/earn-protocol/app/claim/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 
 const ClaimRedirectPage = () => {
-  redirect(`/`)
+  redirect('/not-found')
 }
 
 export default ClaimRedirectPage

--- a/apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx
@@ -6,6 +6,7 @@ import {
 } from '@summerfi/app-types'
 import { parseServerResponseToClient, subgraphNetworkToId } from '@summerfi/app-utils'
 import { unstable_cache as unstableCache } from 'next/cache'
+import { redirect } from 'next/navigation'
 
 import { fetchRaysLeaderboard } from '@/app/server-handlers/leaderboard'
 import { portfolioWalletAssetsHandler } from '@/app/server-handlers/portfolio/portfolio-wallet-assets-handler'
@@ -26,6 +27,7 @@ import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/ty
 import { mergePositionWithVault } from '@/features/portfolio/helpers/merge-position-with-vault'
 import { type GetPositionHistoryQuery } from '@/graphql/clients/position-history/client'
 import { getPositionHistoricalData } from '@/helpers/chart-helpers/get-position-historical-data'
+import { isValidAddress } from '@/helpers/is-valid-address'
 import { decorateVaultsWithConfig } from '@/helpers/vault-custom-value-helpers'
 
 type PortfolioPageProps = {
@@ -104,6 +106,10 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { walletAddress: walletAddressRaw } = await params
 
   const walletAddress = walletAddressRaw.toLowerCase()
+
+  if (!isValidAddress(walletAddress)) {
+    redirect('/not-found')
+  }
 
   const {
     walletData,

--- a/apps/earn-protocol/app/stake-delegate/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/stake-delegate/[walletAddress]/page.tsx
@@ -19,7 +19,7 @@ const StakeDelegatePage = async ({ params }: StakeDelegatePageProps) => {
   const { walletAddress } = await params
 
   if (!isValidAddress(walletAddress)) {
-    redirect(`/`)
+    redirect('/not-found')
   }
 
   const [

--- a/apps/earn-protocol/app/stake-delegate/page.tsx
+++ b/apps/earn-protocol/app/stake-delegate/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 
 const StakeDelegateRedirectPage = () => {
-  redirect(`/`)
+  redirect('/not-found')
 }
 
 export default StakeDelegateRedirectPage


### PR DESCRIPTION
This pull request introduces several changes to the `earn-protocol` application, primarily focused on improving error handling by redirecting to a "not found" page when invalid addresses or parameters are encountered. The changes include importing the `redirect` function from `next/navigation` and adding conditional checks to various pages.

Error handling improvements:

* `apps/earn-protocol/app/[network]/page.tsx`: Imported `NotFoundPage` and added a condition to return the `NotFoundPage` component if the network parameter is invalid. ([apps/earn-protocol/app/[network]/page.tsxR8](diffhunk://#diff-90441029444ff79740de7a8fd2a44632095c9364d1c7f840e24587292d55e691R8), [apps/earn-protocol/app/[network]/page.tsxR24-R28](diffhunk://#diff-90441029444ff79740de7a8fd2a44632095c9364d1c7f840e24587292d55e691R24-R28))
* `apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx`: Imported `redirect` and added conditions to redirect to `/not-found` if the vault ID or wallet address is invalid. ([apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsxR14](diffhunk://#diff-0165553f1d4864b81002ff0ea23b003d62361c7c8d7c49e5e1e3f4e6826fc5f0R14), [apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsxR53-R59](diffhunk://#diff-0165553f1d4864b81002ff0ea23b003d62361c7c8d7c49e5e1e3f4e6826fc5f0R53-R59))
* `apps/earn-protocol/app/[network]/position/[vaultId]/page.tsx`: Imported `redirect` and added a condition to redirect to `/not-found` if the vault ID is invalid. ([apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxR8](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5R8), [apps/earn-protocol/app/[network]/position/[vaultId]/page.tsxR44-R47](diffhunk://#diff-c91769e178406d1f14d4e6b95aad5bd1f2df8d4ea7d3c5f496fabfb09ad4cec5R44-R47))
* `apps/earn-protocol/app/bridge/[walletAddress]/page.tsx`: Updated the redirect URL to `/not-found` for invalid wallet addresses. ([apps/earn-protocol/app/bridge/[walletAddress]/page.tsxL18-R18](diffhunk://#diff-f2fc4835e2a1ba176e21cc50a76555485198d26f9a2d5d323a69727c17a69594L18-R18))
* [`apps/earn-protocol/app/bridge/page.tsx`](diffhunk://#diff-987348d3cae622f3b8b33c99452d572c89e3ecfcf5bc44ac4762c7a330d50ee9L4-R4): Changed the redirect URL to `/not-found`.
* `apps/earn-protocol/app/claim/[walletAddress]/page.tsx`: Updated the redirect URL to `/not-found` for invalid wallet addresses. ([apps/earn-protocol/app/claim/[walletAddress]/page.tsxL23-R23](diffhunk://#diff-147a311a7199841a4a709bcb787be4bc6b2a83e6586988adf10030e4c6f00f31L23-R23))
* [`apps/earn-protocol/app/claim/page.tsx`](diffhunk://#diff-ae1eb95d3fc4def7dbcf843c4b8d622da48eec629620662b7078fbce852bba11L4-R4): Changed the redirect URL to `/not-found`.
* `apps/earn-protocol/app/portfolio/[walletAddress]/page.tsx`: Imported `redirect` and `isValidAddress`, and added a condition to redirect to `/not-found` if the wallet address is invalid. ([apps/earn-protocol/app/portfolio/[walletAddress]/page.tsxR9](diffhunk://#diff-69886e19d7f72a5c03b4cc3260471467741fad422ddeee6c03a2073b666aa049R9), [apps/earn-protocol/app/portfolio/[walletAddress]/page.tsxR30](diffhunk://#diff-69886e19d7f72a5c03b4cc3260471467741fad422ddeee6c03a2073b666aa049R30), [apps/earn-protocol/app/portfolio/[walletAddress]/page.tsxR110-R113](diffhunk://#diff-69886e19d7f72a5c03b4cc3260471467741fad422ddeee6c03a2073b666aa049R110-R113))
* `apps/earn-protocol/app/stake-delegate/[walletAddress]/page.tsx`: Updated the redirect URL to `/not-found` for invalid wallet addresses. ([apps/earn-protocol/app/stake-delegate/[walletAddress]/page.tsxL22-R22](diffhunk://#diff-c7161c9fde08eb6f79765a918e8d8bc1c154ca775da43f248fff9fe553cd53cfL22-R22))
* [`apps/earn-protocol/app/stake-delegate/page.tsx`](diffhunk://#diff-2c5783224cff0d82209ab8d0749387c9972949e95e730f32174cf857b1d62ce6L4-R4): Changed the redirect URL to `/not-found`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated redirection behavior across the application. Users now receive a "Not Found" page when entering invalid network parameters, wallet addresses, or vault IDs. This change is applied consistently across network vaults, positions, bridge, claim, portfolio, and stake delegate pages to provide improved error handling and a clearer user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->