### PR TITLE
Update address for admiralsQuarters in sumr.json

### DIFF
--- a/sdk/armada-protocol-common/src/deployments/sumr.json
+++ b/sdk/armada-protocol-common/src/deployments/sumr.json
@@ -191,7 +191,7 @@
           "address": "0x09eb323dBFECB43fd746c607A9321dACdfB0140F"
         },
         "admiralsQuarters": {
-          "address": "0x275CA55c32258CE10870CA4e44c071aa14A2C836"
+          "address": "0x8cF2D41dd29aDE7E4f7555887E06A5dbE1f988EF"
         },
         "fleetCommanderRewardsManagerFactory": {
           "address": "0x83e1E5Ea1a7A5994486508bB7B7bA20f269dC90c"
@@ -340,7 +340,7 @@
           "address": "0x09eb323dBFECB43fd746c607A9321dACdfB0140F"
         },
         "admiralsQuarters": {
-          "address": "0x275CA55c32258CE10870CA4e44c071aa14A2C836"
+          "address": "0x4758276018B944DFe320E98Da5C3f4c03c3a6BDB"
         },
         "fleetCommanderRewardsManagerFactory": {
           "address": "0x83e1E5Ea1a7A5994486508bB7B7bA20f269dC90c"


### PR DESCRIPTION
Change the address for admiralsQuarters to the new specified value in the sumr.json file.

Newly deployed AdmiralsQuarters contracts:

base: 0x6A6295C8047Abf5aE8f8224a168F661e4F3Ac838
arbitrum: 0x8cF2D41dd29aDE7E4f7555887E06A5dbE1f988EF
mainnet: 0x4758276018B944DFe320E98Da5C3f4c03c3a6BDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "admiralsQuarters" contract addresses for both the Arbitrum and Mainnet environments in the deployment configuration. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->