### PR TITLE
Performance chart global timeframe handling

### DIFF
--- a/apps/earn-protocol/components/organisms/Charts/ArkHistoricalYieldChart.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/ArkHistoricalYieldChart.tsx
@@ -7,7 +7,7 @@ import { type ArksHistoricalChartData, type TimeframesType } from '@summerfi/app
 import { ChartHeader } from '@/components/organisms/Charts/ChartHeader'
 import { NotEnoughData } from '@/components/organisms/Charts/components/NotEnoughData'
 import { YieldsChart } from '@/components/organisms/Charts/components/Yields'
-import { DAYS_TO_WAIT_FOR_CHART, POINTS_REQUIRED_FOR_CHART } from '@/constants/charts'
+import { POINTS_REQUIRED_FOR_CHART } from '@/constants/charts'
 import { useTimeframes } from '@/hooks/use-timeframes'
 
 type ArkHistoricalYieldChartProps = {
@@ -58,7 +58,9 @@ export const ArkHistoricalYieldChart = ({
         position: 'relative',
       }}
     >
-      {!parsedDataWithCutoff.length && <NotEnoughData daysToWait={DAYS_TO_WAIT_FOR_CHART} />}
+      {!parsedDataWithCutoff.length && (
+        <NotEnoughData daysToWait={POINTS_REQUIRED_FOR_CHART[timeframe]} />
+      )}
       <ChartHeader
         timeframes={timeframes}
         checkboxValue={compare}

--- a/apps/earn-protocol/components/organisms/Charts/PositionHistoricalChart.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/PositionHistoricalChart.tsx
@@ -6,6 +6,7 @@ import {
   type HistoryChartData,
   type IArmadaPosition,
   type SDKVaultishType,
+  type TimeframesType,
   type TokenSymbolsList,
 } from '@summerfi/app-types'
 
@@ -19,6 +20,7 @@ export type PositionHistoricalChartProps = {
     position: IArmadaPosition
     vault: SDKVaultishType
   }
+  timeframe?: TimeframesType
 }
 
 import classNames from './PositionHistoricalChart.module.scss'
@@ -27,8 +29,9 @@ export const PositionHistoricalChart = ({
   chartData,
   tokenSymbol,
   position,
+  timeframe,
 }: PositionHistoricalChartProps) => {
-  const staticTimeframe = '7d'
+  const defaultTimeframe = '7d'
 
   const parsedData = useMemo(() => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -36,10 +39,10 @@ export const PositionHistoricalChart = ({
       return []
     }
 
-    return chartData.data[staticTimeframe]
-  }, [chartData])
+    return chartData.data[timeframe ?? defaultTimeframe]
+  }, [chartData, timeframe])
 
-  const chartHidden = parsedData.length < POINTS_REQUIRED_FOR_CHART[staticTimeframe]
+  const chartHidden = parsedData.length < POINTS_REQUIRED_FOR_CHART[timeframe ?? defaultTimeframe]
 
   return (
     <Card
@@ -57,7 +60,7 @@ export const PositionHistoricalChart = ({
       className={classNames.positionHistoricalChartWrapper}
     >
       <HistoricalChart
-        timeframe={staticTimeframe}
+        timeframe={timeframe ?? defaultTimeframe}
         data={parsedData}
         tokenSymbol={tokenSymbol}
         portfolioPosition={position}

--- a/apps/earn-protocol/components/organisms/Charts/components/ChartCross.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/components/ChartCross.tsx
@@ -19,7 +19,7 @@ export const ChartCross = ({
     }
     // taking the active point by active tooltip index (same count as points)
     // kinda hacky, but it works for now, we might revisit that later
-    const { x, y } = formattedGraphicalItems[1].props.points[activeTooltipIndex]
+    const { x, y } = formattedGraphicalItems[0].props.points[activeTooltipIndex]
     const pointProps = { cx: x, cy: y }
 
     return (

--- a/apps/earn-protocol/components/organisms/Charts/components/Historical.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/components/Historical.tsx
@@ -26,7 +26,7 @@ import {
 import { ChartCross } from '@/components/organisms/Charts/components/ChartCross'
 import { HistoricalLegend } from '@/components/organisms/Charts/components/HistoricalLegend'
 import { NotEnoughData } from '@/components/organisms/Charts/components/NotEnoughData'
-import { DAYS_TO_WAIT_FOR_CHART, POINTS_REQUIRED_FOR_CHART } from '@/constants/charts'
+import { POINTS_REQUIRED_FOR_CHART } from '@/constants/charts'
 import { useDeviceType } from '@/contexts/DeviceContext/DeviceContext'
 import { formatChartCryptoValue } from '@/features/forecast/chart-formatters'
 
@@ -68,7 +68,7 @@ export const HistoricalChart = ({
     <RechartResponsiveWrapper height="340px">
       {chartHidden && (
         <NotEnoughData
-          daysToWait={DAYS_TO_WAIT_FOR_CHART}
+          daysToWait={POINTS_REQUIRED_FOR_CHART[timeframe]}
           style={{
             width: '80%',
             backgroundColor: 'var(--color-surface-subtle)',
@@ -113,6 +113,7 @@ export const HistoricalChart = ({
           onMouseLeave={() => {
             setHighlightedData(legendBaseData)
           }}
+          dataKey="netValue"
         >
           <XAxis
             dataKey="timestampParsed"
@@ -138,7 +139,7 @@ export const HistoricalChart = ({
             ]}
             hide={chartHidden}
           />
-          {/* Cursor is needed for the chart cross to work */}
+          {/* Tooltip is needed for the chart cross to work */}
           <Tooltip content={() => null} cursor={false} />
           {!chartHidden ? <Customized component={<ChartCross />} /> : null}
           <Line

--- a/apps/earn-protocol/constants/charts.ts
+++ b/apps/earn-protocol/constants/charts.ts
@@ -5,11 +5,10 @@ export const CHART_TIMESTAMP_FORMAT_SHORT = 'DD MMM YYYY' // used for daily and 
 export const POINTS_REQUIRED_FOR_CHART: {
   [key in TimeframesType]: number
 } = {
-  '7d': 12, // hourly
+  '7d': 1, // hourly
   '30d': 24, // hourly
   '90d': 14, // daily
-  '6m': 30, // daily
-  '1y': 60, // daily
+  '6m': 60, // daily
+  '1y': 120, // daily
   '3y': 360, // weekly
 }
-export const DAYS_TO_WAIT_FOR_CHART = 3

--- a/apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx
@@ -8,6 +8,7 @@ import {
   PortfolioPosition,
   SUMR_CAP,
   Text,
+  Timeframes,
   useLocalConfig,
   useMobileCheck,
   WithArrow,
@@ -31,31 +32,9 @@ import { PortfolioSummerPro } from '@/features/portfolio/components/PortfolioSum
 import { PortfolioVaultsCarousel } from '@/features/portfolio/components/PortfolioVaultsCarousel/PortfolioVaultsCarousel'
 import { type PositionWithVault } from '@/features/portfolio/helpers/merge-position-with-vault'
 import { calculateOverallSumr } from '@/helpers/calculate-overall-sumr'
+import { allTimeframesAvailable, useTimeframes } from '@/hooks/use-timeframes'
 
 import portfolioOverviewStyles from './PortfolioOverview.module.scss'
-
-// const dummyNewsAndUpdatesItems = [
-//   {
-//     title: 'SUMR Market Cap hits 10b',
-//     timestamp: 1729236816761,
-//     link: './',
-//   },
-//   {
-//     title: 'SUMR Market Cap hits 10b',
-//     timestamp: 1729236816762,
-//     link: './',
-//   },
-//   {
-//     title: 'SUMR Market Cap hits 10b',
-//     timestamp: 1729236816763,
-//     link: './',
-//   },
-//   {
-//     title: 'SUMR Market Cap hits 10b',
-//     timestamp: 1729236816764,
-//     link: './',
-//   },
-// ]
 
 const getDatablocks = ({
   totalSummerPortfolioUSD,
@@ -133,6 +112,14 @@ export const PortfolioOverview = ({
     state: { sumrNetApyConfig },
   } = useLocalConfig()
 
+  const {
+    timeframe,
+    setTimeframe,
+    timeframes: _timeframes, // ignored on portfolio, we allow all timeframes
+  } = useTimeframes({
+    chartData: positionsHistoricalChartMap[getUniqueVaultId(positions[0].vault)].data,
+  })
+
   const { deviceType } = useDeviceType()
   const { isMobile, isTablet } = useMobileCheck(deviceType)
 
@@ -186,9 +173,16 @@ export const PortfolioOverview = ({
           </Card>
         ))}
         <Card style={{ flexDirection: 'column' }} variant="cardSecondary">
-          <Text as="h5" variant="h5">
-            Positions
-          </Text>
+          <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+            <Text as="h5" variant="h5">
+              Positions
+            </Text>
+            <Timeframes
+              timeframes={allTimeframesAvailable}
+              setActiveTimeframe={setTimeframe}
+              activeTimeframe={timeframe}
+            />
+          </div>
           {positions.length > 0 ? (
             positions.map((position) => (
               <PortfolioPosition
@@ -199,6 +193,7 @@ export const PortfolioOverview = ({
                   <PositionHistoricalChart
                     chartData={positionsHistoricalChartMap[getUniqueVaultId(position.vault)]}
                     position={position}
+                    timeframe={timeframe}
                     tokenSymbol={
                       getDisplayToken(position.vault.inputToken.symbol) as TokenSymbolsList
                     }


### PR DESCRIPTION
This pull request includes several changes to the `apps/earn-protocol` components, primarily focusing on improving the handling of timeframes in historical chart data and simplifying the codebase by removing unused constants. The most important changes are summarized below:

### Timeframe Handling Improvements:
* [`apps/earn-protocol/components/organisms/Charts/ArkHistoricalYieldChart.tsx`](diffhunk://#diff-ac22d370a8c0b27a60bc02e64a7ef092a5f3a48c501b861cd4ffbf044b836c29L10-R10): Replaced `DAYS_TO_WAIT_FOR_CHART` with `POINTS_REQUIRED_FOR_CHART` for better handling of chart data based on timeframes. [[1]](diffhunk://#diff-ac22d370a8c0b27a60bc02e64a7ef092a5f3a48c501b861cd4ffbf044b836c29L10-R10) [[2]](diffhunk://#diff-ac22d370a8c0b27a60bc02e64a7ef092a5f3a48c501b861cd4ffbf044b836c29L61-R63)
* [`apps/earn-protocol/components/organisms/Charts/PositionHistoricalChart.tsx`](diffhunk://#diff-519d3fe15069f57a8a0714fb605a33b8081c378789634f212f146fecc062e4aeR9): Added `timeframe` as an optional prop and updated the chart data parsing logic to use the provided timeframe or a default value. [[1]](diffhunk://#diff-519d3fe15069f57a8a0714fb605a33b8081c378789634f212f146fecc062e4aeR9) [[2]](diffhunk://#diff-519d3fe15069f57a8a0714fb605a33b8081c378789634f212f146fecc062e4aeR23) [[3]](diffhunk://#diff-519d3fe15069f57a8a0714fb605a33b8081c378789634f212f146fecc062e4aeR32-R45) [[4]](diffhunk://#diff-519d3fe15069f57a8a0714fb605a33b8081c378789634f212f146fecc062e4aeL60-R63)
* [`apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx`](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R11): Integrated timeframes into the portfolio overview, allowing users to select different timeframes for position charts. [[1]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R11) [[2]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R35-L59) [[3]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R115-R122) [[4]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R176-R185) [[5]](diffhunk://#diff-6629158d1b9eb8e133681364aca648cf344885a7c7519c861ed3127079336a01R196)

### Codebase Simplification:
* [`apps/earn-protocol/components/organisms/Charts/components/ChartCross.tsx`](diffhunk://#diff-fc13b5528cf8306cf4375ac84ca7c1a7c9919c0bf65c570d64e8b17bb241cb0aL22-R22): Adjusted the index for accessing graphical items to improve chart cross functionality.
* [`apps/earn-protocol/components/organisms/Charts/components/Historical.tsx`](diffhunk://#diff-7fbd1ee22bf6db73f7a5eaaac360499b6743a891881edb52cf52d6e2c61b7b32L29-R29): Simplified the import statements and updated the logic to use `POINTS_REQUIRED_FOR_CHART` instead of `DAYS_TO_WAIT_FOR_CHART`. [[1]](diffhunk://#diff-7fbd1ee22bf6db73f7a5eaaac360499b6743a891881edb52cf52d6e2c61b7b32L29-R29) [[2]](diffhunk://#diff-7fbd1ee22bf6db73f7a5eaaac360499b6743a891881edb52cf52d6e2c61b7b32L71-R71) [[3]](diffhunk://#diff-7fbd1ee22bf6db73f7a5eaaac360499b6743a891881edb52cf52d6e2c61b7b32R116) [[4]](diffhunk://#diff-7fbd1ee22bf6db73f7a5eaaac360499b6743a891881edb52cf52d6e2c61b7b32L141-R142)

### Constants Update:
* [`apps/earn-protocol/constants/charts.ts`](diffhunk://#diff-c3f4b3f13637f9905f903e442de4448504eff10bbb978a5b89d2e8f5b15ddd64L8-L15): Updated the `POINTS_REQUIRED_FOR_CHART` values for different timeframes and removed the `DAYS_TO_WAIT_FOR_CHART` constant.