### PR TITLE
Handle missing config maps gracefully in ArmadaManagerMigrations

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMigrations.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMigrations.ts
@@ -168,13 +168,10 @@ export class ArmadaManagerMigrations implements IArmadaManagerMigrations {
     if (!configMapsPerChain) {
       throw new Error('Unsupported migration type: ' + params.migrationType)
     }
-    const configMaps = configMapsPerChain[params.chainInfo.chainId]
-    if (!configMaps) {
-      return []
-    }
 
     // no configs for this chain
-    if (Object.values(configMaps).length === 0) {
+    const configMaps = configMapsPerChain[params.chainInfo.chainId]
+    if (!configMaps || Object.keys(configMaps).length === 0) {
       return []
     }
 

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMigrations.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMigrations.ts
@@ -170,7 +170,7 @@ export class ArmadaManagerMigrations implements IArmadaManagerMigrations {
     }
     const configMaps = configMapsPerChain[params.chainInfo.chainId]
     if (!configMaps) {
-      throw new Error('No addresses mapping found for chain ' + params.chainInfo.chainId)
+      return []
     }
 
     // no configs for this chain


### PR DESCRIPTION
Return an empty array instead of throwing an error when no config maps are found for a given chain.