### PR TITLE
Add 30-day SMA APY calculation

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMigrations.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMigrations.ts
@@ -335,16 +335,18 @@ export class ArmadaManagerMigrations implements IArmadaManagerMigrations {
         // take the last record for current apy
         const apy = json.data[json.data.length - 1].apy
 
-        // take last 7 records for the 7 days apy
+        // take last 7 records for the 7 days and calculate the SMA fer the last 7 days
         const last7Records = json.data.slice(-7)
-        const apy7d =
-          last7Records.reduce((acc, record) => acc + record.apy, 0) / last7Records.length
-        LoggingService.debug('apy7d for position ' + positionId, apy7d)
+        const apy7d = last7Records.reduce((acc, record) => acc + record.apy, 0) / 7
+        // take last 30 records for the 30 days and calculate the SMA fer the last 30 days
+        const last30Records = json.data.slice(-30)
+        const apy30d = last30Records.reduce((acc, record) => acc + record.apy, 0) / 30
 
         return {
           positionId: positionId,
           apy: Percentage.createFrom({ value: apy }),
           apy7d: Percentage.createFrom({ value: apy7d }),
+          apy30d: Percentage.createFrom({ value: apy30d }),
         } as ArmadaMigratablePositionApy
       }),
     )

--- a/sdk/sdk-common/src/common/types/ArmadaMigratablePositionApy.ts
+++ b/sdk/sdk-common/src/common/types/ArmadaMigratablePositionApy.ts
@@ -1,11 +1,12 @@
-import type { ArmadaMigrationType } from '../enums'
-import type { IFiatCurrencyAmount, IPercentage, ITokenAmount } from '../interfaces'
+import type { IPercentage } from '../interfaces'
 
 export type ArmadaMigratablePositionApy = {
   // position id
   positionId: string
   // current annual percentage yield
   apy: IPercentage | null
-  // 7day average annual percentage yield
+  // 7day SMA annual percentage yield
   apy7d: IPercentage | null
+  // 30day SMA annual percentage yield
+  apy30d: IPercentage | null
 }


### PR DESCRIPTION
Introduce a new calculation for the 30-day simple moving average (SMA) of annual percentage yield (APY) alongside the existing 7-day SMA. Update the data structure to include the new 30-day SMA APY field.