### PR TITLE
Update beach club link to use dynamic host in Navigation components

### DIFF
--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationActions.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationActions.tsx
@@ -29,6 +29,8 @@ export const NavigationActions = ({
 }: NavigationActionsProps): React.ReactNode => {
   const beachClubEnabled = !!featuresConfig?.BeachClub
 
+  const host = typeof window !== 'undefined' ? window.location.origin : ''
+
   return (
     <div>
       <div className={navigationActionsStyles.navigationActionsWrapper}>
@@ -38,7 +40,7 @@ export const NavigationActions = ({
           </div>
         )}
         {beachClubEnabled && (
-          <Link href={INTERNAL_LINKS.beachClub} target="_blank">
+          <Link href={`${host}${INTERNAL_LINKS.beachClub}`}>
             <Text
               as="div"
               variant="p2semiColorfulBeachClub"

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
@@ -36,6 +36,7 @@ export const NavigationMenuMobile = ({
   featuresConfig,
 }: NavigationMobileMenuType): React.ReactNode => {
   const beachClubEnabled = !!featuresConfig?.BeachClub
+  const host = typeof window !== 'undefined' ? window.location.origin : ''
 
   return (
     <>
@@ -58,7 +59,7 @@ export const NavigationMenuMobile = ({
       <div className={navigationMenuMobileStyles.linksListWrapper}>
         <div className={navigationMenuMobileStyles.linksList}>
           {beachClubEnabled && (
-            <Link href={INTERNAL_LINKS.beachClub} target="_blank">
+            <Link href={`${host}${INTERNAL_LINKS.beachClub}`}>
               <Button
                 variant="textSecondaryLarge"
                 disabled={false}

--- a/packages/app-earn-ui/src/helpers/application-links.ts
+++ b/packages/app-earn-ui/src/helpers/application-links.ts
@@ -3,7 +3,7 @@ export const INTERNAL_LINKS = {
   summerPro: 'https://pro.summer.fi',
   summerLazy: 'https://summer.fi',
   appUrl: 'https://summer.fi',
-  beachClub: 'https://summer.fi/beach-club',
+  beachClub: '/beach-club',
   homepage: '/earn/',
   about: '/earn/about',
   privacy: '/earn/privacy',


### PR DESCRIPTION
# Update Beach Club Navigation Links

## Changes
- Modified Beach Club link handling to use relative paths instead of absolute URLs
- Updated navigation components to use dynamic host detection
- Removed `target="_blank"` from Beach Club links to keep navigation within the app

## Technical Details
- Added host detection using `window.location.origin`
- Updated `INTERNAL_LINKS.beachClub` to use relative path `/beach-club`
- Modified link handling in both desktop and mobile navigation components

## Impact
- Improves navigation consistency by keeping Beach Club links within the same window
- Reduces potential security risks by removing `target="_blank"` attributes
- Maintains proper routing regardless of the deployment environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved link handling for the Beach Club section to ensure correct navigation by dynamically using the current site origin.
  - Updated Beach Club link to use a relative path for better compatibility across environments.
  - Adjusted link behavior to open in the same tab where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->