### PR TITLE
Ensure Docker services restart automatically in docker-compose

### DIFF
--- a/stacks/local-env/docker-compose.yaml
+++ b/stacks/local-env/docker-compose.yaml
@@ -3,6 +3,7 @@ name: summerfi-api-local
 services:
   rays-db:
     image: postgres:16
+    restart: always
     environment:
       POSTGRES_DB: rays
       POSTGRES_USER: user
@@ -34,6 +35,7 @@ services:
       - redis-cache-v7-data:/data
   oasis-borrow-db:
     image: postgres:12
+    restart: always
     build:
       context: .
       dockerfile: compose-build/oasis-borrow-seed.Dockerfile
@@ -55,6 +57,7 @@ services:
       - oasis-borrow-pg-v12-data:/var/lib/postgresql/data
   summer-protocol-db:
     image: postgres:16
+    restart: always
     environment:
       POSTGRES_DB: summerprotocol
       POSTGRES_USER: user


### PR DESCRIPTION
Add the `restart: always` policy to relevant Docker services in the docker-compose file to ensure they restart automatically.

Run
```
pnpm sst:dev
```

to override the current docker container settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced system reliability by configuring essential services to automatically restart upon unexpected stops, ensuring a more resilient and stable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->