### PR TITLE
Integrate proAppStats into landing page data and update BuildBySummer…

### DIFF
--- a/apps/earn-protocol-landing-page/app/page.tsx
+++ b/apps/earn-protocol-landing-page/app/page.tsx
@@ -93,7 +93,7 @@ export default function HomePage() {
         <SummerFiProSection />
         <CryptoUtilities />
         <Audits chainSecurityLogo={chainSecurityLogo} prototechLabsLogo={prototechLabsLogo} />
-        <BuildBySummerFi />
+        <BuildBySummerFi proAppStats={landingPageData?.proAppStats} />
         <LandingFaqSection />
         <HighestQualityYieldsDisclaimer />
       </MarketingPoints>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/BuildBySummerFi.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/BuildBySummerFi.tsx
@@ -1,4 +1,7 @@
+import { type FC } from 'react'
 import { Emphasis, INTERNAL_LINKS, Text, WithArrow } from '@summerfi/app-earn-ui'
+import { type ProAppStats } from '@summerfi/app-types'
+import { formatFiatBalance } from '@summerfi/app-utils'
 import Link from 'next/link'
 
 import buildBySummerFiStyles from '@/components/layout/LandingPageContent/content/BuildBySummerFi.module.css'
@@ -16,9 +19,9 @@ const StatBlock = ({ title, value }: { title: string; value: string }) => {
   )
 }
 
-export const BuildBySummerFi = () => {
+const BuildBySummerFiHeader = () => {
   return (
-    <div>
+    <>
       <div className={buildBySummerFiStyles.buildBySummerFiHeaderWrapper}>
         <Text variant="h2" className={buildBySummerFiStyles.buildBySummerFiHeader}>
           Built by <Emphasis variant="h2colorful">Summer.fi</Emphasis>,{' '}
@@ -38,10 +41,35 @@ export const BuildBySummerFi = () => {
           </WithArrow>
         </Link>
       </div>
+    </>
+  )
+}
+
+interface BuildBySummerFiProps {
+  proAppStats?: ProAppStats
+}
+
+export const BuildBySummerFi: FC<BuildBySummerFiProps> = ({ proAppStats }) => {
+  if (!proAppStats) {
+    return (
+      <div>
+        <BuildBySummerFiHeader />
+      </div>
+    )
+  }
+
+  const { monthlyVolume, managedOnOasis, lockedCollateralActiveTrigger } = proAppStats
+
+  return (
+    <div>
+      <BuildBySummerFiHeader />
       <div className={buildBySummerFiStyles.buildBySummerFiStatBlockWrapper}>
-        <StatBlock title="Summer.fi TVL" value="2.63B" />
-        <StatBlock title="Summer.fi 30D Volume" value="$374.66M" />
-        <StatBlock title="Capital Automated" value="$202.50M" />
+        <StatBlock title="Summer.fi TVL" value={`$${formatFiatBalance(managedOnOasis)}`} />
+        <StatBlock title="Summer.fi 30D Volume" value={`$${formatFiatBalance(monthlyVolume)}`} />
+        <StatBlock
+          title="Capital Automated"
+          value={`$${formatFiatBalance(lockedCollateralActiveTrigger)}`}
+        />
         <StatBlock title="Time Operating" value="7 years" />
       </div>
     </div>

--- a/apps/earn-protocol/app/server-handlers/pro-app-stats/get-pro-app-stats.ts
+++ b/apps/earn-protocol/app/server-handlers/pro-app-stats/get-pro-app-stats.ts
@@ -1,0 +1,29 @@
+import { INTERNAL_LINKS } from '@summerfi/app-earn-ui'
+import { type ProAppStats } from '@summerfi/app-types'
+
+const DEFAULT_STATS: ProAppStats = {
+  monthlyVolume: 0,
+  managedOnOasis: 0,
+  medianVaultSize: 0,
+  vaultsWithActiveTrigger: 0,
+  executedTriggersLast90Days: 0,
+  lockedCollateralActiveTrigger: 0,
+  triggersSuccessRate: 0,
+}
+
+export const getProAppStats = async (): Promise<ProAppStats> => {
+  try {
+    const response = await fetch(`${INTERNAL_LINKS.summerPro}/api/stats`)
+
+    if (!response.ok) {
+      return DEFAULT_STATS
+    }
+
+    return response.json()
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching pro stats:', error)
+
+    return DEFAULT_STATS
+  }
+}

--- a/packages/app-earn-ui/src/constants/revalidation.ts
+++ b/packages/app-earn-ui/src/constants/revalidation.ts
@@ -11,6 +11,7 @@ export const REVALIDATION_TIMES = {
   ALWAYS_FRESH: 0,
   MEDIAN_DEFI_YIELD: 3600,
   MIGRATION_DATA: 30,
+  PRO_APP_STATS: 3600,
 }
 
 export const REVALIDATION_TAGS = {
@@ -21,4 +22,5 @@ export const REVALIDATION_TAGS = {
   POSITION_HISTORY: 'position-history',
   CONFIG: 'config',
   MIGRATION_DATA: 'migration-data',
+  PRO_APP_STATS: 'pro-app-stats',
 }

--- a/packages/app-types/types/index.ts
+++ b/packages/app-types/types/index.ts
@@ -192,6 +192,7 @@ export type {
   GetVaultsApyResponse,
   LandingPageData,
   SupportedDefillamaTvlProtocols,
+  ProAppStats,
 } from './src/earn-protocol'
 export { supportedDefillamaProtocols, supportedDefillamaProtocolsConfig } from './src/earn-protocol'
 export { DeviceType } from './src/device-type'

--- a/packages/app-types/types/src/earn-protocol/index.ts
+++ b/packages/app-types/types/src/earn-protocol/index.ts
@@ -298,6 +298,16 @@ export type SupportedDefillamaTvlProtocols =
   | 'ethena'
   | 'fluid'
 
+export type ProAppStats = {
+  monthlyVolume: number
+  managedOnOasis: number
+  medianVaultSize: number
+  vaultsWithActiveTrigger: number
+  executedTriggersLast90Days: number
+  lockedCollateralActiveTrigger: number
+  triggersSuccessRate: number
+}
+
 export type LandingPageData = {
   systemConfig: EarnAppConfigType
   vaultsWithConfig: SDKVaultishType[]
@@ -306,4 +316,5 @@ export type LandingPageData = {
     [key in SupportedDefillamaTvlProtocols]: bigint
   }
   totalRebalances: number
+  proAppStats: ProAppStats
 }


### PR DESCRIPTION
# Add dynamic Pro app stats to landing page

## Changes
- Add dynamic stats integration from Pro app API to landing page
- Update `BuildBySummerFi` component to display real-time stats
- Add caching mechanism for Pro app stats with 1-hour revalidation
- Add new types and interfaces for Pro app stats

## Technical Details
- Added `ProAppStats` type with fields for volume, TVL, and automation metrics
- Implemented `getProAppStats` server handler with fallback to default values
- Updated landing page data API to include Pro app stats
- Added revalidation tags and times for Pro app stats caching

## Testing
- Verify Pro app stats are displayed correctly on landing page
- Check fallback behavior when stats API is unavailable
- Confirm caching mechanism works as expected

## Notes
- Stats are cached for 1 hour to prevent excessive API calls
- Default values are used when API is unavailable