### PR TITLE
Update dependencies to version 4.24.0 and viem to 2.26.1 across multiple packages

### DIFF
--- a/apps/earn-protocol/account-kit/config.ts
+++ b/apps/earn-protocol/account-kit/config.ts
@@ -1,20 +1,11 @@
-import { alchemy, arbitrum, base, mainnet, optimism } from '@account-kit/infra'
+import { alchemy, arbitrum, base, mainnet, optimism, sonic } from '@account-kit/infra'
 import { type AlchemyAccountsUIConfig, cookieStorage, createConfig } from '@account-kit/react'
 import { SDKChainId, SDKSupportedNetworkIdsEnum } from '@summerfi/app-types'
 import { QueryClient } from '@tanstack/react-query'
 import { type Chain } from 'viem'
-import { sonic } from 'viem/chains'
 import { safe } from 'wagmi/connectors'
 
 export const queryClient = new QueryClient()
-
-const customAAKitSonicConfig: Chain = {
-  ...sonic,
-  rpcUrls: {
-    ...sonic.rpcUrls,
-    alchemy: sonic.rpcUrls.default,
-  },
-}
 
 export type AccountKitSupportedNetworks =
   | SDKChainId.BASE
@@ -84,7 +75,7 @@ export const getAccountKitConfig = ({
         [SDKSupportedNetworkIdsEnum.BASE]: base,
         [SDKSupportedNetworkIdsEnum.MAINNET]: mainnet,
         [SDKSupportedNetworkIdsEnum.OPTIMISM]: optimism,
-        [SDKSupportedNetworkIdsEnum.SONIC]: customAAKitSonicConfig,
+        [SDKSupportedNetworkIdsEnum.SONIC]: sonic,
       }[chainId ?? defaultChain.id] as Chain,
       chains: Object.values(SDKChainIdToAAChainMap).map((chain) => ({
         chain,

--- a/apps/earn-protocol/helpers/sdk-network-to-aa-chain.ts
+++ b/apps/earn-protocol/helpers/sdk-network-to-aa-chain.ts
@@ -1,13 +1,9 @@
-import { arbitrum, base, mainnet } from '@account-kit/infra'
+import { arbitrum, base, mainnet, sonic } from '@account-kit/infra'
 import { SDKNetwork, type SDKSupportedNetwork, sdkSupportedNetworks } from '@summerfi/app-types'
 import { type Chain } from 'viem'
-import { sonic } from 'viem/chains'
 
 /**
  * Converts a SDKNetwork to an AccountKit Chain
- * IMPORTANT: SONIC is currently not reexported from @account-kit/infra, so we need to import it from viem
- * ALSO AccountKit usually uses different viem version internally, so we use chains directly from viem to
- * perform some AA logic (i.e. setChain) it may not work as expected
  * @param network - The SDKNetwork to convert
  * @returns The AccountKit Chain
  */

--- a/apps/earn-protocol/hooks/use-tokens-balances.ts
+++ b/apps/earn-protocol/hooks/use-tokens-balances.ts
@@ -1,8 +1,7 @@
-import { arbitrum, base, mainnet } from '@account-kit/infra'
+import { arbitrum, base, mainnet, sonic } from '@account-kit/infra'
 import { SDKChainId, SDKNetwork } from '@summerfi/app-types'
 import BigNumber from 'bignumber.js'
 import { createPublicClient, http } from 'viem'
-import { sonic } from 'viem/chains'
 
 import { SDKChainIdToRpcGatewayMap } from '@/constants/networks-list'
 import { supportedNetworkGuard } from '@/helpers/supported-network-guard'

--- a/apps/earn-protocol/hooks/use-update-aa-network.ts
+++ b/apps/earn-protocol/hooks/use-update-aa-network.ts
@@ -1,10 +1,9 @@
 'use client'
 import { useEffect } from 'react'
-import { arbitrum, base, mainnet } from '@account-kit/infra'
+import { arbitrum, base, mainnet, sonic } from '@account-kit/infra'
 import { useChain } from '@account-kit/react'
 import { humanNetworktoSDKNetwork, subgraphNetworkToId } from '@summerfi/app-utils'
 import { useParams } from 'next/navigation'
-import { sonic } from 'viem/chains'
 
 import { NetworkIds } from '@/constants/networks-list'
 import { useClientChainId } from '@/hooks/use-client-chain-id'

--- a/apps/earn-protocol/package.json
+++ b/apps/earn-protocol/package.json
@@ -13,10 +13,10 @@
     "generate": "DOTENV_CONFIG_PATH=../../.env graphql-codegen -r dotenv/config"
   },
   "dependencies": {
-    "@account-kit/core": "^4.15.3",
-    "@account-kit/infra": "^4.15.3",
-    "@account-kit/react": "^4.15.3",
-    "@account-kit/signer": "^4.15.3",
+    "@account-kit/core": "^4.24.0",
+    "@account-kit/infra": "^4.24.0",
+    "@account-kit/react": "^4.24.0",
+    "@account-kit/signer": "^4.24.0",
     "@layerzerolabs/scan-client": "^0.0.8",
     "@loadable/component": "^5.16.4",
     "@safe-global/safe-apps-sdk": "^9.0.0",
@@ -54,7 +54,7 @@
     "sharp": "^0.33.5",
     "uniqolor": "1.1.1",
     "usehooks-ts": "^3.1.0",
-    "viem": "2.21.55",
+    "viem": "2.26.1",
     "wagmi": "^2.10.9",
     "websocket": "^1.0.35"
   },

--- a/packages/app-tos/package.json
+++ b/packages/app-tos/package.json
@@ -34,7 +34,7 @@
     "next": "15.2.3",
     "zod": "^3.22.4",
     "kysely": "^0.27.3",
-    "viem": "2.21.55",
+    "viem": "2.26.1",
     "@safe-global/safe-apps-sdk": "^9.0.0",
     "jose": "^6.0.10",
     "@summerfi/serverless-shared": "workspace:*"

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -47,7 +47,7 @@
     "lodash-es": "^4.17.1",
     "next": "15.2.3",
     "jose": "^6.0.10",
-    "viem": "2.21.55"
+    "viem": "2.26.1"
   },
   "dependencies": {
     "rollup-preserve-directives": "^1.1.3",

--- a/packages/triggers-calculations/package.json
+++ b/packages/triggers-calculations/package.json
@@ -14,7 +14,7 @@
     "@summerfi/serverless-shared": "workspace:*",
     "@summerfi/prices-subgraph": "workspace:*",
     "@summerfi/triggers-shared": "workspace:*",
-    "viem": "2.21.55"
+    "viem": "2.26.1"
   },
   "devDependencies": {
     "@summerfi/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,17 +129,17 @@ importers:
   apps/earn-protocol:
     dependencies:
       '@account-kit/core':
-        specifier: ^4.15.3
-        version: 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(wagmi@2.10.9)
+        specifier: ^4.24.0
+        version: 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(wagmi@2.10.9)
       '@account-kit/infra':
-        specifier: ^4.15.3
-        version: 4.15.3(typescript@5.7.3)(viem@2.21.55)
+        specifier: ^4.24.0
+        version: 4.24.0(typescript@5.7.3)(viem@2.26.1)
       '@account-kit/react':
-        specifier: ^4.15.3
-        version: 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(@wagmi/core@2.13.8)(immer@9.0.21)(react-dom@19.0.0)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(tailwindcss@3.4.13)(typescript@5.7.3)(viem@2.21.55)(wagmi@2.10.9)
+        specifier: ^4.24.0
+        version: 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(@wagmi/core@2.13.8)(immer@9.0.21)(react-dom@19.0.0)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(tailwindcss@3.4.13)(typescript@5.7.3)(viem@2.26.1)(wagmi@2.10.9)
       '@account-kit/signer':
-        specifier: ^4.15.3
-        version: 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)
+        specifier: ^4.24.0
+        version: 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)
       '@layerzerolabs/scan-client':
         specifier: ^0.0.8
         version: 0.0.8(axios@1.7.7)
@@ -252,11 +252,11 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(react@19.0.0)
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       wagmi:
         specifier: ^2.10.9
-        version: 2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
+        version: 2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
       websocket:
         specifier: ^1.0.35
         version: 1.0.35
@@ -1155,8 +1155,8 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3(rollup@4.34.9)
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       vite-tsconfig-paths:
         specifier: ^5.1.3
         version: 5.1.4(typescript@5.7.3)(vite@6.2.3)
@@ -1383,8 +1383,8 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3(rollup@4.34.9)
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       vite-tsconfig-paths:
         specifier: ^5.1.3
         version: 5.1.4(typescript@5.7.3)(vite@6.2.3)
@@ -2022,8 +2022,8 @@ importers:
         specifier: workspace:*
         version: link:../triggers-shared
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     devDependencies:
       '@summerfi/eslint-config':
         specifier: workspace:*
@@ -2912,8 +2912,8 @@ importers:
         specifier: ^1.13.3
         version: 1.13.3
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -3657,8 +3657,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(typescript@5.7.3)(zod@3.22.4)
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -4007,8 +4007,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/triggers-shared
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -4149,8 +4149,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       viem:
-        specifier: 2.21.55
-        version: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+        specifier: 2.26.1
+        version: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -4191,14 +4191,14 @@ importers:
 
 packages:
 
-  /@aa-sdk/core@4.15.3(typescript@5.7.3)(viem@2.21.55):
-    resolution: {integrity: sha512-wArC+TCv7pyp9LN9ijRS06qXP5i1oJK4fsrrru0Icd8ntWdvAtHL9P0RMdpwj+pcG9Yry1uSzRAVbaHynjfUkw==}
+  /@aa-sdk/core@4.24.0(typescript@5.7.3)(viem@2.26.1):
+    resolution: {integrity: sha512-RuPezEEeUUdxGEIpJgDaaKoKckiU/KIc9C0ALj/JM6FQXM5krV7/sf5t7/Gqrzeg74taWS1cZEsE6QpQQyo2gw==}
     peerDependencies:
       viem: ^2.22.6
     dependencies:
       abitype: 0.8.7(typescript@5.7.3)(zod@3.22.4)
       eventemitter3: 5.0.1
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod: 3.22.4
     transitivePeerDependencies:
       - typescript
@@ -4209,20 +4209,20 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@account-kit/core@4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(wagmi@2.10.9):
-    resolution: {integrity: sha512-w7Sa8yQi0yUpVafhjzoInTHiAhjf7UnRQMBrpgcLmYThYbk/1CP6koHXSSCqDfB5Qp8QHKwETZ9UWXjzcsRlZA==}
+  /@account-kit/core@4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(wagmi@2.10.9):
+    resolution: {integrity: sha512-DQglsjZZelJgTTCtXpxvYhryQgaRprrlyRNwiC85Ct1dNsxs5X5xw98+xLYRcNCR+v8NHBlRpLwm//PsARLuLA==}
     peerDependencies:
       viem: ^2.22.6
       wagmi: ^2.12.7
     dependencies:
-      '@account-kit/infra': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/logging': 4.15.3
-      '@account-kit/react-native-signer': 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(zod@3.22.4)
-      '@account-kit/signer': 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/smart-contracts': 4.15.3(typescript@5.7.3)(viem@2.21.55)
+      '@account-kit/infra': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/logging': 4.24.0
+      '@account-kit/react-native-signer': 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(zod@3.22.4)
+      '@account-kit/signer': 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/smart-contracts': 4.24.0(typescript@5.7.3)(viem@2.26.1)
       js-cookie: 3.0.5
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
-      wagmi: 2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
+      wagmi: 2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
       zod: 3.22.4
       zustand: 5.0.0(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)
     optionalDependencies:
@@ -4245,15 +4245,15 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@account-kit/infra@4.15.3(typescript@5.7.3)(viem@2.21.55):
-    resolution: {integrity: sha512-AOAVri7/VOZOJyqOn3c0Y9FFCer5Q9CQfIIjjE17Rxe2odJuVkRt0D3uYYmcnl9oG68CHZGY4t+vAvghz5xw1A==}
+  /@account-kit/infra@4.24.0(typescript@5.7.3)(viem@2.26.1):
+    resolution: {integrity: sha512-8FqWbvtPvt6NV2AiSR9Flpzy7Q0WH0B9cvCCKmouO0zh5fZEQuXeI5UPc2iG3MEDkwbcKG9iawNiB1f9u7RvvA==}
     peerDependencies:
       viem: ^2.22.6
     dependencies:
-      '@aa-sdk/core': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/logging': 4.15.3
+      '@aa-sdk/core': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/logging': 4.24.0
       eventemitter3: 5.0.1
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod: 3.22.4
     optionalDependencies:
       alchemy-sdk: 3.3.1
@@ -4266,8 +4266,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@account-kit/logging@4.15.3:
-    resolution: {integrity: sha512-SKrH7Cc5SzD2cFcaf4SUj8pFdLppm/owPKVHKv/J2mp9I8qsywuWWHg+Qj71+CrX1YFU3wryZC3ny+cj+mpqpw==}
+  /@account-kit/logging@4.24.0:
+    resolution: {integrity: sha512-LN42QfZ60HkmGO/wWJ+VjYRQ7ClzxlaMHyR0+XPxqIabhQJFKbkj3uFmzhxE0DtYiFdrw8a51+8YDxy5ooY7Ug==}
     dependencies:
       '@segment/analytics-next': 1.75.0
       uuid: 11.0.3
@@ -4275,35 +4275,37 @@ packages:
       - encoding
     dev: false
 
-  /@account-kit/react-native-signer@4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(zod@3.22.4):
-    resolution: {integrity: sha512-42ZVagDiqoAls54Vh9oGwVFaajwfDS74oEVTm7xXv9HM/gRgHaRTXg0X5VwmzRdv+PmBPIRd1qxzQ9AftL/6sw==}
+  /@account-kit/react-native-signer@4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(zod@3.22.4):
+    resolution: {integrity: sha512-aThuHj0DaFef/ll9xKMMhQiWnVrhCWozvGGvrG/u2PaCqT3Mg8DOVxX+RpzFwr/VNhzfXaBVZkcS9WG+WpazMA==}
     peerDependencies:
       react: '>=18.0.0'
       react-native: '>=0.76.0'
       react-native-inappbrowser-reborn: ^3.7.0
       react-native-mmkv: ^3.1.0
     dependencies:
-      '@aa-sdk/core': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/signer': 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)
+      '@aa-sdk/core': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/signer': 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)
       react: 19.0.0
       react-native: 0.78.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)
       react-native-inappbrowser-reborn: 3.7.0(react-native@0.78.0)
       react-native-mmkv: 3.2.0(react-native@0.78.0)(react@19.0.0)
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
       - '@types/react'
       - bufferutil
       - encoding
+      - immer
       - supports-color
       - typescript
+      - use-sync-external-store
       - utf-8-validate
       - zod
     dev: false
 
-  /@account-kit/react@4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(@wagmi/core@2.13.8)(immer@9.0.21)(react-dom@19.0.0)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(tailwindcss@3.4.13)(typescript@5.7.3)(viem@2.21.55)(wagmi@2.10.9):
-    resolution: {integrity: sha512-J6PZU/Zp/aZxRTbnRjee6MiNbdQikQjDNBa2xBca7a0G+dpUDVK4dfpNpiJhR0cC1IBcvB3D8PiAWRMjHUK4PQ==}
+  /@account-kit/react@4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(@wagmi/core@2.13.8)(immer@9.0.21)(react-dom@19.0.0)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(tailwindcss@3.4.13)(typescript@5.7.3)(viem@2.26.1)(wagmi@2.10.9):
+    resolution: {integrity: sha512-wcjwapMhQX8ojvVhN8GAxEy+h0mRvmXUHw7M6TQJEr5/nAJ+EdY5BqjI7LNywelhg7MWm/CjS92GKgc70eFPAQ==}
     peerDependencies:
       '@tanstack/react-query': ^5.28.9
       react: ^18.2.0
@@ -4312,20 +4314,20 @@ packages:
       viem: ^2.22.6
       wagmi: ^2.12.7
     dependencies:
-      '@account-kit/core': 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(wagmi@2.10.9)
-      '@account-kit/infra': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/logging': 4.15.3
-      '@account-kit/signer': 4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)
+      '@account-kit/core': 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react-native-inappbrowser-reborn@3.7.0)(react-native-mmkv@3.2.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(wagmi@2.10.9)
+      '@account-kit/infra': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/logging': 4.24.0
+      '@account-kit/signer': 4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)
       '@tanstack/react-form': 0.33.0(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
       '@tanstack/react-query': 5.51.1(react@19.0.0)
       '@tanstack/zod-form-adapter': 0.33.0(zod@3.22.4)
-      '@wagmi/connectors': 5.1.15(@types/react@19.0.8)(@wagmi/core@2.13.8)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
+      '@wagmi/connectors': 5.1.15(@types/react@19.0.8)(@wagmi/core@2.13.8)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-remove-scroll: 2.6.0(@types/react@19.0.8)(react@19.0.0)
       tailwindcss: 3.4.13
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
-      wagmi: 2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
+      wagmi: 2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
       zod: 3.22.4
       zustand: 5.0.0(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)
     optionalDependencies:
@@ -4364,40 +4366,44 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@account-kit/signer@4.15.3(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55):
-    resolution: {integrity: sha512-vpHyMzJvIIKVyAWs1QazBqv2tWzH7BYeduYXQ7gtZasb9jRj5uuhFDc57E3My4PEdax9OIIv51bP8bEpJGUqHQ==}
+  /@account-kit/signer@4.24.0(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1):
+    resolution: {integrity: sha512-M27UxFevJwGTjpIt3HTh5PH38bXwi9m4skq3NmqvLRJTOuOwvK/JS0f8ohaP6iEcaSf4qiNlqjwMUgus209wjg==}
     peerDependencies:
       viem: ^2.22.6
     dependencies:
-      '@aa-sdk/core': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/logging': 4.15.3
+      '@aa-sdk/core': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/logging': 4.24.0
+      '@solana/web3.js': 1.98.0
       '@turnkey/http': 2.10.0
       '@turnkey/iframe-stamper': 1.2.0
-      '@turnkey/viem': 0.4.22(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(viem@2.21.55)
+      '@turnkey/viem': 0.4.22(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(viem@2.26.1)
       '@turnkey/webauthn-stamper': 0.4.3
       jwt-decode: 4.0.0
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zod: 3.22.4
+      zustand: 5.0.0(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
       - '@types/react'
       - bufferutil
       - encoding
+      - immer
       - react
       - supports-color
       - typescript
+      - use-sync-external-store
       - utf-8-validate
     dev: false
 
-  /@account-kit/smart-contracts@4.15.3(typescript@5.7.3)(viem@2.21.55):
-    resolution: {integrity: sha512-aR5AhyFcZTvZMqFSU+JRXZzIWtMn9Y/snDooWgf0Ev7cINs3UoSY7jDyjD6LoL9IMxS0C0rjAMtt4sE2wPGQbA==}
+  /@account-kit/smart-contracts@4.24.0(typescript@5.7.3)(viem@2.26.1):
+    resolution: {integrity: sha512-JwJQ/ORAsvIKEoy5vAlaEDoMxdoKqGe5ZX/qTLwZ+1xmbgSQoorc81WiPM9SYH3Lix5WBhgnILuQaOlIbM0c7A==}
     peerDependencies:
       viem: ^2.22.6
     dependencies:
-      '@aa-sdk/core': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      '@account-kit/infra': 4.15.3(typescript@5.7.3)(viem@2.21.55)
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      '@aa-sdk/core': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      '@account-kit/infra': 4.24.0(typescript@5.7.3)(viem@2.26.1)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6977,7 +6983,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.25.9
       regexpu-core: 5.3.2
       semver: 6.3.1
     dev: false
@@ -7116,20 +7122,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.26.0):
-    resolution: {integrity: sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-wrap-function': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==}
     engines: {node: '>=6.9.0'}
@@ -7256,18 +7248,6 @@ packages:
   /@babel/helper-validator-option@7.25.9:
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
-
-  /@babel/helper-wrap-function@7.24.7:
-    resolution: {integrity: sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-function-name': 7.24.7
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/helper-wrap-function@7.25.9:
     resolution: {integrity: sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==}
@@ -7399,7 +7379,7 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.26.0)
+      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
@@ -7512,7 +7492,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
@@ -7607,6 +7587,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.24.7
+    dev: true
 
   /@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0):
     resolution: {integrity: sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==}
@@ -7801,7 +7782,7 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.26.0)
+      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7823,6 +7804,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.24.7
+    dev: true
 
   /@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==}
@@ -7878,6 +7860,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-classes@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==}
@@ -7914,6 +7897,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.24.7
+    dev: true
 
   /@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==}
@@ -7990,6 +7974,7 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.26.0)
+    dev: true
 
   /@babel/plugin-transform-flow-strip-types@7.26.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==}
@@ -8024,6 +8009,7 @@ packages:
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
+    dev: true
 
   /@babel/plugin-transform-function-name@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==}
@@ -8058,6 +8044,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.24.7
+    dev: true
 
   /@babel/plugin-transform-literals@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==}
@@ -8273,7 +8260,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.26.0)
+      '@babel/helper-create-class-features-plugin': 7.26.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
@@ -8286,8 +8273,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.26.0)
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.26.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
     transitivePeerDependencies:
@@ -8358,6 +8345,7 @@ packages:
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==}
@@ -8649,7 +8637,7 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-validator-option': 7.25.9
-      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-flow-strip-types': 7.26.5(@babel/core@7.26.0)
     dev: false
 
   /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.0):
@@ -14406,13 +14394,6 @@ packages:
     dependencies:
       '@noble/hashes': 1.4.0
 
-  /@noble/curves@1.7.0:
-    resolution: {integrity: sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==}
-    engines: {node: ^14.21.3 || >=16}
-    dependencies:
-      '@noble/hashes': 1.6.0
-    dev: false
-
   /@noble/curves@1.8.0:
     resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
     engines: {node: ^14.21.3 || >=16}
@@ -14442,16 +14423,6 @@ packages:
   /@noble/hashes@1.4.0:
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
-
-  /@noble/hashes@1.6.0:
-    resolution: {integrity: sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==}
-    engines: {node: ^14.21.3 || >=16}
-    dev: false
-
-  /@noble/hashes@1.6.1:
-    resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
-    engines: {node: ^14.21.3 || >=16}
-    dev: false
 
   /@noble/hashes@1.7.0:
     resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
@@ -15301,7 +15272,7 @@ packages:
   /@react-native-community/cli-debugger-ui@13.6.4:
     resolution: {integrity: sha512-9Gs31s6tA1kuEo69ay9qLgM3x2gsN/RI994DCUKnFSW+qSusQJyyrmfllR2mGU3Wl1W09/nYpIg87W9JPf5y4A==}
     dependencies:
-      serve-static: 1.15.0
+      serve-static: 1.16.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15385,7 +15356,7 @@ packages:
       errorhandler: 1.5.1
       nocache: 3.0.4
       pretty-format: 26.6.2
-      serve-static: 1.15.0
+      serve-static: 1.16.2
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -15506,34 +15477,34 @@ packages:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.26.0)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
       '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.26.0)
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
       '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoping': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-classes': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-destructuring': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-flow-strip-types': 7.26.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-function-name': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-literals': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.26.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.26.0)
-      '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-typescript': 7.26.8(@babel/core@7.26.0)
       '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.26.0)
-      '@babel/template': 7.25.9
+      '@babel/template': 7.26.9
       '@react-native/babel-plugin-codegen': 0.74.81(@babel/preset-env@7.24.7)
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.26.0)
       react-refresh: 0.14.2
@@ -15658,7 +15629,7 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
-      '@babel/parser': 7.26.0
+      '@babel/parser': 7.26.9
       '@babel/preset-env': 7.24.7(@babel/core@7.26.0)
       glob: 7.2.3
       hermes-parser: 0.19.1
@@ -15787,7 +15758,7 @@ packages:
       nullthrows: 1.1.1
       open: 7.4.2
       selfsigned: 2.4.1
-      serve-static: 1.15.0
+      serve-static: 1.16.2
       temp-dir: 2.0.0
       ws: 6.2.3
     transitivePeerDependencies:
@@ -16344,7 +16315,7 @@ packages:
     resolution: {integrity: sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.21.2
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -16386,14 +16357,6 @@ packages:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.7
 
-  /@scure/bip32@1.6.0:
-    resolution: {integrity: sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==}
-    dependencies:
-      '@noble/curves': 1.7.0
-      '@noble/hashes': 1.6.1
-      '@scure/base': 1.2.4
-    dev: false
-
   /@scure/bip32@1.6.2:
     resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
     dependencies:
@@ -16420,13 +16383,6 @@ packages:
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.7
-
-  /@scure/bip39@1.5.0:
-    resolution: {integrity: sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==}
-    dependencies:
-      '@noble/hashes': 1.6.1
-      '@scure/base': 1.2.4
-    dev: false
 
   /@scure/bip39@1.5.4:
     resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
@@ -17694,6 +17650,30 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@solana/web3.js@1.98.0:
+    resolution: {integrity: sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==}
+    dependencies:
+      '@babel/runtime': 7.26.9
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@solana/buffer-layout': 4.0.1
+      agentkeepalive: 4.5.0
+      bigint-buffer: 1.1.5
+      bn.js: 5.2.1
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.1.3
+      node-fetch: 2.7.0
+      rpc-websockets: 9.1.1
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
   /@solidity-parser/parser@0.14.5:
     resolution: {integrity: sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==}
     dependencies:
@@ -18937,7 +18917,7 @@ packages:
       - encoding
     dev: false
 
-  /@turnkey/viem@0.4.22(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(viem@2.21.55):
+  /@turnkey/viem@0.4.22(@babel/core@7.26.0)(@babel/preset-env@7.24.7)(@types/react@19.0.8)(react@19.0.0)(viem@2.26.1):
     resolution: {integrity: sha512-f90rUC77fMv2nr7EziJPda+o8a6TGjm0IvCUZCcZt6K+26HE5UcDpxsErJjEVMxhRv//CdlCbomYOJTqvMWABQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -18949,7 +18929,7 @@ packages:
       '@turnkey/sdk-server': 1.0.0
       cross-fetch: 4.0.0
       typescript: 5.7.3
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -19382,6 +19362,10 @@ packages:
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
     dev: false
 
+  /@types/uuid@8.3.4:
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+    dev: false
+
   /@types/w3c-web-usb@1.0.10:
     resolution: {integrity: sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ==}
     dev: false
@@ -19404,7 +19388,6 @@ packages:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
       '@types/node': 20.14.2
-    dev: true
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -19923,7 +19906,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/connectors@5.0.21(@types/react@19.0.8)(@wagmi/core@2.11.6)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4):
+  /@wagmi/connectors@5.0.21(@types/react@19.0.8)(@wagmi/core@2.11.6)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4):
     resolution: {integrity: sha512-lbjXEv6HhOa9nXZ5r6NGFJdaadCt2Yj9hSWHjKuiTobrE6dEGQqG16mCQS17yXcvXpI62Q/sW6SL347JrBju/Q==}
     peerDependencies:
       '@wagmi/core': 2.11.6
@@ -19937,12 +19920,12 @@ packages:
       '@metamask/sdk': 0.26.4(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)
       '@safe-global/safe-apps-provider': 0.18.1(typescript@5.7.3)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.7.3)(zod@3.22.4)
-      '@wagmi/core': 2.11.6(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
+      '@wagmi/core': 2.11.6(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
       '@walletconnect/ethereum-provider': 2.13.0(@types/react@19.0.8)(react@19.0.0)
       '@walletconnect/modal': 2.6.2(@types/react@19.0.8)(react@19.0.0)
       cbw-sdk: /@coinbase/wallet-sdk@3.9.3
       typescript: 5.7.3
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -19970,7 +19953,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/connectors@5.1.15(@types/react@19.0.8)(@wagmi/core@2.13.8)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4):
+  /@wagmi/connectors@5.1.15(@types/react@19.0.8)(@wagmi/core@2.13.8)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4):
     resolution: {integrity: sha512-Bz5EBpn8hAYFuxCWoXviwABk2VlLRuQTpJ7Yd/hu4HuuXnTdCN27cfvT+Fy2sWbwpLnr1e29LJGAUCIyYkHz7g==}
     peerDependencies:
       '@wagmi/core': 2.13.8
@@ -19984,12 +19967,12 @@ packages:
       '@metamask/sdk': 0.28.4(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)
       '@safe-global/safe-apps-provider': 0.18.3(typescript@5.7.3)(zod@3.22.4)
       '@safe-global/safe-apps-sdk': 9.1.0(typescript@5.7.3)(zod@3.22.4)
-      '@wagmi/core': 2.13.8(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)
+      '@wagmi/core': 2.13.8(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)
       '@walletconnect/ethereum-provider': 2.17.0(@types/react@19.0.8)(react@19.0.0)
       '@walletconnect/modal': 2.7.0(@types/react@19.0.8)(react@19.0.0)
       cbw-sdk: /@coinbase/wallet-sdk@3.9.3
       typescript: 5.7.3
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -20057,7 +20040,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/core@2.11.6(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4):
+  /@wagmi/core@2.11.6(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4):
     resolution: {integrity: sha512-Ohk7Bh+Q8kjzxEHImIq98CnPduz8n1a5bdwJi6F7zU3h62crhlVq7fZBYoBhoDgmX0ROVOMr8WW3XU3XhRwUOw==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
@@ -20072,7 +20055,7 @@ packages:
       eventemitter3: 5.0.1
       mipd: 0.0.5(typescript@5.7.3)(zod@3.22.4)
       typescript: 5.7.3
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zustand: 4.4.1(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
@@ -20083,7 +20066,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/core@2.13.8(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55):
+  /@wagmi/core@2.13.8(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1):
     resolution: {integrity: sha512-bX84cpLq3WWQgGthJlSgcWPAOdLzrP/W0jnbz5XowkCUn6j/T77WyxN5pBb+HmLoJf3ei9tkX9zWhMpczTc3cA==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
@@ -20098,7 +20081,7 @@ packages:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.7.3)
       typescript: 5.7.3
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
       zustand: 4.4.1(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
@@ -20150,8 +20133,8 @@ packages:
       '@walletconnect/jsonrpc-ws-connection': 1.0.14
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/relay-api': 1.0.10
-      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.11.0
@@ -22487,21 +22470,6 @@ packages:
       zod: 3.22.4
     dev: false
 
-  /abitype@1.0.7(typescript@5.7.3)(zod@3.22.4):
-    resolution: {integrity: sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.7.3
-      zod: 3.22.4
-    dev: false
-
   /abitype@1.0.8(typescript@5.7.3)(zod@3.22.4):
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
@@ -23337,7 +23305,7 @@ packages:
   /babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
     dependencies:
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.26.0)
     transitivePeerDependencies:
       - '@babel/core'
     dev: false
@@ -23557,10 +23525,6 @@ packages:
 
   /blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
-
-  /bn.js@4.11.6:
-    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
-    dev: true
 
   /bn.js@4.11.8:
     resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
@@ -27479,7 +27443,7 @@ packages:
     resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 4.11.6
+      bn.js: 5.2.1
       number-to-bn: 1.7.0
     dev: true
 
@@ -30050,14 +30014,6 @@ packages:
       ws: 8.13.0
     dev: false
 
-  /isows@1.0.6(ws@8.18.0):
-    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
-    peerDependencies:
-      ws: '*'
-    dependencies:
-      ws: 8.18.0
-    dev: false
-
   /isows@1.0.6(ws@8.18.1):
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
@@ -30163,6 +30119,28 @@ packages:
 
   /jayson@4.1.0:
     resolution: {integrity: sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      JSONStream: 1.3.5
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.10)
+      json-stringify-safe: 5.0.1
+      uuid: 8.3.2
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /jayson@4.1.3:
+    resolution: {integrity: sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
@@ -30791,11 +30769,11 @@ packages:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.26.0
+      '@babel/parser': 7.26.9
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.26.0)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.26.0)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.26.0)
       '@babel/preset-env': 7.24.7(@babel/core@7.26.0)
       '@babel/preset-flow': 7.24.7(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.26.0)
@@ -32033,7 +32011,7 @@ packages:
     resolution: {integrity: sha512-8PTVIgrVcyU+X/rVCy/9yxNlvXsBCk5JwwkbAm/Dm+Abo6NBGtNjWF0M1Xo/NWCb4phamNWcD7cHdR91HhbJvg==}
     engines: {node: '>=18'}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.9
     dev: false
 
   /metro-runtime@0.81.3:
@@ -32048,8 +32026,8 @@ packages:
     resolution: {integrity: sha512-RMn+XS4VTJIwMPOUSj61xlxgBvPeY4G6s5uIn6kt6HB6A/k9ekhr65UkkDD7WzHYs3a9o869qU8tvOZvqeQzgw==}
     engines: {node: '>=18'}
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
       invariant: 2.2.4
       metro-symbolicate: 0.80.9
       nullthrows: 1.1.1
@@ -32113,9 +32091,9 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/generator': 7.26.0
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/generator': 7.26.9
+      '@babel/template': 7.26.9
+      '@babel/traverse': 7.26.9
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -32140,9 +32118,9 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/generator': 7.26.0
-      '@babel/parser': 7.26.0
-      '@babel/types': 7.26.0
+      '@babel/generator': 7.26.9
+      '@babel/parser': 7.26.9
+      '@babel/types': 7.26.9
       metro: 0.80.9
       metro-babel-transformer: 0.80.9
       metro-cache: 0.80.9
@@ -32186,13 +32164,13 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.26.0
+      '@babel/code-frame': 7.26.2
       '@babel/core': 7.26.0
-      '@babel/generator': 7.26.0
-      '@babel/parser': 7.26.0
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/generator': 7.26.9
+      '@babel/parser': 7.26.9
+      '@babel/template': 7.26.9
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -33121,7 +33099,7 @@ packages:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 4.11.6
+      bn.js: 5.2.1
       strip-hex-prefix: 1.0.0
     dev: true
 
@@ -33456,26 +33434,6 @@ packages:
     dependencies:
       os-homedir: 1.0.2
       os-tmpdir: 1.0.2
-    dev: false
-
-  /ox@0.1.2(typescript@5.7.3)(zod@3.22.4):
-    resolution: {integrity: sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.7.3)(zod@3.22.4)
-      eventemitter3: 5.0.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - zod
     dev: false
 
   /ox@0.6.9(typescript@5.7.3)(zod@3.22.4):
@@ -35854,6 +35812,21 @@ packages:
       utf-8-validate: 5.0.10
     dev: false
 
+  /rpc-websockets@9.1.1:
+    resolution: {integrity: sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==}
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/uuid': 8.3.4
+      '@types/ws': 8.5.10
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      uuid: 8.3.2
+      ws: 8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
+    dev: false
+
   /rrdom@2.0.0-alpha.15:
     resolution: {integrity: sha512-c7BMmqJf6u9cm5G1wx7Mgnc5pyNog4CLaGTDUZCDGZAIfRIFOWwu7A4f2z9IPiEeokgc5wq8R/8/dKp6xpg8Ug==}
     dependencies:
@@ -36166,6 +36139,7 @@ packages:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
@@ -37203,6 +37177,11 @@ packages:
 
   /superstruct@1.0.4:
     resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -38877,32 +38856,31 @@ packages:
       - zod
     dev: false
 
-  /viem@2.21.55(typescript@5.7.3)(zod@3.22.4):
-    resolution: {integrity: sha512-PgXew7C11cAuEtOSgRyQx2kJxEOPUwIwZA9dMglRByqJuFVA7wSGZZOOo/93iylAA8E15bEdqy9xulU3oKZ70Q==}
+  /viem@2.23.11(typescript@5.7.3)(zod@3.22.4):
+    resolution: {integrity: sha512-yPkHJt4Vn88kLlrv8mrtVN54PW4vNLWRWDScf8SaHK2f44VlMk5IZbMJw4ycUoW9K9GUvCMrYuUa34MAcwYHIg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@noble/curves': 1.7.0
-      '@noble/hashes': 1.6.1
-      '@scure/bip32': 1.6.0
-      '@scure/bip39': 1.5.0
-      abitype: 1.0.7(typescript@5.7.3)(zod@3.22.4)
-      isows: 1.0.6(ws@8.18.0)
-      ox: 0.1.2(typescript@5.7.3)(zod@3.22.4)
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.7.3)(zod@3.22.4)
+      isows: 1.0.6(ws@8.18.1)
+      ox: 0.6.9(typescript@5.7.3)(zod@3.22.4)
       typescript: 5.7.3
-      webauthn-p256: 0.0.10
-      ws: 8.18.0
+      ws: 8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
     dev: false
 
-  /viem@2.23.11(typescript@5.7.3)(zod@3.22.4):
-    resolution: {integrity: sha512-yPkHJt4Vn88kLlrv8mrtVN54PW4vNLWRWDScf8SaHK2f44VlMk5IZbMJw4ycUoW9K9GUvCMrYuUa34MAcwYHIg==}
+  /viem@2.26.1(typescript@5.7.3)(zod@3.22.4):
+    resolution: {integrity: sha512-bGRLLTHlmk9OEF9lvtAIv6eqQe9vIVDOWowBI05GM3npIwDD7WeTryBE8QeJZXb0ZTpDU/4Gf4iAWKZApKC4KQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -39231,7 +39209,7 @@ packages:
       - zod
     dev: false
 
-  /wagmi@2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4):
+  /wagmi@2.10.9(@tanstack/react-query@5.51.1)(@types/react@19.0.8)(immer@9.0.21)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4):
     resolution: {integrity: sha512-pYGTLmVIAC4q/a90i+vlrkJL86n5Kf/gwhhi65XtQklpsUQWrKDmn4dsY1/yFeAmZ/1yx1mpxYpX3LI97eTuWA==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
@@ -39243,12 +39221,12 @@ packages:
         optional: true
     dependencies:
       '@tanstack/react-query': 5.51.1(react@19.0.0)
-      '@wagmi/connectors': 5.0.21(@types/react@19.0.8)(@wagmi/core@2.11.6)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
-      '@wagmi/core': 2.11.6(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.21.55)(zod@3.22.4)
+      '@wagmi/connectors': 5.0.21(@types/react@19.0.8)(@wagmi/core@2.11.6)(react-dom@19.0.0)(react-native@0.78.0)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
+      '@wagmi/core': 2.11.6(@types/react@19.0.8)(immer@9.0.21)(react@19.0.0)(typescript@5.7.3)(viem@2.26.1)(zod@3.22.4)
       react: 19.0.0
       typescript: 5.7.3
       use-sync-external-store: 1.2.0(react@19.0.0)
-      viem: 2.21.55(typescript@5.7.3)(zod@3.22.4)
+      viem: 2.26.1(typescript@5.7.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -39317,13 +39295,6 @@ packages:
       randombytes: 2.1.0
       utf8: 3.0.0
     dev: true
-
-  /webauthn-p256@0.0.10:
-    resolution: {integrity: sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==}
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-    dev: false
 
   /webcrypto-core@1.7.9:
     resolution: {integrity: sha512-FE+a4PPkOmBbgNDIyRmcHhgXn+2ClRl3JzJdDu/P4+B8y81LqKe6RAsI9b3lAOHe1T1BMkSjsRHTYRikImZnVA==}
@@ -39695,6 +39666,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}

--- a/sdk/sdk-client/bundle/package.json
+++ b/sdk/sdk-client/bundle/package.json
@@ -11,7 +11,7 @@
     "@trpc/client": "11.0.0-next-beta.264",
     "@trpc/server": "11.0.0-next-beta.264",
     "superjson": "^1.13.3",
-    "viem": "2.21.55",
+    "viem": "2.26.1",
     "zod": "^3.22.4"
   }
 }

--- a/summerfi-api/get-meta-morpho-details-function/package.json
+++ b/summerfi-api/get-meta-morpho-details-function/package.json
@@ -14,7 +14,7 @@
     "@summerfi/morpho-blue-external-api-client": "workspace:*",
     "@summerfi/serverless-shared": "workspace:*",
     "abitype": "^1.0.2",
-    "viem": "2.21.55",
+    "viem": "2.26.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/summerfi-api/get-triggers-function/package.json
+++ b/summerfi-api/get-triggers-function/package.json
@@ -17,7 +17,7 @@
     "@summerfi/serverless-shared": "workspace:*",
     "@summerfi/triggers-calculations": "workspace:*",
     "@summerfi/triggers-shared": "workspace:*",
-    "viem": "2.21.55",
+    "viem": "2.26.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/summerfi-api/setup-trigger-function/package.json
+++ b/summerfi-api/setup-trigger-function/package.json
@@ -23,7 +23,7 @@
     "bignumber.js": "^9.1.2",
     "just-memoize": "^2.2.0",
     "node-fetch": "^3.3.2",
-    "viem": "2.21.55",
+    "viem": "2.26.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
This PR updates viem package dependencies and refactors chain imports to use @account-kit/infra for better consistency.

## Changes
- Updated viem package:
  - Upgraded from 2.21.55 to 2.26.1 across all packages
  - Updated related @account-kit packages to 4.24.0
- Refactored chain imports:
  - Replaced viem/chains imports with @account-kit/infra
  - Updated sonic chain configuration
  - Consolidated chain imports
- Package updates:
  - Updated wagmi dependencies
  - Aligned all package versions
  - Updated pnpm-lock.yaml

## Benefits
1. Consistent chain configuration across the application
2. Latest viem features and improvements
3. Better dependency management
4. Simplified chain imports

## Testing
- Verify chain configurations
- Test network interactions
- Validate token balance fetching
- Check Account Kit integration

## Next steps
- Monitor for any viem-related deprecations
- Consider further chain import consolidation

## Additional Notes
This update ensures we're using the latest stable versions while maintaining consistent chain handling across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded token balance retrieval to include the sonic network for a more comprehensive asset view.

- **Refactor**
  - Streamlined network configuration and mapping to improve consistency and integration for the sonic network.

- **Chores**
  - Upgraded various dependencies, including key AccountKit and viem packages, to ensure enhanced performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->