### PR TITLE
Refactor exports for clarity and organization in type definitions

### DIFF
--- a/packages/app-types/.eslintrc.cjs
+++ b/packages/app-types/.eslintrc.cjs
@@ -1,0 +1,6 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ['@summerfi/eslint-config/library.cjs'],
+  parser: '@typescript-eslint/parser',
+}

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -20,6 +20,8 @@
     "@types/react": "19.0.8"
   },
   "devDependencies": {
+    "@summerfi/eslint-config": "workspace:*",
+    "@summerfi/typescript-config": "workspace:*",
     "@types/node-fetch": "^2.6.11",
     "@types/node": "^20.14.2",
     "@types/react": "19.0.8",

--- a/packages/app-types/scripts/get-earn-config-types.js
+++ b/packages/app-types/scripts/get-earn-config-types.js
@@ -26,7 +26,7 @@ const getInterfaces = (configObject = { features: {} }) => {
         return typeInterface
       })
       .join('\n\n')
-    const importRisk = 'import { Risk } from "../earn-protocol";\n'
+    const importRisk = 'import { Risk } from "../earn-protocol/risk";\n'
     const intarfacesMapped = interfaces
       .replaceAll('_0x', 'EarnAppFleetCustomConfigType')
       .replaceAll(

--- a/packages/app-types/tsconfig.json
+++ b/packages/app-types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@summerfi/typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "baseUrl": ".",
+    "isolatedModules": true
+  },
+  "include": ["types/**/*.ts", "e2e/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/app-types/types/index.ts
+++ b/packages/app-types/types/index.ts
@@ -12,7 +12,7 @@ export {
   emptyConfig as raysEmptyConfig,
 } from './src/generated/rays-config'
 export { AutomationFeatures, AutomationKinds } from './src/automation'
-export {
+export type {
   DropdownOption,
   DropdownRawOption,
   InlineButtonOption,
@@ -34,12 +34,12 @@ export {
   TimeframesType,
   WithNavigationModules,
 } from './src/components'
-export { IconNamesList, TokenConfig, TokenSymbolsList } from './src/icons'
-export { LeaderboardItem, LeaderboardResponse } from './src/leaderboard'
-export { PortfolioMigrations } from './src/migrations'
+export type { IconNamesList, TokenConfig, TokenSymbolsList } from './src/icons'
+export type { LeaderboardItem, LeaderboardResponse } from './src/leaderboard'
+export type { PortfolioMigrations } from './src/migrations'
 export { LendingProtocol, lendingProtocolMap } from './src/lending-protocol'
 export { MixpanelEventProduct, MixpanelEventTypes } from './src/mixpanel'
-export {
+export type {
   NavigationFeaturedProduct,
   NavigationLinkTypes,
   NavigationMenuPanelListItem,
@@ -47,6 +47,17 @@ export {
 } from './src/navigation'
 export { NetworkHexIds, NetworkIds, NetworkNames } from './src/networks'
 export {
+  OmniBorrowFormAction,
+  OmniEarnFormAction,
+  OmniMultiplyFormAction,
+  OmniMultiplyPanel,
+  OmniProductType,
+  OmniSidebarAutomationStep,
+  OmniSidebarBorrowPanel,
+  OmniSidebarEarnPanel,
+  OmniSidebarStep,
+} from './src/omni-kit'
+export type {
   AutomationMetadataValues,
   AutomationMetadataValuesSimulation,
   GenericProductContext,
@@ -56,9 +67,7 @@ export {
   LendingMetadata,
   NetworkIdsWithValues,
   OmniAutomationSimulationResponse,
-  OmniBorrowFormAction,
   OmniCloseTo,
-  OmniEarnFormAction,
   OmniEntryToken,
   OmniExtraTokenData,
   OmniFiltersParameters,
@@ -69,23 +78,16 @@ export {
   OmniGenericPosition,
   OmniLendingMetadataHandlers,
   OmniMetadataParams,
-  OmniMultiplyFormAction,
-  OmniMultiplyPanel,
   OmniNotificationCallbackWithParams,
   OmniPartialValidations,
   OmniPositionSet,
   OmniProductBorrowishType,
   OmniProductPage,
-  OmniProductType,
   OmniProtocolHookProps,
   OmniProtocolSettings,
   OmniProtocolsSettings,
   OmniSidebarAutomationEditingStep,
-  OmniSidebarAutomationStep,
-  OmniSidebarBorrowPanel,
-  OmniSidebarEarnPanel,
   OmniSidebarEditingStep,
-  OmniSidebarStep,
   OmniSidebarStepsSet,
   OmniSimulationCommon,
   OmniSimulationData,
@@ -112,9 +114,9 @@ export {
   SupplyMetadata,
   WithAutomation,
 } from './src/omni-kit'
-export {
+export { ProductHubCategory, ProductHubTag } from './src/product-hub'
+export type {
   ProductHubCategories,
-  ProductHubCategory,
   ProductHubColumnKey,
   ProductHubData,
   ProductHubDatabaseQuery,
@@ -131,25 +133,32 @@ export {
   ProductHubManagementType,
   ProductHubMultiplyStrategyType,
   ProductHubSupportedNetworks,
-  ProductHubTag,
   ProductHubTags,
   ProductHubTooltipType,
 } from './src/product-hub'
-export { RaysApiResponse } from './src/server-handlers'
-export { TranslatableType } from './src/translatable'
-export {
+export type { RaysApiResponse } from './src/server-handlers'
+export type { TranslatableType } from './src/translatable'
+export { TOSStatus } from './src/terms-of-service'
+export type {
   TOSFinishedStep,
   TOSInitializedStep,
   TOSLoadingStep,
   TOSRetryStep,
   TOSState,
-  TOSStatus,
   TOSWaitingForAcceptanceStep,
   TOSWaitingForAcceptanceUpdatedStep,
   TOSWaitingForSignatureStep,
 } from './src/terms-of-service'
-export { JWTChallenge, JwtPayload } from './src/auth'
+export type { JWTChallenge, JwtPayload } from './src/auth'
 export {
+  SDKChainId,
+  SDKNetwork,
+  SDKSupportedNetworkIdsEnum,
+  UserActivityType,
+  sdkSupportedChains,
+  sdkSupportedNetworks,
+} from './src/earn-protocol'
+export type {
   ArkDetailsType,
   ArksHistoricalChartData,
   ChartDataPoints,
@@ -167,26 +176,21 @@ export {
   PlatformLogo,
   PositionForecastAPIResponse,
   Risk,
-  SDKChainId,
   SDKGlobalRebalanceType,
   SDKGlobalRebalancesType,
-  SDKNetwork,
   SDKSupportedChain,
   SDKSupportedNetwork,
-  SDKSupportedNetworkIdsEnum,
   SDKUserActivityType,
   SDKUsersActivityType,
   SDKVaultType,
   SDKVaultishType,
   SDKVaultsListType,
   UserActivity,
-  UserActivityType,
   UsersActivity,
   VaultApyData,
-  sdkSupportedChains,
-  sdkSupportedNetworks,
 } from './src/earn-protocol'
-export { DeviceInfo, DeviceType } from './src/device-type'
+export { DeviceType } from './src/device-type'
+export type { DeviceInfo } from './src/device-type'
 export { TransactionAction } from './src/transaction'
 
 export type { SdkClient } from './src/sdk-client-react'

--- a/packages/app-types/types/index.ts
+++ b/packages/app-types/types/index.ts
@@ -158,6 +158,7 @@ export {
   sdkSupportedChains,
   sdkSupportedNetworks,
 } from './src/earn-protocol'
+export type { Risk } from './src/earn-protocol/risk'
 export type {
   ArkDetailsType,
   ArksHistoricalChartData,
@@ -175,7 +176,6 @@ export type {
   PerformanceChartData,
   PlatformLogo,
   PositionForecastAPIResponse,
-  Risk,
   SDKGlobalRebalanceType,
   SDKGlobalRebalancesType,
   SDKSupportedChain,

--- a/packages/app-types/types/index.ts
+++ b/packages/app-types/types/index.ts
@@ -11,24 +11,183 @@ export {
   type ProductsConfig,
   emptyConfig as raysEmptyConfig,
 } from './src/generated/rays-config'
-export * from './src/automation'
-export * from './src/components'
-export * from './src/icons'
-export * from './src/leaderboard'
-export * from './src/migrations'
-export * from './src/lending-protocol'
-export * from './src/mixpanel'
-export * from './src/navigation'
-export * from './src/networks'
-export * from './src/omni-kit'
-export * from './src/product-hub'
-export * from './src/server-handlers'
-export * from './src/translatable'
-export * from './src/terms-of-service'
-export * from './src/auth'
-export * from './src/earn-protocol'
-export * from './src/device-type'
-export * from './src/transaction'
+export { AutomationFeatures, AutomationKinds } from './src/automation'
+export {
+  DropdownOption,
+  DropdownRawOption,
+  InlineButtonOption,
+  NavigationBrandingPill,
+  NavigationBrandingPillColor,
+  NavigationBrandingProps,
+  NavigationMenuPanelAsset,
+  NavigationMenuPanelIcon,
+  NavigationMenuPanelLink,
+  NavigationMenuPanelLinkProps,
+  NavigationMenuPanelLinkType,
+  NavigationMenuPanelList,
+  NavigationMenuPanelListTags,
+  NavigationMenuPanelProps,
+  NavigationMenuPanelType,
+  NavigationModule,
+  NavigationProps,
+  TimeframesItem,
+  TimeframesType,
+  WithNavigationModules,
+} from './src/components'
+export { IconNamesList, TokenConfig, TokenSymbolsList } from './src/icons'
+export { LeaderboardItem, LeaderboardResponse } from './src/leaderboard'
+export { PortfolioMigrations } from './src/migrations'
+export { LendingProtocol, lendingProtocolMap } from './src/lending-protocol'
+export { MixpanelEventProduct, MixpanelEventTypes } from './src/mixpanel'
+export {
+  NavigationFeaturedProduct,
+  NavigationLinkTypes,
+  NavigationMenuPanelListItem,
+  NavigationResponse,
+} from './src/navigation'
+export { NetworkHexIds, NetworkIds, NetworkNames } from './src/networks'
+export {
+  AutomationMetadataValues,
+  AutomationMetadataValuesSimulation,
+  GenericProductContext,
+  GetOmniMetadata,
+  GetOmniValidationResolverParams,
+  GetOmniValidationsParams,
+  LendingMetadata,
+  NetworkIdsWithValues,
+  OmniAutomationSimulationResponse,
+  OmniBorrowFormAction,
+  OmniCloseTo,
+  OmniEarnFormAction,
+  OmniEntryToken,
+  OmniExtraTokenData,
+  OmniFiltersParameters,
+  OmniFlowStateFilterParams,
+  OmniFormAction,
+  OmniFormDefaults,
+  OmniFormState,
+  OmniGenericPosition,
+  OmniLendingMetadataHandlers,
+  OmniMetadataParams,
+  OmniMultiplyFormAction,
+  OmniMultiplyPanel,
+  OmniNotificationCallbackWithParams,
+  OmniPartialValidations,
+  OmniPositionSet,
+  OmniProductBorrowishType,
+  OmniProductPage,
+  OmniProductType,
+  OmniProtocolHookProps,
+  OmniProtocolSettings,
+  OmniProtocolsSettings,
+  OmniSidebarAutomationEditingStep,
+  OmniSidebarAutomationStep,
+  OmniSidebarBorrowPanel,
+  OmniSidebarEarnPanel,
+  OmniSidebarEditingStep,
+  OmniSidebarStep,
+  OmniSidebarStepsSet,
+  OmniSimulationCommon,
+  OmniSimulationData,
+  OmniSimulationSwap,
+  OmniSupplyMetadataHandlers,
+  OmniSupportedNetworkIds,
+  OmniSupportedProtocols,
+  OmniSwapToken,
+  OmniTokensPrecision,
+  OmniValidationItem,
+  OmniValidationMessage,
+  OmniValidations,
+  ProductContextAutomation,
+  ProductContextAutomationForm,
+  ProductContextAutomationForms,
+  ProductContextProviderPropsWithBorrow,
+  ProductContextProviderPropsWithEarn,
+  ProductContextProviderPropsWithMultiply,
+  ProductContextWithBorrow,
+  ProductContextWithEarn,
+  ProductContextWithMultiply,
+  ProductDetailsContextProviderProps,
+  ShouldShowDynamicLtvMetadata,
+  SupplyMetadata,
+  WithAutomation,
+} from './src/omni-kit'
+export {
+  ProductHubCategories,
+  ProductHubCategory,
+  ProductHubColumnKey,
+  ProductHubData,
+  ProductHubDatabaseQuery,
+  ProductHubFeaturedFilters,
+  ProductHubFeaturedProducts,
+  ProductHubFilters,
+  ProductHubItem,
+  ProductHubItemBasics,
+  ProductHubItemData,
+  ProductHubItemDetails,
+  ProductHubItemTooltips,
+  ProductHubItemWithFlattenTooltip,
+  ProductHubItemWithoutAddress,
+  ProductHubManagementType,
+  ProductHubMultiplyStrategyType,
+  ProductHubSupportedNetworks,
+  ProductHubTag,
+  ProductHubTags,
+  ProductHubTooltipType,
+} from './src/product-hub'
+export { RaysApiResponse } from './src/server-handlers'
+export { TranslatableType } from './src/translatable'
+export {
+  TOSFinishedStep,
+  TOSInitializedStep,
+  TOSLoadingStep,
+  TOSRetryStep,
+  TOSState,
+  TOSStatus,
+  TOSWaitingForAcceptanceStep,
+  TOSWaitingForAcceptanceUpdatedStep,
+  TOSWaitingForSignatureStep,
+} from './src/terms-of-service'
+export { JWTChallenge, JwtPayload } from './src/auth'
+export {
+  ArkDetailsType,
+  ArksHistoricalChartData,
+  ChartDataPoints,
+  ChartsDataTimeframes,
+  EarnAllowanceTypes,
+  EarnProtocolDbNetwork,
+  EarnTransactionViewStates,
+  FleetRate,
+  ForecastData,
+  ForecastDataPoints,
+  GetInterestRatesParams,
+  HistoryChartData,
+  IArmadaPosition,
+  PerformanceChartData,
+  PlatformLogo,
+  PositionForecastAPIResponse,
+  Risk,
+  SDKChainId,
+  SDKGlobalRebalanceType,
+  SDKGlobalRebalancesType,
+  SDKNetwork,
+  SDKSupportedChain,
+  SDKSupportedNetwork,
+  SDKSupportedNetworkIdsEnum,
+  SDKUserActivityType,
+  SDKUsersActivityType,
+  SDKVaultType,
+  SDKVaultishType,
+  SDKVaultsListType,
+  UserActivity,
+  UserActivityType,
+  UsersActivity,
+  VaultApyData,
+  sdkSupportedChains,
+  sdkSupportedNetworks,
+} from './src/earn-protocol'
+export { DeviceInfo, DeviceType } from './src/device-type'
+export { TransactionAction } from './src/transaction'
 
 export type { SdkClient } from './src/sdk-client-react'
 export type { IToken, QuoteData } from './src/sdk-common'

--- a/packages/app-types/types/src/components/Navigation.types.ts
+++ b/packages/app-types/types/src/components/Navigation.types.ts
@@ -55,14 +55,6 @@ export interface NavigationMenuPanelAsset {
   link: string
 }
 
-export interface NavigationMenuPanelLink {
-  icon: IconNamesList
-  title: string
-  link: string
-  hash?: string
-  footnote?: ReactNode
-}
-
 export type NavigationMenuPanelListTags = ([string, string] | string)[]
 
 export interface NavigationMenuPanelList {

--- a/packages/app-types/types/src/components/index.ts
+++ b/packages/app-types/types/src/components/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   NavigationBrandingPill,
   NavigationBrandingPillColor,
   NavigationBrandingProps,
@@ -15,6 +15,6 @@ export {
   NavigationProps,
   WithNavigationModules,
 } from './Navigation.types'
-export { DropdownOption, DropdownRawOption } from './Dropdown.types'
-export { InlineButtonOption } from './InlineButtons.types'
-export { TimeframesItem, TimeframesType } from './Timeframes.types'
+export type { DropdownOption, DropdownRawOption } from './Dropdown.types'
+export type { InlineButtonOption } from './InlineButtons.types'
+export type { TimeframesItem, TimeframesType } from './Timeframes.types'

--- a/packages/app-types/types/src/components/index.ts
+++ b/packages/app-types/types/src/components/index.ts
@@ -1,4 +1,20 @@
-export * from './Navigation.types'
-export * from './Dropdown.types'
-export * from './InlineButtons.types'
-export * from './Timeframes.types'
+export {
+  NavigationBrandingPill,
+  NavigationBrandingPillColor,
+  NavigationBrandingProps,
+  NavigationMenuPanelAsset,
+  NavigationMenuPanelIcon,
+  NavigationMenuPanelLink,
+  NavigationMenuPanelLinkProps,
+  NavigationMenuPanelLinkType,
+  NavigationMenuPanelList,
+  NavigationMenuPanelListTags,
+  NavigationMenuPanelProps,
+  NavigationMenuPanelType,
+  NavigationModule,
+  NavigationProps,
+  WithNavigationModules,
+} from './Navigation.types'
+export { DropdownOption, DropdownRawOption } from './Dropdown.types'
+export { InlineButtonOption } from './InlineButtons.types'
+export { TimeframesItem, TimeframesType } from './Timeframes.types'

--- a/packages/app-types/types/src/earn-protocol/index.ts
+++ b/packages/app-types/types/src/earn-protocol/index.ts
@@ -50,8 +50,6 @@ export type SDKGlobalRebalanceType = SDKGlobalRebalancesType[0]
 export type SDKUsersActivityType = GetUsersActivityQuery['positions']
 export type SDKUserActivityType = SDKUsersActivityType[0]
 
-export type Risk = 'lower' | 'medium' | 'higher'
-
 // -ish because it can be a detailed vault or a vault from list (less details), use with that in mind
 export type SDKVaultishType = (SDKVaultType | SDKVaultsListType[number]) & VaultCustomFields
 

--- a/packages/app-types/types/src/earn-protocol/risk.ts
+++ b/packages/app-types/types/src/earn-protocol/risk.ts
@@ -1,0 +1,1 @@
+export type Risk = 'lower' | 'medium' | 'higher'

--- a/packages/app-types/types/src/sdk-client-react/index.ts
+++ b/packages/app-types/types/src/sdk-client-react/index.ts
@@ -1,2 +1,3 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // can't reexport SdkClient from @summerfi/sdk-client-react because of barrel export and issues with ts later
 export type SdkClient = any

--- a/packages/app-types/types/src/server-handlers/index.ts
+++ b/packages/app-types/types/src/server-handlers/index.ts
@@ -1,1 +1,1 @@
-export { RaysApiResponse } from './rays'
+export type { RaysApiResponse } from './rays'

--- a/packages/app-types/types/src/server-handlers/index.ts
+++ b/packages/app-types/types/src/server-handlers/index.ts
@@ -1,1 +1,1 @@
-export * from './rays'
+export { RaysApiResponse } from './rays'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1234,6 +1234,12 @@ importers:
         specifier: 19.0.8
         version: 19.0.8
     devDependencies:
+      '@summerfi/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@summerfi/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
       '@types/node':
         specifier: ^20.14.2
         version: 20.14.2
@@ -16538,7 +16544,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 4.34.9
-    dev: true
 
   /@rollup/rollup-android-arm-eabi@4.34.9:
     resolution: {integrity: sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==}
@@ -23939,6 +23944,10 @@ packages:
   /blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
 
+  /bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+    dev: true
+
   /bn.js@4.11.8:
     resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
     dev: false
@@ -27905,7 +27914,7 @@ packages:
     resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.11.6
       number-to-bn: 1.7.0
     dev: true
 
@@ -33661,7 +33670,7 @@ packages:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 4.11.6
       strip-hex-prefix: 1.0.0
     dev: true
 
@@ -39582,7 +39591,7 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || 3 || 4 || 5
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.34.9)
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       vite: 6.2.5(@types/node@20.12.7)(sass@1.77.8)(tsx@4.16.5)


### PR DESCRIPTION
This pull request refactors the export structure in the `packages/app-types/types` module to improve clarity and maintainability by replacing wildcard exports with named exports. The changes focus on making individual exports more explicit and granular across multiple files.

### Refactoring of exports:

* **`index.ts`:**
  - Replaced wildcard exports with named exports for all modules, including `automation`, `components`, `icons`, `leaderboard`, `migrations`, `lending-protocol`, `mixpanel`, `navigation`, `networks`, `omni-kit`, `product-hub`, `server-handlers`, `translatable`, `terms-of-service`, `auth`, `earn-protocol`, `device-type`, and `transaction`. This change ensures that only the required types and constants are exported explicitly.

* **`src/components/index.ts`:**
  - Replaced wildcard exports with named exports for `Navigation.types`, `Dropdown.types`, `InlineButtons.types`, and `Timeframes.types`. This provides more control over the exported entities and improves the readability of the module.

* **`src/server-handlers/index.ts`:**
  - Replaced the wildcard export for `rays` with a named export of `RaysApiResponse`, ensuring a more precise export structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated export statements to use explicit named exports instead of wildcard exports across multiple modules, improving clarity of available types and constants without affecting functionality.
  - Refined component and server handler exports for more granular type exposure.
- **Bug Fixes**
  - Removed a deprecated interface and relocated a type alias to a dedicated module for better type organization.
- **Chores**
  - Added ESLint and TypeScript configuration files to enhance code quality and maintainability.
  - Introduced new development dependencies for linting and TypeScript configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->