### PR TITLE
Update Vite to version 6.2.3 across multiple packages

### DIFF
--- a/packages/app-earn-ui/package.json
+++ b/packages/app-earn-ui/package.json
@@ -44,7 +44,7 @@
     "sass": "^1.77.8",
     "tsc-watch": "^6.2.0",
     "typescript": "^5.7.3",
-    "vite": "6.2.0",
+    "vite": "6.2.3",
     "vite-plugin-lib-inject-css": "^2.2.1"
   },
   "peerDependencies": {

--- a/packages/app-icons/package.json
+++ b/packages/app-icons/package.json
@@ -32,7 +32,7 @@
     "glob": "^11.0.0",
     "jest": "29.7.0",
     "typescript": "^5.7.3",
-    "vite": "6.2.0"
+    "vite": "6.2.3"
   },
   "peerDependencies": {
     "@loadable/component": "^5.16.4",

--- a/packages/app-risk/package.json
+++ b/packages/app-risk/package.json
@@ -21,7 +21,7 @@
     "@vitejs/plugin-react-swc": "^3.8.0",
     "eslint": "8.57.0",
     "typescript": "^5.7.3",
-    "vite": "6.2.0",
+    "vite": "6.2.3",
     "vite-plugin-dts": "4.5.3",
     "glob": "^11.0.0"
   },

--- a/packages/app-tos/package.json
+++ b/packages/app-tos/package.json
@@ -32,7 +32,7 @@
     "eslint": "8.57.0",
     "tsc-watch": "^6.2.0",
     "typescript": "^5.7.3",
-    "vite": "6.2.0",
+    "vite": "6.2.3",
     "vite-plugin-dts": "4.5.3",
     "glob": "^11.0.0"
   },

--- a/packages/app-ui/package.json
+++ b/packages/app-ui/package.json
@@ -35,7 +35,7 @@
     "jest": "29.7.0",
     "sass": "^1.77.8",
     "typescript": "^5.7.3",
-    "vite": "6.2.0",
+    "vite": "6.2.3",
     "vite-plugin-dts": "4.5.3",
     "vite-plugin-lib-inject-css": "^2.2.1"
   },

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -34,7 +34,7 @@
     "vite-plugin-node-polyfills": "^0.23.0",
     "eslint": "8.57.0",
     "typescript": "^5.7.3",
-    "vite": "6.2.0",
+    "vite": "6.2.3",
     "vite-plugin-dts": "4.5.3",
     "glob": "^11.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -936,7 +936,7 @@ importers:
         version: 3.1.0(react@19.0.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.7.3)(vite@6.2.0)
+        version: 4.3.2(typescript@5.7.3)(vite@6.2.3)
     devDependencies:
       '@summerfi/app-icons':
         specifier: workspace:*
@@ -973,7 +973,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
-        version: 3.8.0(vite@6.2.0)
+        version: 3.8.0(vite@6.2.3)
       concurrently:
         specifier: ^9.0.1
         version: 9.0.1
@@ -999,11 +999,11 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.0
-        version: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+        specifier: 6.2.3
+        version: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
       vite-plugin-lib-inject-css:
         specifier: ^2.2.1
-        version: 2.2.1(vite@6.2.0)
+        version: 2.2.1(vite@6.2.3)
 
   packages/app-icons:
     dependencies:
@@ -1018,7 +1018,7 @@ importers:
         version: 8.1.0(@svgr/core@8.1.0)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.0)
+        version: 4.3.4(vite@6.2.3)
       next:
         specifier: 15.2.3
         version: 15.2.3(@babel/core@7.26.0)(react-dom@19.0.0)(react@19.0.0)(sass@1.77.8)
@@ -1030,10 +1030,10 @@ importers:
         version: 19.0.0(react@19.0.0)
       vite-plugin-dts:
         specifier: 4.5.3
-        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.0)
+        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.3)
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(typescript@5.7.3)(vite@6.2.0)
+        version: 4.2.0(typescript@5.7.3)(vite@6.2.3)
     devDependencies:
       '@summerfi/app-types':
         specifier: workspace:*
@@ -1060,8 +1060,8 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.0
-        version: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+        specifier: 6.2.3
+        version: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
 
   packages/app-risk:
     dependencies:
@@ -1082,7 +1082,7 @@ importers:
         version: 1.1.3(rollup@4.34.9)
       vite-tsconfig-paths:
         specifier: ^5.1.3
-        version: 5.1.4(typescript@5.7.3)(vite@6.2.0)
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.3)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1098,7 +1098,7 @@ importers:
         version: 19.0.8
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
-        version: 3.8.0(vite@6.2.0)
+        version: 3.8.0(vite@6.2.3)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1109,11 +1109,11 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.0
-        version: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+        specifier: 6.2.3
+        version: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
       vite-plugin-dts:
         specifier: 4.5.3
-        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.0)
+        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.3)
 
   packages/app-token-config:
     dependencies:
@@ -1149,7 +1149,7 @@ importers:
         version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
       vite-tsconfig-paths:
         specifier: ^5.1.3
-        version: 5.1.4(typescript@5.7.3)(vite@6.2.0)
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.3)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1171,7 +1171,7 @@ importers:
         version: 19.0.8
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
-        version: 3.8.0(vite@6.2.0)
+        version: 3.8.0(vite@6.2.3)
       concurrently:
         specifier: ^9.0.1
         version: 9.0.1
@@ -1191,14 +1191,14 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.0
-        version: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+        specifier: 6.2.3
+        version: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
       vite-plugin-dts:
         specifier: 4.5.3
-        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.0)
+        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.3)
       vite-plugin-node-polyfills:
         specifier: ^0.23.0
-        version: 0.23.0(rollup@4.34.9)(vite@6.2.0)
+        version: 0.23.0(rollup@4.34.9)(vite@6.2.3)
 
   packages/app-types:
     dependencies:
@@ -1301,7 +1301,7 @@ importers:
         version: 3.1.0(react@19.0.0)
       vite-tsconfig-paths:
         specifier: ^5.1.3
-        version: 5.1.4(typescript@5.7.3)(vite@6.2.0)
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.3)
     devDependencies:
       '@summerfi/app-token-config':
         specifier: workspace:*
@@ -1332,7 +1332,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
-        version: 3.8.0(vite@6.2.0)
+        version: 3.8.0(vite@6.2.3)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1349,14 +1349,14 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.0
-        version: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+        specifier: 6.2.3
+        version: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
       vite-plugin-dts:
         specifier: 4.5.3
-        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.0)
+        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.3)
       vite-plugin-lib-inject-css:
         specifier: ^2.2.1
-        version: 2.2.1(vite@6.2.0)
+        version: 2.2.1(vite@6.2.3)
 
   packages/app-utils:
     dependencies:
@@ -1383,7 +1383,7 @@ importers:
         version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
       vite-tsconfig-paths:
         specifier: ^5.1.3
-        version: 5.1.4(typescript@5.7.3)(vite@6.2.0)
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.3)
     devDependencies:
       '@summerfi/app-types':
         specifier: workspace:*
@@ -1407,14 +1407,14 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.0
-        version: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+        specifier: 6.2.3
+        version: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
       vite-plugin-dts:
         specifier: 4.5.3
-        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.0)
+        version: 4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.3)
       vite-plugin-node-polyfills:
         specifier: ^0.23.0
-        version: 0.23.0(rollup@4.34.9)(vite@6.2.0)
+        version: 0.23.0(rollup@4.34.9)(vite@6.2.3)
 
   packages/automation-subgraph:
     dependencies:
@@ -16045,27 +16045,11 @@ packages:
       picomatch: 4.0.2
       rollup: 4.34.9
 
-  /@rollup/rollup-android-arm-eabi@4.22.4:
-    resolution: {integrity: sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-android-arm-eabi@4.34.9:
     resolution: {integrity: sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.22.4:
-    resolution: {integrity: sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-android-arm64@4.34.9:
@@ -16075,27 +16059,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.22.4:
-    resolution: {integrity: sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-darwin-arm64@4.34.9:
     resolution: {integrity: sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.22.4:
-    resolution: {integrity: sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-x64@4.34.9:
@@ -16119,27 +16087,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.22.4:
-    resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-arm-gnueabihf@4.34.9:
     resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-arm-musleabihf@4.22.4:
-    resolution: {integrity: sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.34.9:
@@ -16149,27 +16101,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.22.4:
-    resolution: {integrity: sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-arm64-gnu@4.34.9:
     resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-musl@4.22.4:
-    resolution: {integrity: sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.34.9:
@@ -16186,27 +16122,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.22.4:
-    resolution: {integrity: sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-powerpc64le-gnu@4.34.9:
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.22.4:
-    resolution: {integrity: sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.34.9:
@@ -16216,27 +16136,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.22.4:
-    resolution: {integrity: sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-s390x-gnu@4.34.9:
     resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-gnu@4.22.4:
-    resolution: {integrity: sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.34.9:
@@ -16246,27 +16150,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.22.4:
-    resolution: {integrity: sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-x64-musl@4.34.9:
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-win32-arm64-msvc@4.22.4:
-    resolution: {integrity: sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.34.9:
@@ -16276,27 +16164,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.22.4:
-    resolution: {integrity: sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-win32-ia32-msvc@4.34.9:
     resolution: {integrity: sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.22.4:
-    resolution: {integrity: sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.34.9:
@@ -18143,7 +18015,7 @@ packages:
   /@swc/helpers@0.5.15:
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.1
     dev: false
 
   /@swc/types@0.1.19:
@@ -19860,18 +19732,18 @@ packages:
       - vitest
     dev: true
 
-  /@vitejs/plugin-react-swc@3.8.0(vite@6.2.0):
+  /@vitejs/plugin-react-swc@3.8.0(vite@6.2.3):
     resolution: {integrity: sha512-T4sHPvS+DIqDP51ifPqa9XIRAz/kIvIi8oXcnOZZgHmMotgmmdxe/DD5tMFlt5nuIRzT0/QuiwmKlH0503Aapw==}
     peerDependencies:
       vite: ^4 || ^5 || ^6
     dependencies:
       '@swc/core': 1.11.5
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@vitejs/plugin-react@4.3.4(vite@6.2.0):
+  /@vitejs/plugin-react@4.3.4(vite@6.2.3):
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -19882,7 +19754,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -23689,6 +23561,10 @@ packages:
 
   /blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+
+  /bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+    dev: true
 
   /bn.js@4.11.8:
     resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
@@ -27617,7 +27493,7 @@ packages:
     resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.11.6
       number-to-bn: 1.7.0
     dev: true
 
@@ -33257,7 +33133,7 @@ packages:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.11.6
       strip-hex-prefix: 1.0.0
     dev: true
 
@@ -35916,32 +35792,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: false
-
-  /rollup@4.22.4:
-    resolution: {integrity: sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.22.4
-      '@rollup/rollup-android-arm64': 4.22.4
-      '@rollup/rollup-darwin-arm64': 4.22.4
-      '@rollup/rollup-darwin-x64': 4.22.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.22.4
-      '@rollup/rollup-linux-arm-musleabihf': 4.22.4
-      '@rollup/rollup-linux-arm64-gnu': 4.22.4
-      '@rollup/rollup-linux-arm64-musl': 4.22.4
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.22.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.22.4
-      '@rollup/rollup-linux-s390x-gnu': 4.22.4
-      '@rollup/rollup-linux-x64-gnu': 4.22.4
-      '@rollup/rollup-linux-x64-musl': 4.22.4
-      '@rollup/rollup-win32-arm64-msvc': 4.22.4
-      '@rollup/rollup-win32-ia32-msvc': 4.22.4
-      '@rollup/rollup-win32-x64-msvc': 4.22.4
-      fsevents: 2.3.3
-    dev: true
 
   /rollup@4.34.9:
     resolution: {integrity: sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==}
@@ -39053,7 +38903,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.0):
+  /vite-plugin-dts@4.5.3(@types/node@20.12.7)(rollup@4.34.9)(typescript@5.7.3)(vite@6.2.3):
     resolution: {integrity: sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==}
     peerDependencies:
       typescript: '*'
@@ -39072,13 +38922,13 @@ packages:
       local-pkg: 1.1.1
       magic-string: 0.30.17
       typescript: 5.7.3
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  /vite-plugin-lib-inject-css@2.2.1(vite@6.2.0):
+  /vite-plugin-lib-inject-css@2.2.1(vite@6.2.3):
     resolution: {integrity: sha512-PW3n/zRacr7bwNagHOnJfaVLoZyGDCPuFMJTyTFqjk4Xi0HKd1cK5+WlBidBBeWK8QE3SV0i+FsWmN+frBLCVQ==}
     peerDependencies:
       vite: '*'
@@ -39086,22 +38936,22 @@ packages:
       '@ast-grep/napi': 0.32.3
       magic-string: 0.30.17
       picocolors: 1.1.1
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     dev: true
 
-  /vite-plugin-node-polyfills@0.23.0(rollup@4.34.9)(vite@6.2.0):
+  /vite-plugin-node-polyfills@0.23.0(rollup@4.34.9)(vite@6.2.3):
     resolution: {integrity: sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.34.9)
       node-stdlib-browser: 1.2.0
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - rollup
     dev: true
 
-  /vite-plugin-svgr@4.2.0(typescript@5.7.3)(vite@6.2.0):
+  /vite-plugin-svgr@4.2.0(typescript@5.7.3)(vite@6.2.3):
     resolution: {integrity: sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==}
     peerDependencies:
       vite: ^2.6.0 || 3 || 4 || 5
@@ -39109,14 +38959,14 @@ packages:
       '@rollup/pluginutils': 5.1.0(rollup@4.34.9)
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
     dev: false
 
-  /vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@6.2.0):
+  /vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@6.2.3):
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
       vite: '*'
@@ -39127,13 +38977,13 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.7.3)
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.2.0):
+  /vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.2.3):
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
       vite: '*'
@@ -39144,7 +38994,7 @@ packages:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.7.3)
-      vite: 6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
+      vite: 6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -39183,14 +39033,14 @@ packages:
     dependencies:
       '@types/node': 20.14.2
       esbuild: 0.21.5
-      postcss: 8.4.47
-      rollup: 4.22.4
+      postcss: 8.5.3
+      rollup: 4.34.9
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vite@6.2.0(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5):
-    resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
+  /vite@6.2.3(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5):
+    resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
Upgrade Vite dependency to version 6.2.3 in various packages to ensure compatibility and access to the latest features and fixes.