### PR TITLE
fix: fix latest rate in reward rates

### DIFF
--- a/summerfi-api/get-rates-function/src/db-service.ts
+++ b/summerfi-api/get-rates-function/src/db-service.ts
@@ -221,9 +221,22 @@ export class RatesService {
           .where('network', '=', network)
           .where('productId', '=', productId)
           .orderBy('timestamp', 'desc')
-          .limit(1)
+          .limit(100)
           .execute(),
       ])
+
+      // Sum rates with same timestamp
+      const summedLatestRate = latestRate.reduce(
+        (acc, rate) => {
+          if (!acc.length) return [rate]
+          if (acc[0].timestamp === rate.timestamp) {
+            acc[0].rate = (Number(acc[0].rate) + Number(rate.rate)).toString()
+            return acc
+          }
+          return acc
+        },
+        [] as typeof latestRate,
+      )
 
       return {
         dailyRates: dailyRates.map((rate) => ({
@@ -242,14 +255,14 @@ export class RatesService {
           date: rate.date.toString(),
         })),
         latestRate:
-          latestRate.length > 0
+          summedLatestRate.length > 0
             ? [
                 {
                   rate: [
                     {
-                      id: latestRate[0].id,
-                      rate: latestRate[0].rate.toString(),
-                      timestamp: latestRate[0].timestamp.toString(),
+                      id: summedLatestRate[0].id,
+                      rate: summedLatestRate[0].rate.toString(),
+                      timestamp: summedLatestRate[0].timestamp.toString(),
                     },
                   ],
                 },


### PR DESCRIPTION
# Fix Rate Summation in Historical Rates Query

## Description
This PR fixes rate aggregation in the historical rates endpoint by implementing rate summation for entries with the same timestamp in the latest rate query, similar to other rate endpoints.

## Changes
- Modified `getHistoricalRates` function to fetch more latest rates (limit 100)
- Added rate summation logic for latest rates with identical timestamps
- Maintained existing aggregation for daily, weekly, and hourly rates

## Benefits
- Consistent rate calculation across all endpoints
- More accurate latest rate representation
- Prevents rate splitting across multiple entries

## Testing
1. Query historical rates for a product with multiple reward sources
2. Verify latest rate shows combined value for same timestamp
3. Confirm daily/weekly/hourly rates remain unchanged
4. Compare results with getLatestRates endpoint for consistency

## Next Steps
- Monitor performance impact of increased query limit
- Consider adding metrics for rate summation frequency

## Additional Notes
- Only latest rates are affected by this change
- Daily, weekly, and hourly rates already handle aggregation correctly
- Query limit increased to 100 to ensure all rates at same timestamp are captured

Please review the rate summation logic and verify the aggregation behavior matches other endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the historical data view to include a broader set of recent rate entries.
  - Aggregated results with matching timestamps for a more comprehensive and consolidated display.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->