### PR TITLE
Update caching-for-turbo action to v1.8 across multiple workflows

### DIFF
--- a/.github/workflows/build-integration-test.yaml
+++ b/.github/workflows/build-integration-test.yaml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/build-push-deploy-rays-dashboard-staging.yaml
+++ b/.github/workflows/build-push-deploy-rays-dashboard-staging.yaml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-earn-protocol-app-new-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-app-new-production.yaml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-earn-protocol-app-staging.yaml
+++ b/.github/workflows/deploy-earn-protocol-app-staging.yaml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-earn-protocol-landing-page-new-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-new-production.yaml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-earn-protocol-landing-page-production.yaml
+++ b/.github/workflows/deploy-earn-protocol-landing-page-production.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "aws-prod"
+      - 'aws-prod'
 
 jobs:
   build-earn-protocol-landing-page:
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-lambdas-production.yaml
+++ b/.github/workflows/deploy-lambdas-production.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-lambdas-staging.yaml
+++ b/.github/workflows/deploy-lambdas-staging.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-rays-dashboard-new-production.yaml
+++ b/.github/workflows/deploy-rays-dashboard-new-production.yaml
@@ -2,8 +2,8 @@ name: Deploy New Rays Dashboard Production
 on:
   workflow_dispatch:
   push:
-      branches:
-        - 'main'
+    branches:
+      - 'main'
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:
@@ -59,15 +59,15 @@ jobs:
 
       - name: Establish VPN connection
         run: |
-              sudo apt update
-              sudo apt install -y openvpn openvpn-systemd-resolved
-              echo 'Configuring the VPN...'
-              echo "${{ secrets.NEW_VPN_CONFIG }}" > vpn-config.ovpn
-              echo "${{ secrets.NEW_VPN_USERNAME }}" > vpn-credentials.txt
-              echo "${{ secrets.NEW_VPN_PASSWORD }}" >> vpn-credentials.txt
-              echo 'Connecting to the VPN...'
-              sudo openvpn --config vpn-config.ovpn --auth-user-pass vpn-credentials.txt --daemon
-              sleep 5
+          sudo apt update
+          sudo apt install -y openvpn openvpn-systemd-resolved
+          echo 'Configuring the VPN...'
+          echo "${{ secrets.NEW_VPN_CONFIG }}" > vpn-config.ovpn
+          echo "${{ secrets.NEW_VPN_USERNAME }}" > vpn-credentials.txt
+          echo "${{ secrets.NEW_VPN_PASSWORD }}" >> vpn-credentials.txt
+          echo 'Connecting to the VPN...'
+          sudo openvpn --config vpn-config.ovpn --auth-user-pass vpn-credentials.txt --daemon
+          sleep 5
 
       - name: Check VPN connection
         env:

--- a/.github/workflows/deploy-sdk-armada-prod-new.yaml
+++ b/.github/workflows/deploy-sdk-armada-prod-new.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/deploy-sdk-infra.yaml
+++ b/.github/workflows/deploy-sdk-infra.yaml
@@ -83,6 +83,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.8
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/deploy-sdk-oasis-borrow-prod-new.yaml
+++ b/.github/workflows/deploy-sdk-oasis-borrow-prod-new.yaml
@@ -67,6 +67,9 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@v3
 
+      - name: Set up turbo cache
+        uses: rharkor/caching-for-turbo@v1.8
+
       - uses: pnpm/action-setup@v2.0.1
         with:
           version: 8.14.1

--- a/.github/workflows/deploy-sdk-staging-new.yaml
+++ b/.github/workflows/deploy-sdk-staging-new.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up turbo cache
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v1.8
 
       - uses: pnpm/action-setup@v2.0.1
         with:


### PR DESCRIPTION
Upgrade the caching-for-turbo action to version 1.8 in various workflows to enhance performance and functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the turbo cache action in multiple GitHub Actions workflows to version v1.8 for improved caching performance.
  - Standardized workflow formatting and indentation in deployment files.
  - Minor update to branch naming style in deployment triggers.
  - Added turbo cache setup steps to certain deployment workflows for enhanced build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->