### PR TITLE
Update devIndicators configuration and add redirect for dsr positions

### DIFF
--- a/apps/earn-protocol-landing-page/next.config.ts
+++ b/apps/earn-protocol-landing-page/next.config.ts
@@ -9,9 +9,7 @@ const redirectToProSummer = (pathname: string) => ({
 
 const nextConfig: NextConfig = {
   devIndicators: {
-    buildActivity: true,
-    buildActivityPosition: 'bottom-right',
-    appIsrStatus: true,
+    position: 'bottom-right',
   },
   experimental: {
     turbo: {},

--- a/apps/earn-protocol/next.config.ts
+++ b/apps/earn-protocol/next.config.ts
@@ -9,9 +9,7 @@ const redirectToProSummer = (pathname: string) => ({
 
 const nextConfig: NextConfig = {
   devIndicators: {
-    buildActivity: true,
-    buildActivityPosition: 'bottom-right',
-    appIsrStatus: true,
+    position: 'bottom-right',
   },
   experimental: {
     turbo: {},
@@ -74,6 +72,8 @@ const nextConfig: NextConfig = {
       // maker position redirects
       // matches to `/{number}`
       redirectToProSummer('/:makerPosition(\\d{1,})'),
+      // dsr position redirects
+      redirectToProSummer('/earn/dsr/:otherPosition*'),
     ])
   },
   images: {


### PR DESCRIPTION
This pull request includes changes to the configuration files of the `earn-protocol` and `earn-protocol-landing-page` applications to streamline development indicators and add new URL redirects.

Changes to development indicators:

* [`apps/earn-protocol-landing-page/next.config.ts`](diffhunk://#diff-b8fbffba6ab8b052cd385248923f9225fd799eb0e1646a623f21895c70e2de1cL12-R12): Removed `buildActivity` and `appIsrStatus` indicators and simplified the `position` property.
* [`apps/earn-protocol/next.config.ts`](diffhunk://#diff-ead0f4caa9fde0719457435151639c0a49c8418191c56b68fef7457a3baa88f3L12-R12): Removed `buildActivity` and `appIsrStatus` indicators and simplified the `position` property.

Changes to URL redirects:

* [`apps/earn-protocol/next.config.ts`](diffhunk://#diff-ead0f4caa9fde0719457435151639c0a49c8418191c56b68fef7457a3baa88f3R75-R76): Added a new redirect for `dsr position` URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new redirect route to enhance navigation for DSR-related pages.
- **Refactor**
	- Streamlined indicator settings to ensure a consistent and simplified display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->