### PR TITLE
Add CloudFront invalidation and ECS wait actions to deployment workflows

### DIFF
--- a/.github/workflows/deploy-earn-protocol-app-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-app-production.yaml
@@ -178,6 +178,10 @@ jobs:
         run: |
           aws ecs update-service --cluster $CLUSTER_NAME --service ${{ env.SERVICE_NAME }} --force-new-deployment --region $AWS_REGION
 
+      - name: Invalidate CloudFront
+        run: |
+          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.EARN_CF_DIST_ID }} --paths "/*"
+
       - name: Wait for all services to become stable
         uses: oryanmoshe/ecs-wait-action@v1.3
         with:

--- a/.github/workflows/deploy-earn-protocol-app-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-app-staging.yaml
@@ -208,3 +208,9 @@ jobs:
       - name: Invalidate CloudFront
         run: |
           AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.EARN_CF_DIST_ID }} --paths "/*"
+
+      - name: Wait for all services to become stable
+        uses: oryanmoshe/ecs-wait-action@v1.3
+        with:
+          ecs-cluster: ${{ env.CLUSTER_NAME }}
+          ecs-services: '["${{ env.SERVICE_NAME }}"]'

--- a/.github/workflows/deploy-earn-protocol-landing-page-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-production.yaml
@@ -121,6 +121,10 @@ jobs:
         run: |
           aws ecs update-service --cluster $CLUSTER_NAME --service ${{ env.SERVICE_NAME }} --force-new-deployment --region $AWS_REGION
 
+      - name: Invalidate CloudFront
+        run: |
+          AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.EARN_CF_DIST_ID }} --paths "/*"
+
       - name: Wait for all services to become stable
         uses: oryanmoshe/ecs-wait-action@v1.3
         with:

--- a/.github/workflows/deploy-earn-protocol-landing-page-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-staging.yaml
@@ -151,3 +151,9 @@ jobs:
       - name: Invalidate CloudFront
         run: |
           AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id ${{ secrets.EARN_CF_DIST_ID }} --paths "/*"
+
+      - name: Wait for all services to become stable
+        uses: oryanmoshe/ecs-wait-action@v1.3
+        with:
+          ecs-cluster: ${{ env.CLUSTER_NAME }}
+          ecs-services: '["${{ env.SERVICE_NAME }}"]'


### PR DESCRIPTION
This pull request includes updates to several GitHub Actions workflows to improve the deployment process for the Earn Protocol application. The most important changes involve adding steps to invalidate CloudFront caches and ensuring services become stable after deployment.

Deployment process improvements:

* [`.github/workflows/deploy-earn-protocol-app-production.yaml`](diffhunk://#diff-4db21138a5594c3d7e3b2d032c9bbd085cde0edfcb13be5134a130944489f81eR181-R184): Added a step to invalidate the CloudFront distribution cache after updating the ECS service.
* [`.github/workflows/deploy-earn-protocol-app-staging.yaml`](diffhunk://#diff-bb047b8a69b9f7c419399a30774ceecce15a5611900ebf58adb8da8b38b71294R211-R216): Added a step to wait for all services to become stable after invalidating the CloudFront cache.
* [`.github/workflows/deploy-earn-protocol-landing-page-production.yaml`](diffhunk://#diff-e5242a9fd20db207b9ead45a343f0116f120c138209c55397b90b1eb9f26894bR124-R127): Added a step to invalidate the CloudFront distribution cache after updating the ECS service.
* [`.github/workflows/deploy-earn-protocol-landing-page-staging.yaml`](diffhunk://#diff-5d9102d911ea097bb4ffad7af35eb6421639c679617d305b839e014be1955c77R154-R159): Added a step to wait for all services to become stable after invalidating the CloudFront cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automatic cache refresh after deployments to ensure that the application and landing page display the latest content immediately.
	- Added stability checks during deployment, verifying that all services are fully operational before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->