### PR TITLE
SIP5.5 Enable onchain referrals and update AdmiralQuarters contracts

### DIFF
--- a/sdk/armada-protocol-common/src/deployments/sumr.json
+++ b/sdk/armada-protocol-common/src/deployments/sumr.json
@@ -191,7 +191,7 @@
           "address": "0x09eb323dBFECB43fd746c607A9321dACdfB0140F"
         },
         "admiralsQuarters": {
-          "address": "0x8cF2D41dd29aDE7E4f7555887E06A5dbE1f988EF"
+          "address": "0x0b966c2b4999d85ac175bee4f68fc42005f57f0b"
         },
         "fleetCommanderRewardsManagerFactory": {
           "address": "0x83e1E5Ea1a7A5994486508bB7B7bA20f269dC90c"
@@ -340,7 +340,7 @@
           "address": "0x09eb323dBFECB43fd746c607A9321dACdfB0140F"
         },
         "admiralsQuarters": {
-          "address": "0x4758276018B944DFe320E98Da5C3f4c03c3a6BDB"
+          "address": "0x1fff8345cff27fbf204644fbbcc08450d7fc63ee"
         },
         "fleetCommanderRewardsManagerFactory": {
           "address": "0x83e1E5Ea1a7A5994486508bB7B7bA20f269dC90c"
@@ -545,7 +545,7 @@
           "address": "0xa8E4716a1e8Db9dD79f1812AF30e073d3f4Cf191"
         },
         "admiralsQuarters": {
-          "address": "0xC61b22540516F70Ada02626Dc144AA9546A77343"
+          "address": "0xc5b2e6fdbc3ebdc72aa070b8e4573d2c6d125459"
         },
         "fleetCommanderRewardsManagerFactory": {
           "address": "0xC474Cd1ea6f1809d17be61717b83f0F984EF0459"


### PR DESCRIPTION
SIP5.5 Enable onchain referrals and update AdmiralQuarters contracts

Admiral Quarters Contract Updates
The following addresses are the new contracts, deployed on each chain;

Ethereum: 0x1fff8345cff27fbf204644fbbcc08450d7fc63ee
Arbitrum: 0x0b966c2b4999d85ac175bee4f68fc42005f57f0b
Sonic: 0xc5b2e6fdbc3ebdc72aa070b8e4573d2c6d125459

https://www.tally.xyz/gov/lazy-summer-dao-official/proposal/95567256139385208033190670742408005836472091751960302239690238613307243321121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Ethereum contract addresses for "admiralsQuarters" on Arbitrum, Mainnet, and Sonic networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->