### PR TITLE
chore: remove pagination in protocol-info enpoint

### DIFF
--- a/external-api/get-protocol-info-function/README.md
+++ b/external-api/get-protocol-info-function/README.md
@@ -1,0 +1,74 @@
+# Protocol Info API Endpoints
+
+## Get All Users
+Retrieves all user addresses that have interacted with the protocol across all supported chains.
+
+**Endpoint:** `/all-users`  
+**Method:** GET
+
+**Response:**
+```json
+{
+  "addresses": string[]  // Array of Ethereum addresses
+}
+```
+
+## Get Users Details
+Retrieves detailed information about specific users including their positions, TVL, and rewards.
+
+**Endpoint:** `/users`  
+**Method:** POST (preferred) or GET (deprecated)
+
+**Request Body (POST):**
+```json
+{
+  "addresses": string[],  // Array of Ethereum addresses
+  "chainId": number      // Optional: Specific chain ID to query
+}
+```
+
+**Query Parameters (GET - deprecated):**
+- `addresses`: Comma-separated list of Ethereum addresses
+- `chainId`: (Optional) Specific chain ID to query
+
+**Response:**
+```json
+{
+  "users": [
+    {
+      "address": string,
+      "totalValueLockedUSD": number,
+      "rewards": {
+        "unclaimed": number,
+        "claimed": number,
+        "total": number
+      }
+    }
+  ]
+}
+```
+
+## Get Protocol Stats
+Retrieves overall protocol statistics.
+
+**Endpoint:** `/`  
+**Method:** GET
+
+**Query Parameters:**
+- `chainId`: (Optional) Specific chain ID to query
+
+**Response:**
+```json
+{
+  "protocol": {
+    "totalValueLockedUSD": number,
+    "totalVaults": number
+  }
+}
+```
+
+## Notes
+- All monetary values are normalized and represented in USD
+- Rewards values are normalized (divided by 10^18)
+- The API supports multiple chains. If no chainId is specified, it will query all supported chains
+- Maximum page size for queries is 1000 items

--- a/packages/summer-earn-protocol-subgraph/src/generated/client.ts
+++ b/packages/summer-earn-protocol-subgraph/src/generated/client.ts
@@ -26,11 +26,16 @@ export type Scalars = {
 
 export type Account = {
   __typename?: 'Account';
+  /**  deprecated  */
   claimedSummerToken: Scalars['BigInt']['output'];
   claimedSummerTokenNormalized: Scalars['BigDecimal']['output'];
   /**  Address of the account  */
   id: Scalars['ID']['output'];
+  lastUpdateBlock: Scalars['BigInt']['output'];
   positions: Array<Position>;
+  rewards: Array<AccountRewards>;
+  stakedSummerToken: Scalars['BigInt']['output'];
+  stakedSummerTokenNormalized: Scalars['BigDecimal']['output'];
 };
 
 
@@ -41,6 +46,137 @@ export type AccountPositionsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<Position_Filter>;
 };
+
+
+export type AccountRewardsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AccountRewards_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<AccountRewards_Filter>;
+};
+
+export type AccountRewards = {
+  __typename?: 'AccountRewards';
+  account: Account;
+  claimable: Scalars['BigInt']['output'];
+  claimableNormalized: Scalars['BigDecimal']['output'];
+  claimed: Scalars['BigInt']['output'];
+  claimedNormalized: Scalars['BigDecimal']['output'];
+  id: Scalars['ID']['output'];
+  rewardToken: Token;
+};
+
+export type AccountRewards_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  account?: InputMaybe<Scalars['String']['input']>;
+  account_?: InputMaybe<Account_Filter>;
+  account_contains?: InputMaybe<Scalars['String']['input']>;
+  account_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  account_ends_with?: InputMaybe<Scalars['String']['input']>;
+  account_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  account_gt?: InputMaybe<Scalars['String']['input']>;
+  account_gte?: InputMaybe<Scalars['String']['input']>;
+  account_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  account_lt?: InputMaybe<Scalars['String']['input']>;
+  account_lte?: InputMaybe<Scalars['String']['input']>;
+  account_not?: InputMaybe<Scalars['String']['input']>;
+  account_not_contains?: InputMaybe<Scalars['String']['input']>;
+  account_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  account_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  account_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  account_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  account_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  account_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  account_starts_with?: InputMaybe<Scalars['String']['input']>;
+  account_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  and?: InputMaybe<Array<InputMaybe<AccountRewards_Filter>>>;
+  claimable?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimableNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimable_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimable_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_not?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimed?: InputMaybe<Scalars['BigInt']['input']>;
+  claimedNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimedNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimed_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimed_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_not?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<AccountRewards_Filter>>>;
+  rewardToken?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_?: InputMaybe<Token_Filter>;
+  rewardToken_contains?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_ends_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_gt?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_gte?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardToken_lt?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_lte?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_contains?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardToken_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_starts_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+};
+
+export enum AccountRewards_OrderBy {
+  Account = 'account',
+  AccountClaimedSummerToken = 'account__claimedSummerToken',
+  AccountClaimedSummerTokenNormalized = 'account__claimedSummerTokenNormalized',
+  AccountId = 'account__id',
+  AccountLastUpdateBlock = 'account__lastUpdateBlock',
+  AccountStakedSummerToken = 'account__stakedSummerToken',
+  AccountStakedSummerTokenNormalized = 'account__stakedSummerTokenNormalized',
+  Claimable = 'claimable',
+  ClaimableNormalized = 'claimableNormalized',
+  Claimed = 'claimed',
+  ClaimedNormalized = 'claimedNormalized',
+  Id = 'id',
+  RewardToken = 'rewardToken',
+  RewardTokenDecimals = 'rewardToken__decimals',
+  RewardTokenId = 'rewardToken__id',
+  RewardTokenLastPriceBlockNumber = 'rewardToken__lastPriceBlockNumber',
+  RewardTokenLastPriceUsd = 'rewardToken__lastPriceUSD',
+  RewardTokenName = 'rewardToken__name',
+  RewardTokenSymbol = 'rewardToken__symbol'
+}
 
 export type Account_Filter = {
   /** Filter for the block changed event. */
@@ -70,15 +206,44 @@ export type Account_Filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>;
   id_not?: InputMaybe<Scalars['ID']['input']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  lastUpdateBlock?: InputMaybe<Scalars['BigInt']['input']>;
+  lastUpdateBlock_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  lastUpdateBlock_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  lastUpdateBlock_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  lastUpdateBlock_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  lastUpdateBlock_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  lastUpdateBlock_not?: InputMaybe<Scalars['BigInt']['input']>;
+  lastUpdateBlock_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   or?: InputMaybe<Array<InputMaybe<Account_Filter>>>;
   positions_?: InputMaybe<Position_Filter>;
+  rewards_?: InputMaybe<AccountRewards_Filter>;
+  stakedSummerToken?: InputMaybe<Scalars['BigInt']['input']>;
+  stakedSummerTokenNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  stakedSummerTokenNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  stakedSummerTokenNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  stakedSummerTokenNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  stakedSummerTokenNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  stakedSummerTokenNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  stakedSummerTokenNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  stakedSummerTokenNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  stakedSummerToken_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  stakedSummerToken_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  stakedSummerToken_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  stakedSummerToken_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  stakedSummerToken_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  stakedSummerToken_not?: InputMaybe<Scalars['BigInt']['input']>;
+  stakedSummerToken_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
 };
 
 export enum Account_OrderBy {
   ClaimedSummerToken = 'claimedSummerToken',
   ClaimedSummerTokenNormalized = 'claimedSummerTokenNormalized',
   Id = 'id',
-  Positions = 'positions'
+  LastUpdateBlock = 'lastUpdateBlock',
+  Positions = 'positions',
+  Rewards = 'rewards',
+  StakedSummerToken = 'stakedSummerToken',
+  StakedSummerTokenNormalized = 'stakedSummerTokenNormalized'
 }
 
 export type ActiveAccount = {
@@ -1795,6 +1960,8 @@ export enum Deposit_OrderBy {
   InputTokenBalanceNormalizedUsd = 'inputTokenBalanceNormalizedUSD',
   LogIndex = 'logIndex',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -1804,8 +1971,10 @@ export enum Deposit_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -2551,6 +2720,168 @@ export enum FinancialsDailySnapshot_OrderBy {
   TotalValueLockedUsd = 'totalValueLockedUSD'
 }
 
+export type GovernanceRewardsManager = {
+  __typename?: 'GovernanceRewardsManager';
+  address: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+};
+
+export type GovernanceRewardsManager_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  address_contains?: InputMaybe<Scalars['String']['input']>;
+  address_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  address_ends_with?: InputMaybe<Scalars['String']['input']>;
+  address_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  address_gt?: InputMaybe<Scalars['String']['input']>;
+  address_gte?: InputMaybe<Scalars['String']['input']>;
+  address_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  address_lt?: InputMaybe<Scalars['String']['input']>;
+  address_lte?: InputMaybe<Scalars['String']['input']>;
+  address_not?: InputMaybe<Scalars['String']['input']>;
+  address_not_contains?: InputMaybe<Scalars['String']['input']>;
+  address_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  address_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  address_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  address_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  address_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  address_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  address_starts_with?: InputMaybe<Scalars['String']['input']>;
+  address_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  and?: InputMaybe<Array<InputMaybe<GovernanceRewardsManager_Filter>>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<GovernanceRewardsManager_Filter>>>;
+};
+
+export enum GovernanceRewardsManager_OrderBy {
+  Address = 'address',
+  Id = 'id'
+}
+
+export type GovernanceStaking = {
+  __typename?: 'GovernanceStaking';
+  accounts: Array<Account>;
+  id: Scalars['ID']['output'];
+  /**  Per-block reward token emission as of the current block normalized to a day, in token's native amount. This should be ideally calculated as the theoretical rate instead of the realized amount.  */
+  rewardTokenEmissionsAmount: Array<Scalars['BigInt']['output']>;
+  /**  Per-block reward token emission as of the current block normalized to a day, in token's native amount. This should be ideally calculated as the theoretical rate instead of the realized amount.  */
+  rewardTokenEmissionsAmountsPerOutputToken: Array<Scalars['BigInt']['output']>;
+  /**  Duration of the reward token emission in seconds  */
+  rewardTokenEmissionsFinish: Array<Scalars['BigInt']['output']>;
+  /**  Per-block reward token emission as of the current block normalized to a day, in USD value. This should be ideally calculated as the theoretical rate instead of the realized amount.  */
+  rewardTokenEmissionsUSD?: Maybe<Array<Scalars['BigDecimal']['output']>>;
+  rewardTokens: Array<Token>;
+  summerStaked: Scalars['BigInt']['output'];
+  summerStakedNormalized: Scalars['BigDecimal']['output'];
+};
+
+
+export type GovernanceStakingAccountsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Account_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<Account_Filter>;
+};
+
+
+export type GovernanceStakingRewardTokensArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Token_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<Token_Filter>;
+};
+
+export type GovernanceStaking_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  accounts?: InputMaybe<Array<Scalars['String']['input']>>;
+  accounts_?: InputMaybe<Account_Filter>;
+  accounts_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  accounts_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  accounts_not?: InputMaybe<Array<Scalars['String']['input']>>;
+  accounts_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  accounts_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  and?: InputMaybe<Array<InputMaybe<GovernanceStaking_Filter>>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<GovernanceStaking_Filter>>>;
+  rewardTokenEmissionsAmount?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmount_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmount_contains_nocase?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmount_not?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmount_not_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmount_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmountsPerOutputToken?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmountsPerOutputToken_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmountsPerOutputToken_contains_nocase?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmountsPerOutputToken_not?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmountsPerOutputToken_not_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsAmountsPerOutputToken_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsFinish?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsFinish_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsFinish_contains_nocase?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsFinish_not?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsFinish_not_contains?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsFinish_not_contains_nocase?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardTokenEmissionsUSD?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  rewardTokenEmissionsUSD_contains?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  rewardTokenEmissionsUSD_contains_nocase?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  rewardTokenEmissionsUSD_not?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  rewardTokenEmissionsUSD_not_contains?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  rewardTokenEmissionsUSD_not_contains_nocase?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  rewardTokens?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardTokens_?: InputMaybe<Token_Filter>;
+  rewardTokens_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardTokens_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardTokens_not?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardTokens_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardTokens_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  summerStaked?: InputMaybe<Scalars['BigInt']['input']>;
+  summerStakedNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  summerStakedNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  summerStakedNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  summerStakedNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  summerStakedNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  summerStakedNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  summerStakedNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  summerStakedNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  summerStaked_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  summerStaked_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  summerStaked_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  summerStaked_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  summerStaked_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  summerStaked_not?: InputMaybe<Scalars['BigInt']['input']>;
+  summerStaked_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+};
+
+export enum GovernanceStaking_OrderBy {
+  Accounts = 'accounts',
+  Id = 'id',
+  RewardTokenEmissionsAmount = 'rewardTokenEmissionsAmount',
+  RewardTokenEmissionsAmountsPerOutputToken = 'rewardTokenEmissionsAmountsPerOutputToken',
+  RewardTokenEmissionsFinish = 'rewardTokenEmissionsFinish',
+  RewardTokenEmissionsUsd = 'rewardTokenEmissionsUSD',
+  RewardTokens = 'rewardTokens',
+  SummerStaked = 'summerStaked',
+  SummerStakedNormalized = 'summerStakedNormalized'
+}
+
 export type HourlyInterestRate = {
   __typename?: 'HourlyInterestRate';
   averageRate: Scalars['BigDecimal']['output'];
@@ -2693,7 +3024,8 @@ export enum Network {
   Moonriver = 'MOONRIVER',
   NearMainnet = 'NEAR_MAINNET',
   Optimism = 'OPTIMISM',
-  Osmosis = 'OSMOSIS'
+  Osmosis = 'OSMOSIS',
+  SonicMainnet = 'SONIC_MAINNET'
 }
 
 /** Defines the order direction, either ascending or descending */
@@ -2706,6 +3038,8 @@ export type Position = {
   __typename?: 'Position';
   /**  Account associated with the position  */
   account: Account;
+  claimableSummerToken: Scalars['BigInt']['output'];
+  claimableSummerTokenNormalized: Scalars['BigDecimal']['output'];
   claimedSummerToken: Scalars['BigInt']['output'];
   claimedSummerTokenNormalized: Scalars['BigDecimal']['output'];
   /**  Creation block number  */
@@ -2725,14 +3059,19 @@ export type Position = {
   inputTokenBalanceNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision */
   inputTokenDeposits: Scalars['BigInt']['output'];
+  /**  Sum of deposits in the position - in input token precision normalized */
+  inputTokenDepositsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision normalized to USD */
   inputTokenDepositsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision */
   inputTokenWithdrawals: Scalars['BigInt']['output'];
+  /**  Sum of withdrawals in the position - in input token precision normalized */
+  inputTokenWithdrawalsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision normalized to USD */
   inputTokenWithdrawalsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Supply of the output token for the position  */
   outputTokenBalance: Scalars['BigInt']['output'];
+  rewards: Array<PositionRewards>;
   stakedEvents: Array<Staked>;
   /**  Staked balance of the input token for the position  */
   stakedInputTokenBalance: Scalars['BigInt']['output'];
@@ -2785,6 +3124,15 @@ export type PositionHourlySnapshotsArgs = {
 };
 
 
+export type PositionRewardsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<PositionRewards_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<PositionRewards_Filter>;
+};
+
+
 export type PositionStakedEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Staked_OrderBy>;
@@ -2826,14 +3174,20 @@ export type PositionDailySnapshot = {
   id: Scalars['ID']['output'];
   /**  Amount of input token in the position  */
   inputTokenBalance: Scalars['BigInt']['output'];
+  /**  Input token balance in the position normalized */
+  inputTokenBalanceNormalized: Scalars['BigDecimal']['output'];
   /**  Amount of input token in the position normalized to USD  */
   inputTokenBalanceNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision */
   inputTokenDeposits: Scalars['BigInt']['output'];
+  /**  Sum of deposits in the position - in input token precision normalized */
+  inputTokenDepositsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision normalized to USD */
   inputTokenDepositsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision */
   inputTokenWithdrawals: Scalars['BigInt']['output'];
+  /**  Sum of withdrawals in the position - in input token precision normalized */
+  inputTokenWithdrawalsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision normalized to USD */
   inputTokenWithdrawalsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Amount of output token in the position  */
@@ -2857,6 +3211,7 @@ export type PositionDailySnapshot_Filter = {
   id_not?: InputMaybe<Scalars['ID']['input']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   inputTokenBalance?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenBalanceNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -2865,6 +3220,13 @@ export type PositionDailySnapshot_Filter = {
   inputTokenBalanceNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenBalanceNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenBalanceNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenBalance_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -2873,6 +3235,7 @@ export type PositionDailySnapshot_Filter = {
   inputTokenBalance_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenDeposits?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenDepositsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -2881,6 +3244,13 @@ export type PositionDailySnapshot_Filter = {
   inputTokenDepositsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenDeposits_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -2889,6 +3259,7 @@ export type PositionDailySnapshot_Filter = {
   inputTokenDeposits_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenWithdrawals?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenWithdrawalsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -2897,6 +3268,13 @@ export type PositionDailySnapshot_Filter = {
   inputTokenWithdrawalsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenWithdrawals_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -2947,13 +3325,18 @@ export type PositionDailySnapshot_Filter = {
 export enum PositionDailySnapshot_OrderBy {
   Id = 'id',
   InputTokenBalance = 'inputTokenBalance',
+  InputTokenBalanceNormalized = 'inputTokenBalanceNormalized',
   InputTokenBalanceNormalizedInUsd = 'inputTokenBalanceNormalizedInUSD',
   InputTokenDeposits = 'inputTokenDeposits',
+  InputTokenDepositsNormalized = 'inputTokenDepositsNormalized',
   InputTokenDepositsNormalizedInUsd = 'inputTokenDepositsNormalizedInUSD',
   InputTokenWithdrawals = 'inputTokenWithdrawals',
+  InputTokenWithdrawalsNormalized = 'inputTokenWithdrawalsNormalized',
   InputTokenWithdrawalsNormalizedInUsd = 'inputTokenWithdrawalsNormalizedInUSD',
   OutputTokenBalance = 'outputTokenBalance',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -2963,8 +3346,10 @@ export enum PositionDailySnapshot_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -2984,14 +3369,20 @@ export type PositionHourlySnapshot = {
   id: Scalars['ID']['output'];
   /**  Amount of input token in the position  */
   inputTokenBalance: Scalars['BigInt']['output'];
+  /**  Input token balance in the position normalized */
+  inputTokenBalanceNormalized: Scalars['BigDecimal']['output'];
   /**  Amount of input token in the position normalized to USD  */
   inputTokenBalanceNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision */
   inputTokenDeposits: Scalars['BigInt']['output'];
+  /**  Sum of deposits in the position - in input token precision normalized */
+  inputTokenDepositsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision normalized to USD */
   inputTokenDepositsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision */
   inputTokenWithdrawals: Scalars['BigInt']['output'];
+  /**  Sum of withdrawals in the position - in input token precision normalized */
+  inputTokenWithdrawalsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision normalized to USD */
   inputTokenWithdrawalsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Amount of output token in the position  */
@@ -3015,6 +3406,7 @@ export type PositionHourlySnapshot_Filter = {
   id_not?: InputMaybe<Scalars['ID']['input']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   inputTokenBalance?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenBalanceNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3023,6 +3415,13 @@ export type PositionHourlySnapshot_Filter = {
   inputTokenBalanceNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenBalanceNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenBalanceNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenBalance_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3031,6 +3430,7 @@ export type PositionHourlySnapshot_Filter = {
   inputTokenBalance_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenDeposits?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenDepositsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3039,6 +3439,13 @@ export type PositionHourlySnapshot_Filter = {
   inputTokenDepositsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenDeposits_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3047,6 +3454,7 @@ export type PositionHourlySnapshot_Filter = {
   inputTokenDeposits_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenWithdrawals?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenWithdrawalsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3055,6 +3463,13 @@ export type PositionHourlySnapshot_Filter = {
   inputTokenWithdrawalsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenWithdrawals_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3105,13 +3520,18 @@ export type PositionHourlySnapshot_Filter = {
 export enum PositionHourlySnapshot_OrderBy {
   Id = 'id',
   InputTokenBalance = 'inputTokenBalance',
+  InputTokenBalanceNormalized = 'inputTokenBalanceNormalized',
   InputTokenBalanceNormalizedInUsd = 'inputTokenBalanceNormalizedInUSD',
   InputTokenDeposits = 'inputTokenDeposits',
+  InputTokenDepositsNormalized = 'inputTokenDepositsNormalized',
   InputTokenDepositsNormalizedInUsd = 'inputTokenDepositsNormalizedInUSD',
   InputTokenWithdrawals = 'inputTokenWithdrawals',
+  InputTokenWithdrawalsNormalized = 'inputTokenWithdrawalsNormalized',
   InputTokenWithdrawalsNormalizedInUsd = 'inputTokenWithdrawalsNormalizedInUSD',
   OutputTokenBalance = 'outputTokenBalance',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -3121,8 +3541,10 @@ export enum PositionHourlySnapshot_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -3136,20 +3558,167 @@ export enum PositionHourlySnapshot_OrderBy {
   Timestamp = 'timestamp'
 }
 
+export type PositionRewards = {
+  __typename?: 'PositionRewards';
+  claimable: Scalars['BigInt']['output'];
+  claimableNormalized: Scalars['BigDecimal']['output'];
+  claimed: Scalars['BigInt']['output'];
+  claimedNormalized: Scalars['BigDecimal']['output'];
+  id: Scalars['ID']['output'];
+  position: Position;
+  rewardToken: Token;
+};
+
+export type PositionRewards_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<PositionRewards_Filter>>>;
+  claimable?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimableNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimable_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimable_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_not?: InputMaybe<Scalars['BigInt']['input']>;
+  claimable_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimed?: InputMaybe<Scalars['BigInt']['input']>;
+  claimedNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimedNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimedNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimed_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimed_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_not?: InputMaybe<Scalars['BigInt']['input']>;
+  claimed_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<PositionRewards_Filter>>>;
+  position?: InputMaybe<Scalars['String']['input']>;
+  position_?: InputMaybe<Position_Filter>;
+  position_contains?: InputMaybe<Scalars['String']['input']>;
+  position_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  position_ends_with?: InputMaybe<Scalars['String']['input']>;
+  position_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  position_gt?: InputMaybe<Scalars['String']['input']>;
+  position_gte?: InputMaybe<Scalars['String']['input']>;
+  position_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  position_lt?: InputMaybe<Scalars['String']['input']>;
+  position_lte?: InputMaybe<Scalars['String']['input']>;
+  position_not?: InputMaybe<Scalars['String']['input']>;
+  position_not_contains?: InputMaybe<Scalars['String']['input']>;
+  position_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  position_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  position_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  position_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  position_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  position_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  position_starts_with?: InputMaybe<Scalars['String']['input']>;
+  position_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_?: InputMaybe<Token_Filter>;
+  rewardToken_contains?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_ends_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_gt?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_gte?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardToken_lt?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_lte?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_contains?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  rewardToken_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_starts_with?: InputMaybe<Scalars['String']['input']>;
+  rewardToken_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+};
+
+export enum PositionRewards_OrderBy {
+  Claimable = 'claimable',
+  ClaimableNormalized = 'claimableNormalized',
+  Claimed = 'claimed',
+  ClaimedNormalized = 'claimedNormalized',
+  Id = 'id',
+  Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
+  PositionClaimedSummerToken = 'position__claimedSummerToken',
+  PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
+  PositionCreatedBlockNumber = 'position__createdBlockNumber',
+  PositionCreatedTimestamp = 'position__createdTimestamp',
+  PositionId = 'position__id',
+  PositionInputTokenBalance = 'position__inputTokenBalance',
+  PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
+  PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
+  PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
+  PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
+  PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
+  PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
+  PositionOutputTokenBalance = 'position__outputTokenBalance',
+  PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
+  PositionStakedInputTokenBalanceNormalized = 'position__stakedInputTokenBalanceNormalized',
+  PositionStakedInputTokenBalanceNormalizedInUsd = 'position__stakedInputTokenBalanceNormalizedInUSD',
+  PositionStakedOutputTokenBalance = 'position__stakedOutputTokenBalance',
+  PositionUnstakedInputTokenBalance = 'position__unstakedInputTokenBalance',
+  PositionUnstakedInputTokenBalanceNormalized = 'position__unstakedInputTokenBalanceNormalized',
+  PositionUnstakedInputTokenBalanceNormalizedInUsd = 'position__unstakedInputTokenBalanceNormalizedInUSD',
+  PositionUnstakedOutputTokenBalance = 'position__unstakedOutputTokenBalance',
+  RewardToken = 'rewardToken',
+  RewardTokenDecimals = 'rewardToken__decimals',
+  RewardTokenId = 'rewardToken__id',
+  RewardTokenLastPriceBlockNumber = 'rewardToken__lastPriceBlockNumber',
+  RewardTokenLastPriceUsd = 'rewardToken__lastPriceUSD',
+  RewardTokenName = 'rewardToken__name',
+  RewardTokenSymbol = 'rewardToken__symbol'
+}
+
 export type PositionWeeklySnapshot = {
   __typename?: 'PositionWeeklySnapshot';
   /**  { Position ID }-{ # of weeks since Unix epoch time }  */
   id: Scalars['ID']['output'];
   /**  Amount of input token in the position  */
   inputTokenBalance: Scalars['BigInt']['output'];
+  /**  Input token balance in the position normalized */
+  inputTokenBalanceNormalized: Scalars['BigDecimal']['output'];
   /**  Amount of input token in the position normalized to USD  */
   inputTokenBalanceNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision */
   inputTokenDeposits: Scalars['BigInt']['output'];
+  /**  Sum of deposits in the position - in input token precision normalized */
+  inputTokenDepositsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of deposits in the position - in input token precision normalized to USD */
   inputTokenDepositsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision */
   inputTokenWithdrawals: Scalars['BigInt']['output'];
+  /**  Sum of withdrawals in the position - in input token precision normalized */
+  inputTokenWithdrawalsNormalized: Scalars['BigDecimal']['output'];
   /**  Sum of withdrawals in the position - in input token precision normalized to USD */
   inputTokenWithdrawalsNormalizedInUSD: Scalars['BigDecimal']['output'];
   /**  Amount of output token in the position  */
@@ -3173,6 +3742,7 @@ export type PositionWeeklySnapshot_Filter = {
   id_not?: InputMaybe<Scalars['ID']['input']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   inputTokenBalance?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenBalanceNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3181,6 +3751,13 @@ export type PositionWeeklySnapshot_Filter = {
   inputTokenBalanceNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenBalanceNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenBalanceNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenBalanceNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenBalanceNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenBalance_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3189,6 +3766,7 @@ export type PositionWeeklySnapshot_Filter = {
   inputTokenBalance_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenDeposits?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenDepositsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3197,6 +3775,13 @@ export type PositionWeeklySnapshot_Filter = {
   inputTokenDepositsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenDeposits_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3205,6 +3790,7 @@ export type PositionWeeklySnapshot_Filter = {
   inputTokenDeposits_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenWithdrawals?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenWithdrawalsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3213,6 +3799,13 @@ export type PositionWeeklySnapshot_Filter = {
   inputTokenWithdrawalsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenWithdrawals_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3263,13 +3856,18 @@ export type PositionWeeklySnapshot_Filter = {
 export enum PositionWeeklySnapshot_OrderBy {
   Id = 'id',
   InputTokenBalance = 'inputTokenBalance',
+  InputTokenBalanceNormalized = 'inputTokenBalanceNormalized',
   InputTokenBalanceNormalizedInUsd = 'inputTokenBalanceNormalizedInUSD',
   InputTokenDeposits = 'inputTokenDeposits',
+  InputTokenDepositsNormalized = 'inputTokenDepositsNormalized',
   InputTokenDepositsNormalizedInUsd = 'inputTokenDepositsNormalizedInUSD',
   InputTokenWithdrawals = 'inputTokenWithdrawals',
+  InputTokenWithdrawalsNormalized = 'inputTokenWithdrawalsNormalized',
   InputTokenWithdrawalsNormalizedInUsd = 'inputTokenWithdrawalsNormalizedInUSD',
   OutputTokenBalance = 'outputTokenBalance',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -3279,8 +3877,10 @@ export enum PositionWeeklySnapshot_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -3319,6 +3919,22 @@ export type Position_Filter = {
   account_starts_with?: InputMaybe<Scalars['String']['input']>;
   account_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   and?: InputMaybe<Array<InputMaybe<Position_Filter>>>;
+  claimableSummerToken?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableSummerTokenNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableSummerTokenNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableSummerTokenNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableSummerTokenNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimableSummerTokenNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableSummerTokenNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableSummerTokenNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  claimableSummerTokenNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  claimableSummerToken_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableSummerToken_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableSummerToken_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  claimableSummerToken_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableSummerToken_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableSummerToken_not?: InputMaybe<Scalars['BigInt']['input']>;
+  claimableSummerToken_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   claimedSummerToken?: InputMaybe<Scalars['BigInt']['input']>;
   claimedSummerTokenNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   claimedSummerTokenNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3387,6 +4003,7 @@ export type Position_Filter = {
   inputTokenBalance_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenBalance_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenDeposits?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenDepositsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3395,6 +4012,13 @@ export type Position_Filter = {
   inputTokenDepositsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenDepositsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenDepositsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenDepositsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenDeposits_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3403,6 +4027,7 @@ export type Position_Filter = {
   inputTokenDeposits_not?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   inputTokenWithdrawals?: InputMaybe<Scalars['BigInt']['input']>;
+  inputTokenWithdrawalsNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3411,6 +4036,13 @@ export type Position_Filter = {
   inputTokenWithdrawalsNormalizedInUSD_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not?: InputMaybe<Scalars['BigDecimal']['input']>;
   inputTokenWithdrawalsNormalizedInUSD_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_gt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_gte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
+  inputTokenWithdrawalsNormalized_lt?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_lte?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not?: InputMaybe<Scalars['BigDecimal']['input']>;
+  inputTokenWithdrawalsNormalized_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>;
   inputTokenWithdrawals_gt?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_gte?: InputMaybe<Scalars['BigInt']['input']>;
   inputTokenWithdrawals_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -3427,6 +4059,7 @@ export type Position_Filter = {
   outputTokenBalance_lte?: InputMaybe<Scalars['BigInt']['input']>;
   outputTokenBalance_not?: InputMaybe<Scalars['BigInt']['input']>;
   outputTokenBalance_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewards_?: InputMaybe<PositionRewards_Filter>;
   stakedEvents_?: InputMaybe<Staked_Filter>;
   stakedInputTokenBalance?: InputMaybe<Scalars['BigInt']['input']>;
   stakedInputTokenBalanceNormalized?: InputMaybe<Scalars['BigDecimal']['input']>;
@@ -3523,6 +4156,11 @@ export enum Position_OrderBy {
   AccountClaimedSummerToken = 'account__claimedSummerToken',
   AccountClaimedSummerTokenNormalized = 'account__claimedSummerTokenNormalized',
   AccountId = 'account__id',
+  AccountLastUpdateBlock = 'account__lastUpdateBlock',
+  AccountStakedSummerToken = 'account__stakedSummerToken',
+  AccountStakedSummerTokenNormalized = 'account__stakedSummerTokenNormalized',
+  ClaimableSummerToken = 'claimableSummerToken',
+  ClaimableSummerTokenNormalized = 'claimableSummerTokenNormalized',
   ClaimedSummerToken = 'claimedSummerToken',
   ClaimedSummerTokenNormalized = 'claimedSummerTokenNormalized',
   CreatedBlockNumber = 'createdBlockNumber',
@@ -3535,10 +4173,13 @@ export enum Position_OrderBy {
   InputTokenBalanceNormalized = 'inputTokenBalanceNormalized',
   InputTokenBalanceNormalizedInUsd = 'inputTokenBalanceNormalizedInUSD',
   InputTokenDeposits = 'inputTokenDeposits',
+  InputTokenDepositsNormalized = 'inputTokenDepositsNormalized',
   InputTokenDepositsNormalizedInUsd = 'inputTokenDepositsNormalizedInUSD',
   InputTokenWithdrawals = 'inputTokenWithdrawals',
+  InputTokenWithdrawalsNormalized = 'inputTokenWithdrawalsNormalized',
   InputTokenWithdrawalsNormalizedInUsd = 'inputTokenWithdrawalsNormalizedInUSD',
   OutputTokenBalance = 'outputTokenBalance',
+  Rewards = 'rewards',
   StakedEvents = 'stakedEvents',
   StakedInputTokenBalance = 'stakedInputTokenBalance',
   StakedInputTokenBalanceNormalized = 'stakedInputTokenBalanceNormalized',
@@ -4340,6 +4981,8 @@ export type Query = {
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
   account?: Maybe<Account>;
+  accountRewards?: Maybe<AccountRewards>;
+  accountRewards_collection: Array<AccountRewards>;
   accounts: Array<Account>;
   activeAccount?: Maybe<ActiveAccount>;
   activeAccounts: Array<ActiveAccount>;
@@ -4361,6 +5004,10 @@ export type Query = {
   events: Array<Event>;
   financialsDailySnapshot?: Maybe<FinancialsDailySnapshot>;
   financialsDailySnapshots: Array<FinancialsDailySnapshot>;
+  governanceRewardsManager?: Maybe<GovernanceRewardsManager>;
+  governanceRewardsManagers: Array<GovernanceRewardsManager>;
+  governanceStaking?: Maybe<GovernanceStaking>;
+  governanceStakings: Array<GovernanceStaking>;
   hourlyInterestRate?: Maybe<HourlyInterestRate>;
   hourlyInterestRates: Array<HourlyInterestRate>;
   position?: Maybe<Position>;
@@ -4368,6 +5015,8 @@ export type Query = {
   positionDailySnapshots: Array<PositionDailySnapshot>;
   positionHourlySnapshot?: Maybe<PositionHourlySnapshot>;
   positionHourlySnapshots: Array<PositionHourlySnapshot>;
+  positionRewards?: Maybe<PositionRewards>;
+  positionRewards_collection: Array<PositionRewards>;
   positionWeeklySnapshot?: Maybe<PositionWeeklySnapshot>;
   positionWeeklySnapshots: Array<PositionWeeklySnapshot>;
   positions: Array<Position>;
@@ -4423,6 +5072,24 @@ export type QueryAccountArgs = {
   block?: InputMaybe<Block_Height>;
   id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryAccountRewardsArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryAccountRewards_CollectionArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AccountRewards_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<AccountRewards_Filter>;
 };
 
 
@@ -4617,6 +5284,42 @@ export type QueryFinancialsDailySnapshotsArgs = {
 };
 
 
+export type QueryGovernanceRewardsManagerArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryGovernanceRewardsManagersArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<GovernanceRewardsManager_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<GovernanceRewardsManager_Filter>;
+};
+
+
+export type QueryGovernanceStakingArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryGovernanceStakingsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<GovernanceStaking_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<GovernanceStaking_Filter>;
+};
+
+
 export type QueryHourlyInterestRateArgs = {
   block?: InputMaybe<Block_Height>;
   id: Scalars['ID']['input'];
@@ -4675,6 +5378,24 @@ export type QueryPositionHourlySnapshotsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<PositionHourlySnapshot_Filter>;
+};
+
+
+export type QueryPositionRewardsArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryPositionRewards_CollectionArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<PositionRewards_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<PositionRewards_Filter>;
 };
 
 
@@ -5870,6 +6591,8 @@ export enum Staked_OrderBy {
   InputTokenBalanceNormalizedUsd = 'inputTokenBalanceNormalizedUSD',
   LogIndex = 'logIndex',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -5879,8 +6602,10 @@ export enum Staked_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -5953,6 +6678,8 @@ export type Subscription = {
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
   account?: Maybe<Account>;
+  accountRewards?: Maybe<AccountRewards>;
+  accountRewards_collection: Array<AccountRewards>;
   accounts: Array<Account>;
   activeAccount?: Maybe<ActiveAccount>;
   activeAccounts: Array<ActiveAccount>;
@@ -5974,6 +6701,10 @@ export type Subscription = {
   events: Array<Event>;
   financialsDailySnapshot?: Maybe<FinancialsDailySnapshot>;
   financialsDailySnapshots: Array<FinancialsDailySnapshot>;
+  governanceRewardsManager?: Maybe<GovernanceRewardsManager>;
+  governanceRewardsManagers: Array<GovernanceRewardsManager>;
+  governanceStaking?: Maybe<GovernanceStaking>;
+  governanceStakings: Array<GovernanceStaking>;
   hourlyInterestRate?: Maybe<HourlyInterestRate>;
   hourlyInterestRates: Array<HourlyInterestRate>;
   position?: Maybe<Position>;
@@ -5981,6 +6712,8 @@ export type Subscription = {
   positionDailySnapshots: Array<PositionDailySnapshot>;
   positionHourlySnapshot?: Maybe<PositionHourlySnapshot>;
   positionHourlySnapshots: Array<PositionHourlySnapshot>;
+  positionRewards?: Maybe<PositionRewards>;
+  positionRewards_collection: Array<PositionRewards>;
   positionWeeklySnapshot?: Maybe<PositionWeeklySnapshot>;
   positionWeeklySnapshots: Array<PositionWeeklySnapshot>;
   positions: Array<Position>;
@@ -6036,6 +6769,24 @@ export type SubscriptionAccountArgs = {
   block?: InputMaybe<Block_Height>;
   id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionAccountRewardsArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionAccountRewards_CollectionArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AccountRewards_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<AccountRewards_Filter>;
 };
 
 
@@ -6230,6 +6981,42 @@ export type SubscriptionFinancialsDailySnapshotsArgs = {
 };
 
 
+export type SubscriptionGovernanceRewardsManagerArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionGovernanceRewardsManagersArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<GovernanceRewardsManager_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<GovernanceRewardsManager_Filter>;
+};
+
+
+export type SubscriptionGovernanceStakingArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionGovernanceStakingsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<GovernanceStaking_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<GovernanceStaking_Filter>;
+};
+
+
 export type SubscriptionHourlyInterestRateArgs = {
   block?: InputMaybe<Block_Height>;
   id: Scalars['ID']['input'];
@@ -6288,6 +7075,24 @@ export type SubscriptionPositionHourlySnapshotsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<PositionHourlySnapshot_Filter>;
+};
+
+
+export type SubscriptionPositionRewardsArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionPositionRewards_CollectionArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<PositionRewards_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<PositionRewards_Filter>;
 };
 
 
@@ -7147,6 +7952,8 @@ export enum Unstaked_OrderBy {
   InputTokenBalanceNormalizedUsd = 'inputTokenBalanceNormalizedUSD',
   LogIndex = 'logIndex',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -7156,8 +7963,10 @@ export enum Unstaked_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -9901,6 +10710,8 @@ export enum Withdraw_OrderBy {
   InputTokenBalanceNormalizedUsd = 'inputTokenBalanceNormalizedUSD',
   LogIndex = 'logIndex',
   Position = 'position',
+  PositionClaimableSummerToken = 'position__claimableSummerToken',
+  PositionClaimableSummerTokenNormalized = 'position__claimableSummerTokenNormalized',
   PositionClaimedSummerToken = 'position__claimedSummerToken',
   PositionClaimedSummerTokenNormalized = 'position__claimedSummerTokenNormalized',
   PositionCreatedBlockNumber = 'position__createdBlockNumber',
@@ -9910,8 +10721,10 @@ export enum Withdraw_OrderBy {
   PositionInputTokenBalanceNormalized = 'position__inputTokenBalanceNormalized',
   PositionInputTokenBalanceNormalizedInUsd = 'position__inputTokenBalanceNormalizedInUSD',
   PositionInputTokenDeposits = 'position__inputTokenDeposits',
+  PositionInputTokenDepositsNormalized = 'position__inputTokenDepositsNormalized',
   PositionInputTokenDepositsNormalizedInUsd = 'position__inputTokenDepositsNormalizedInUSD',
   PositionInputTokenWithdrawals = 'position__inputTokenWithdrawals',
+  PositionInputTokenWithdrawalsNormalized = 'position__inputTokenWithdrawalsNormalized',
   PositionInputTokenWithdrawalsNormalizedInUsd = 'position__inputTokenWithdrawalsNormalizedInUSD',
   PositionOutputTokenBalance = 'position__outputTokenBalance',
   PositionStakedInputTokenBalance = 'position__stakedInputTokenBalance',
@@ -10404,7 +11217,7 @@ export const UserPositionsDocument: DocumentNode = gql`
     `;
 export const UsersPositionsDocument: DocumentNode = gql`
     query UsersPositions($userAddresses: [String!]) {
-  positions(where: {account_in: $userAddresses}, first: 1000) {
+  positions(where: {account_in: $userAddresses}, first: 5000) {
     id
     inputTokenBalance
     outputTokenBalance

--- a/packages/summer-earn-protocol-subgraph/src/queries/queries.graphql
+++ b/packages/summer-earn-protocol-subgraph/src/queries/queries.graphql
@@ -18,7 +18,7 @@ query UserPositions($userAddress: String!) {
   }
 }
 query UsersPositions($userAddresses: [String!]) {
-  positions(where: { account_in: $userAddresses }, first: 1000) {
+  positions(where: { account_in: $userAddresses }, first: 5000) {
     id
     inputTokenBalance
     outputTokenBalance


### PR DESCRIPTION
## Description
This PR adds input validation for the number of addresses and improves the all-users endpoint by implementing proper pagination across all chains. It also adds comprehensive API documentation.

## Changes
- Added maximum limit of 1000 addresses for the `/users` endpoint
- Improved `/all-users` endpoint to fetch all users across chains with proper pagination
- Increased page size to 5000 for better performance in `/all-users` endpoint
- Added comprehensive API documentation in README.md
- Removed deprecated pagination parameters schema
- Optimized duplicate removal using Set instead of filter

## Benefits
1. Better protection against large requests that could impact performance
2. More reliable and complete data fetching for all users across chains
3. Clear documentation for API consumers
4. Improved code efficiency with modern JS features (Set vs filter)

## Testing
The changes can be tested by:
- Attempting to query more than 1000 addresses (should receive validation error)
- Verifying all users are fetched correctly across multiple chains
- Confirming pagination works correctly with large datasets
- Verifying documentation accuracy against actual endpoints

## Next steps
- Monitor performance of the all-users endpoint with the increased page size
- Consider adding rate limiting if needed
- Add API versioning for future breaking changes

## Additional Notes
The PR removes the manual pagination parameter from the all-users endpoint as it now automatically fetches all users. This is a breaking change for any clients that were using the pagination parameter, but provides more reliable and complete data.

Please review and provide any feedback or suggestions for improvement.