### PR TITLE
Fix token comparison logic in ArmadaManagerVaults

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
@@ -423,7 +423,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       })
     }
 
-    const shouldSwap = swapFromAmount.token.address.value !== fleetToken.address.value
+    const shouldSwap = !swapFromAmount.token.equals(fleetToken)
     const shouldStake = params.shouldStake ?? true
 
     let swapToAmount: ITokenAmount | undefined


### PR DESCRIPTION
Update the token comparison to use the `equals` method for accuracy in determining whether to swap tokens.