### PR TITLE
Fix oracle spot price backend logic

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -676,7 +676,6 @@ export class ArmadaManager implements IArmadaManager {
     const shouldSwap = !swapFromAmount.token.address.equals(fleetToken.address)
     const shouldStake = params.shouldStake ?? true
 
-    let swapMinAmount: ITokenAmount | undefined
     let swapToAmount: ITokenAmount | undefined
     const transactions: ExtendedTransactionInfo[] = []
 
@@ -735,7 +734,6 @@ export class ArmadaManager implements IArmadaManager {
       )
 
       swapToAmount = swapCall.toAmount
-      swapMinAmount = swapCall.minAmount
     }
 
     // when staking admirals quarters will receive LV tokens, otherwise the user

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -1432,7 +1432,7 @@ export class ArmadaManager implements IArmadaManager {
 
     const spotPrice = await this._oracleManager.getSpotPrice({
       baseToken: params.fromAmount.token,
-      quoteToken: params.toAmount.token,
+      denomination: params.toAmount.token,
     })
 
     const impact =

--- a/sdk/oracle-common/src/interfaces/IOracleManager.ts
+++ b/sdk/oracle-common/src/interfaces/IOracleManager.ts
@@ -12,9 +12,14 @@ export interface IOracleManager extends IManagerWithProviders<OracleProviderType
    * @description Returns the prevailing market price for a given asset
    *              in terms of a base currency
    * @param baseToken Token for which the price is being requested
-   * @param quoteToken Token in which the price is being requested, defaults to USD
+   * @param denomination Token in which the price is being requested, defaults to USD
+   * @param forceUseProvider Optional provider to force the use of
    */
-  getSpotPrice(params: { baseToken: IToken; quoteToken?: Denomination }): Promise<SpotPriceInfo>
+  getSpotPrice(params: {
+    baseToken: IToken
+    denomination?: Denomination
+    forceUseProvider?: OracleProviderType
+  }): Promise<SpotPriceInfo>
 
   /**
    * @name getSpotPrices
@@ -22,10 +27,12 @@ export interface IOracleManager extends IManagerWithProviders<OracleProviderType
    *              in terms of a base currency
    * @param baseToken A price request for baseToken
    * @param quoteTokens A price request for multiple quoteTokens
+   * @param forceUseProvider Optional provider to force the use of
    */
   getSpotPrices(params: {
     chainInfo: IChainInfo
     baseTokens: IToken[]
     quoteCurrency?: FiatCurrency
+    forceUseProvider?: OracleProviderType
   }): Promise<SpotPricesInfo>
 }

--- a/sdk/oracle-service/src/implementation/OracleManager.ts
+++ b/sdk/oracle-service/src/implementation/OracleManager.ts
@@ -24,15 +24,13 @@ export class OracleManager
   }
 
   /** @see IOracleManager.getSpotPrice */
-  async getSpotPrice(params: {
-    baseToken: IToken
-    quoteToken?: Denomination
-    forceUseProvider?: OracleProviderType
-  }): Promise<SpotPriceInfo> {
+  async getSpotPrice(
+    params: Parameters<IOracleManager['getSpotPrice']>[0],
+  ): ReturnType<IOracleManager['getSpotPrice']> {
     if (
-      params.quoteToken &&
-      isToken(params.quoteToken) &&
-      !params.baseToken.chainInfo.equals(params.quoteToken.chainInfo)
+      params.denomination &&
+      isToken(params.denomination) &&
+      !params.baseToken.chainInfo.equals(params.denomination.chainInfo)
     ) {
       throw new Error('Base token and quote token must be on the same chain')
     }

--- a/sdk/oracle-service/src/implementation/coingecko/CoingeckoOracleProvider.ts
+++ b/sdk/oracle-service/src/implementation/coingecko/CoingeckoOracleProvider.ts
@@ -140,7 +140,7 @@ export class CoingeckoOracleProvider
         const errorType = this._parseErrorType(errorJSON)
 
         throw Error(
-          `Error performing 1inch spot price request: ${JSON.stringify({
+          `Error performing coingecko spot price request: ${JSON.stringify({
             apiQuery: spotUrl,
             statusCode: response.status,
             json: errorJSON,
@@ -158,7 +158,7 @@ export class CoingeckoOracleProvider
       }
 
       return {
-        provider: OracleProviderType.OneInch,
+        provider: OracleProviderType.Coingecko,
         token: baseToken,
         price: Price.createFrom({
           value: price.toString(),

--- a/sdk/oracle-service/src/implementation/oneinch/OneInchOracleProvider.ts
+++ b/sdk/oracle-service/src/implementation/oneinch/OneInchOracleProvider.ts
@@ -103,7 +103,6 @@ export class OneInchOracleProvider
       }
 
       const value = BigNumber(baseUSDPrice).div(quoteUSDPrice).toString()
-      console.log('value', value)
 
       return {
         provider: OracleProviderType.OneInch,

--- a/sdk/oracle-service/src/implementation/oneinch/OneInchOracleProvider.ts
+++ b/sdk/oracle-service/src/implementation/oneinch/OneInchOracleProvider.ts
@@ -7,10 +7,8 @@ import {
   IAddress,
   IChainInfo,
   SwapErrorType,
-  isTokenAmount,
   ChainId,
   Price,
-  isFiatCurrencyAmount,
   isToken,
   LoggingService,
 } from '@summerfi/sdk-common'

--- a/sdk/oracle-service/src/implementation/oneinch/Types.ts
+++ b/sdk/oracle-service/src/implementation/oneinch/Types.ts
@@ -1,2 +1,2 @@
 /** 1Inch spot price response */
-export type OneInchSpotResponse = Record<string, number>
+export type OneInchSpotResponse = Record<string, string>

--- a/sdk/oracle-service/tests/OracleManager.spec.ts
+++ b/sdk/oracle-service/tests/OracleManager.spec.ts
@@ -31,7 +31,7 @@ describe('OracleManager', () => {
   it('should fetch spot price', async () => {
     const wethSpotPrice = await oracleManager.getSpotPrice({
       baseToken: WETH,
-      quoteToken: FiatCurrency.USD,
+      denomination: FiatCurrency.USD,
     })
 
     expect(wethSpotPrice).toBeDefined()

--- a/sdk/oracle-service/tests/mocks/MockOracleProvider.ts
+++ b/sdk/oracle-service/tests/mocks/MockOracleProvider.ts
@@ -29,7 +29,7 @@ export class MockOracleProvider
 
   async getSpotPrice(params: {
     baseToken: IToken
-    quoteToken?: Denomination
+    denomination?: Denomination
   }): Promise<SpotPriceInfo> {
     return {
       provider: this.type,

--- a/sdk/simulator-service/src/implementation/utils/EstimateSwapFromAmount.ts
+++ b/sdk/simulator-service/src/implementation/utils/EstimateSwapFromAmount.ts
@@ -34,7 +34,7 @@ export async function estimateSwapFromAmount(params: {
   const spotPriceSourceToken = (
     await params.oracleManager.getSpotPrice({
       baseToken: params.fromToken,
-      quoteToken: receiveAtLeast.token,
+      denomination: receiveAtLeast.token,
     })
   ).price
 

--- a/sdk/simulator-service/src/implementation/utils/GetSwapStepData.ts
+++ b/sdk/simulator-service/src/implementation/utils/GetSwapStepData.ts
@@ -38,7 +38,7 @@ export async function getSwapStepData(params: {
     }),
     params.oracleManager.getSpotPrice({
       baseToken: params.toToken,
-      quoteToken: params.fromAmount.token,
+      denomination: params.fromAmount.token,
     }),
   ])
 

--- a/sdk/simulator-service/tests/mocks/contextMock.ts
+++ b/sdk/simulator-service/tests/mocks/contextMock.ts
@@ -53,7 +53,7 @@ async function getSwapQuoteExactInput(params: { fromAmount: TokenAmount; toToken
 
 async function getSpotPrice(params: {
   baseToken: IToken
-  quoteToken?: Denomination
+  denomination?: Denomination
 }): Promise<SpotPriceInfo> {
   const MOCK_PRICE = 0.5
   const MOCK_QUOTE_CURRENCY = FiatCurrency.USD
@@ -63,7 +63,7 @@ async function getSpotPrice(params: {
     price: Price.createFrom({
       value: MOCK_PRICE.toString(),
       base: params.baseToken,
-      quote: params.quoteToken || MOCK_QUOTE_CURRENCY,
+      quote: params.denomination || MOCK_QUOTE_CURRENCY,
     }),
   }
 }


### PR DESCRIPTION
Update the backend logic for fetching spot prices to use a consistent parameter naming convention, replacing `quoteToken` with `denomination`. This change improves clarity and ensures compatibility with the updated data structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined asset pricing retrieval for greater consistency and clarity.
  - Enhanced flexibility for selecting price data sources and improved error reporting.
  - Updated parameter naming conventions from `quoteToken` to `denomination` for better clarity in pricing methods.

- **Tests**
  - Updated test cases to align with the refined pricing logic, reflecting the new parameter naming.

- **Chores**
  - Adjusted type definitions to ensure uniformity across pricing responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->