### PR TITLE
Enhance RewardsService with SiloRewardFetcher integration

### DIFF
--- a/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/IRewardFetcher.ts
+++ b/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/IRewardFetcher.ts
@@ -1,0 +1,13 @@
+import { Product } from '@summerfi/summer-earn-rates-subgraph'
+import { ChainId } from '@summerfi/serverless-shared'
+import { RewardRate } from '../rewards-service'
+
+export interface IRewardFetcher {
+  /**
+   * Fetches reward rates for a batch of products
+   * @param products Array of products to fetch rewards for
+   * @param chainId Chain ID to fetch rewards on
+   * @returns Promise resolving to a record of product IDs to their reward rates
+   */
+  getRewardRates(products: Product[], chainId: ChainId): Promise<Record<string, RewardRate[]>>
+}

--- a/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/SiloRewardFetcher.ts
+++ b/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/SiloRewardFetcher.ts
@@ -1,0 +1,163 @@
+import { Product } from '@summerfi/summer-earn-rates-subgraph'
+import { ChainId } from '@summerfi/serverless-shared'
+import { Logger } from '@aws-lambda-powertools/logger'
+import { IRewardFetcher } from './IRewardFetcher'
+import { RewardRate } from '../rewards-service'
+
+interface SiloProgram {
+  rewardTokenSymbol: string
+  apr: string
+}
+
+interface SiloVaultReward {
+  vaultAddress: string
+  programs?: SiloProgram[]
+
+  chainKey?: string
+  protocolKey?: string
+  vaultSymbol?: string
+  vaultName?: string
+  [key: string]: any // Allow other fields
+}
+
+export class SiloRewardFetcher implements IRewardFetcher {
+  private readonly SILO_API_URL = 'https://v2.silo.finance/api/detailed-vault'
+  private readonly logger: Logger
+  private readonly chainIdToSiloNetworkName: Partial<Record<ChainId, string>> = {
+    [ChainId.SONIC]: 'sonic',
+  }
+  private readonly REQUEST_DELAY_MS = 100 // Delay between requests to be gentle on the API
+
+  constructor(logger: Logger) {
+    this.logger = logger
+  }
+
+  async getRewardRates(
+    products: Product[],
+    chainId: ChainId,
+  ): Promise<Record<string, RewardRate[]>> {
+    try {
+      const networkName = this.chainIdToSiloNetworkName[chainId]
+      if (!networkName) {
+        this.logger.warn(`[SiloRewardFetcher] No network name found for chainId: ${chainId}`)
+        return Object.fromEntries(products.map((product) => [product.id, []]))
+      }
+
+      const productToSiloResponse: Record<string, SiloVaultReward> = {}
+
+      // Fetch data for each product sequentially with a small delay
+      for (const product of products) {
+        try {
+          this.logger.info(
+            `[SiloRewardFetcher] Fetching rewards for vault: ${product.pool} on ${networkName}`,
+          )
+          const response = await this.fetchWithRetry(
+            `${this.SILO_API_URL}/${networkName}-${product.pool}`,
+          )
+
+          const rawData = await response.json()
+
+          // Check if response is valid
+          if (typeof rawData === 'string' || !rawData || !rawData.vaultAddress) {
+            this.logger.warn(`[SiloRewardFetcher] Invalid response for vault: ${product.pool}`)
+            continue
+          }
+
+          productToSiloResponse[product.id] = rawData as SiloVaultReward
+
+          // Add a small delay between requests to avoid overwhelming the API
+          if (products.indexOf(product) < products.length - 1) {
+            await new Promise((resolve) => setTimeout(resolve, this.REQUEST_DELAY_MS))
+          }
+        } catch (error) {
+          this.logger.error(`[SiloRewardFetcher] Error fetching data for vault ${product.pool}:`, {
+            error: error as Error,
+          })
+          // Continue with next product even if this one fails
+        }
+      }
+
+      // Process responses
+      return products.reduce(
+        (acc, product) => {
+          const vaultData = productToSiloResponse[product.id]
+
+          if (!vaultData || !vaultData.programs || !Array.isArray(vaultData.programs)) {
+            acc[product.id] = []
+            return acc
+          }
+
+          acc[product.id] = vaultData.programs
+            .filter((program) => program.rewardTokenSymbol && program.apr)
+            .map((program, index) => {
+              // Convert APR from 18 decimals and multiply by 100 for percentage
+              const aprValue = (parseFloat(program.apr) / 1e18) * 100
+
+              return {
+                rewardToken: '0x0000000000000000000000000000000000000000', // Zero address as we don't know token addresses
+                rate: aprValue.toString(),
+                index,
+                token: {
+                  address: '0x0000000000000000000000000000000000000000',
+                  symbol: program.rewardTokenSymbol,
+                  decimals: 18,
+                  precision: (10n ** BigInt(18)).toString(),
+                },
+              }
+            })
+
+          return acc
+        },
+        {} as Record<string, RewardRate[]>,
+      )
+    } catch (error) {
+      this.logger.error('[SiloRewardFetcher] Error fetching Silo rewards:', {
+        error: error as Error,
+      })
+      return Object.fromEntries(products.map((product) => [product.id, []]))
+    }
+  }
+
+  private async fetchWithRetry(url: string, options?: RequestInit): Promise<Response> {
+    const maxRetries = 5
+    const initialDelay = 2000 // 2 seconds
+    const backoffFactor = 2
+    let attempt = 0
+
+    while (attempt <= maxRetries) {
+      try {
+        const response = await fetch(url, options)
+
+        // Handle 500 errors without retry (wrong address)
+        if (response.status === 500) {
+          this.logger.warn(
+            `[SiloRewardFetcher] 500 error for ${url} - likely invalid vault address`,
+          )
+          throw new Error(`Invalid vault address: ${response.status}`)
+        }
+
+        if (response.ok) return response
+
+        // For other errors, continue with retry logic
+        const text = await response.text()
+        throw new Error(`HTTP error! status: ${response.status} ${text}`)
+      } catch (error) {
+        // If it's a 500 error, don't retry
+        if (error instanceof Error && error.message.includes('Invalid vault address')) {
+          throw error
+        }
+
+        attempt++
+        if (attempt > maxRetries) {
+          this.logger.error(`[SiloRewardFetcher] Max retries (${maxRetries}) reached for ${url}`)
+          throw error
+        }
+
+        const delay = initialDelay * Math.pow(backoffFactor, attempt - 1)
+        this.logger.warn(`[SiloRewardFetcher] Attempt ${attempt} failed. Retrying in ${delay}ms...`)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+    throw new Error('Unexpected error in fetchWithRetry')
+  }
+}


### PR DESCRIPTION
# Add SiloRewardFetcher with modular interface pattern

- Added SiloRewardFetcher to the RewardsService for fetching reward rates from the Silo protocol.
- Added IRewardFetcher interface to be used by future reward fetchers

## Description
This PR introduces a modular approach to reward fetching by creating an `IRewardFetcher` interface and implementing the first fetcher using this pattern for Silo Finance. The implementation fetches reward APRs from Silo's API while maintaining backwards compatibility with the existing RewardsService.

## Changes
- Created `IRewardFetcher` interface defining a standard contract for all reward fetchers
- Implemented `SiloRewardFetcher` class that fetches rewards from Silo Finance API
- Integrated SiloRewardFetcher into RewardsService while keeping existing code intact
- Added proper error handling for API failures (including 500 errors for invalid vaults)
- Implemented sequential fetching with delays to respect API rate limits
- Added support for Sonic chain with proper network name mapping

## Benefits
1. **Modularity**: Each protocol's reward fetching logic is now isolated in its own class
2. **Testability**: Individual fetchers can be unit tested in isolation
3. **Maintainability**: Easier to add new protocols or modify existing ones without affecting others
4. **Gradual migration**: Existing code continues to work while we migrate to the new pattern
5. **Rate limit friendly**: Sequential requests with delays prevent overwhelming the API

## Testing
- Test with Silo vaults on Sonic chain
- Verify APR calculations (18 decimal conversion to percentage)
- Test error handling with invalid vault addresses
- Verify that existing reward fetchers continue to work unchanged

## Next steps
- Migrate existing reward fetchers (Morpho, Euler, Aave, Gearbox) to implement IRewardFetcher
- Add unit tests for SiloRewardFetcher
- Extract common retry logic into a base class or utility
- Add more chain mappings as Silo expands to other networks
- Consider adding configurable rate limiting per protocol

## Additional Notes
- The Silo API returns APRs with 18 decimals which are converted to percentages
- Token addresses are currently set to zero address as we don't have the mapping yet
- 500 errors are treated as invalid vault addresses and not retried
- The implementation is conservative with a 100ms delay between requests

Please review and provide any feedback or suggestions for improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for fetching and displaying reward rates for products on the Silo protocol.
- **Improvements**
  - Enhanced reward aggregation to include Silo protocol alongside existing protocols, providing a more comprehensive rewards overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->