### PR TITLE
Enhance Modal component with Suspense and loading spinner for improved user experience

### DIFF
--- a/packages/app-earn-ui/src/components/atoms/Modal/Modal.tsx
+++ b/packages/app-earn-ui/src/components/atoms/Modal/Modal.tsx
@@ -1,8 +1,9 @@
 'use client'
-import { type FC, type ReactNode, useEffect, useRef } from 'react'
+import { type FC, type ReactNode, Suspense, useEffect, useRef } from 'react'
 
 import { Button } from '@/components/atoms/Button/Button.tsx'
 import { Icon } from '@/components/atoms/Icon/Icon.tsx'
+import { LoadingSpinner } from '@/components/molecules/LoadingSpinner/LoadingSpinner'
 
 import modalStyles from '@/components/atoms/Modal/Modal.module.scss'
 
@@ -53,7 +54,7 @@ export const Modal: FC<ModalProps> = ({
   return (
     <dialog ref={ref} onCancel={closeModal} className={modalStyles.dialog}>
       <div id="modal-portal" style={{ position: 'absolute' }} />
-      {children}
+      <Suspense fallback={<LoadingSpinner size={40} />}>{openModal ? children : null}</Suspense>
       {withCloseButton && (
         <Button variant="unstyled" onClick={closeModal} className={modalStyles.closeButton}>
           <Icon iconName="close" variant="xs" color="var(--earn-protocol-secondary-40)" />


### PR DESCRIPTION
This pull request includes changes to the `Modal` component in the `packages/app-earn-ui` directory. The main updates involve adding a loading spinner and using the `Suspense` component to handle loading states.

Improvements to the `Modal` component:

* [`packages/app-earn-ui/src/components/atoms/Modal/Modal.tsx`](diffhunk://#diff-88e77534173737a8311d3001a83d5df15fbac64948fcdc2f2a3e9bcac43f323fL2-R6): Added `Suspense` and `LoadingSpinner` to manage loading states within the `Modal` component. [[1]](diffhunk://#diff-88e77534173737a8311d3001a83d5df15fbac64948fcdc2f2a3e9bcac43f323fL2-R6) [[2]](diffhunk://#diff-88e77534173737a8311d3001a83d5df15fbac64948fcdc2f2a3e9bcac43f323fL56-R57)