### PR TITLE
Handle unsupported Sonic chain gracefully in migrations client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3653,10 +3653,7 @@ importers:
         version: link:../../packages/serverless-shared
       reverse-mirage:
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.7.3)(viem@1.21.4)
-      viem:
-        specifier: ^1.21.4
-        version: 1.21.4(typescript@5.7.3)(zod@3.22.4)
+        version: 1.1.0(typescript@5.7.3)(viem@2.21.55)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -35701,7 +35698,7 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /reverse-mirage@1.1.0(typescript@5.7.3)(viem@1.21.4):
+  /reverse-mirage@1.1.0(typescript@5.7.3)(viem@2.21.55):
     resolution: {integrity: sha512-cA1O7GR0pn4rMFoaiEG7Skms9GenuW91DtCxeR5hphyNhH90eowV4RmUVlVPVS11CPkezm/iUjnCfmxlHri05w==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -35711,7 +35708,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.7.3
-      viem: 1.21.4(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
     dev: false
 
   /rfdc@1.3.1:

--- a/summerfi-api/get-migrations-function/package.json
+++ b/summerfi-api/get-migrations-function/package.json
@@ -14,7 +14,6 @@
     "@oasisdex/addresses": "^0.1.84",
     "@summerfi/serverless-shared": "workspace:*",
     "reverse-mirage": "^1.1.0",
-    "viem": "^1.21.4",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/summerfi-api/get-migrations-function/src/client.ts
+++ b/summerfi-api/get-migrations-function/src/client.ts
@@ -51,8 +51,9 @@ export function createMigrationsClient(
       if (!isChainId(chainId)) {
         throw new Error(`Invalid chainId: ${chainId}`)
       }
-      if (chainId === ChainId.SONIC) {
-        throw new Error('Sonic is not supported yet')
+      // skik unsupported chains
+      if ([ChainId.SONIC].includes(chainId)) {
+        return
       }
       if (customChainId && customChainId !== chainId) {
         return

--- a/summerfi-api/get-migrations-function/src/client.ts
+++ b/summerfi-api/get-migrations-function/src/client.ts
@@ -1,5 +1,5 @@
 import { Chain, createPublicClient, extractChain, getContract, http, HttpTransport } from 'viem'
-import { arbitrum, base, mainnet, optimism, sepolia } from 'viem/chains'
+import { arbitrum, base, mainnet, optimism, sepolia, sonic } from 'viem/chains'
 import { aavePoolContract } from './abi/aavePoolContract'
 import { decodeBitmapToAssetsAddresses } from './decodeBitmapToAssetsAddresses'
 import { aavePoolDataProviderContract } from './abi/aavePoolDataProviderContract'
@@ -59,7 +59,7 @@ export function createMigrationsClient(
         return
       }
       const chain = extractChain({
-        chains: [mainnet, base, optimism, arbitrum, sepolia],
+        chains: [mainnet, base, optimism, arbitrum, sepolia, sonic],
         id: chainId,
       })
 
@@ -131,17 +131,17 @@ async function getAssets(
   const aavePool = getContract({
     address: addressService.getProtocolContract(protocol, 'LendingPool'),
     abi: aavePoolContract.abi,
-    publicClient,
+    client: publicClient,
   })
   const aavePoolDataProvider = getContract({
     address: addressService.getProtocolContract(protocol, 'PoolDataProvider'),
     abi: aavePoolDataProviderContract.abi,
-    publicClient,
+    client: publicClient,
   })
   const aaveOracle = getContract({
     address: addressService.getProtocolContract(protocol, 'Oracle'),
     abi: aaveOracleContract.abi,
-    publicClient,
+    client: publicClient,
   })
 
   // read getReservesList


### PR DESCRIPTION
Modify the migrations client to gracefully handle unsupported Sonic chain by returning early instead of throwing an error and breaking the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of unsupported chain IDs to prevent unexpected interruptions. The system now exits gracefully when encountering unsupported chains, ensuring a more stable and continuous experience. Existing integrations remain unaffected by this improvement.
- **Chores**
	- Removed dependency on the `viem` library from the project, streamlining the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->