### PR TITLE
Refactor Next.js configuration for phase-based webpack externals

### DIFF
--- a/apps/earn-protocol-landing-page/next.config.ts
+++ b/apps/earn-protocol-landing-page/next.config.ts
@@ -1,4 +1,5 @@
-import type { NextConfig, Redirect } from 'next'
+import type { NextConfig } from 'next'
+import { PHASE_DEVELOPMENT_SERVER } from 'next/dist/shared/lib/constants'
 
 const redirectToProSummer = (pathname: string) => ({
   source: pathname,
@@ -7,21 +8,20 @@ const redirectToProSummer = (pathname: string) => ({
   permanent: true,
 })
 
-const nextConfig: NextConfig = {
+const nextConfig: (phase: string) => NextConfig = (phase) => ({
   devIndicators: {
     position: 'bottom-right',
   },
-  experimental: {
-    turbo: {},
-  },
   output: 'standalone',
   reactStrictMode: false,
-  webpack: (config) => {
-    return {
-      ...config,
-      externals: [...config.externals, 'pino-pretty', 'encoding'],
-    }
-  },
+  ...(phase !== PHASE_DEVELOPMENT_SERVER
+    ? {
+        webpack: (config) => ({
+          ...config,
+          externals: [...config.externals, 'pino-pretty', 'encoding'],
+        }),
+      }
+    : {}),
   sassOptions: {
     prependData: `
         @import './node_modules/include-media/dist/_include-media.scss';
@@ -50,6 +50,6 @@ const nextConfig: NextConfig = {
       redirectToProSummer('/:makerPosition(\\d{1,})'),
     ])
   },
-}
+})
 
 export default nextConfig

--- a/apps/earn-protocol/next.config.ts
+++ b/apps/earn-protocol/next.config.ts
@@ -1,4 +1,5 @@
-import type { NextConfig, Redirect } from 'next'
+import type { NextConfig } from 'next'
+import { PHASE_DEVELOPMENT_SERVER } from 'next/dist/shared/lib/constants'
 
 const redirectToProSummer = (pathname: string) => ({
   source: pathname,
@@ -7,22 +8,21 @@ const redirectToProSummer = (pathname: string) => ({
   permanent: true,
 })
 
-const nextConfig: NextConfig = {
+const nextConfig: (phase: string) => NextConfig = (phase) => ({
   devIndicators: {
     position: 'bottom-right',
-  },
-  experimental: {
-    turbo: {},
   },
   basePath: '/earn',
   output: 'standalone',
   reactStrictMode: false,
-  webpack: (config) => {
-    return {
-      ...config,
-      externals: [...config.externals, 'pino-pretty', 'encoding'],
-    }
-  },
+  ...(phase !== PHASE_DEVELOPMENT_SERVER
+    ? {
+        webpack: (config) => ({
+          ...config,
+          externals: [...config.externals, 'pino-pretty', 'encoding'],
+        }),
+      }
+    : {}),
   sassOptions: {
     prependData: `
         @import './node_modules/include-media/dist/_include-media.scss';
@@ -85,6 +85,6 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-}
+})
 
 export default nextConfig


### PR DESCRIPTION
Update the Next.js configuration to support phase-based webpack externals, enhancing the build process for different environments. This change ensures that externals are only applied outside the development phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the system configuration to dynamically adjust settings based on the environment, ensuring smoother transitions between development and production.
  
- **Refactor**
  - Simplified and streamlined the configuration logic for improved maintainability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->