### PR TITLE
Refactor YieldsChart layout and integrate YieldsLegend component for improved visualization

### DIFF
--- a/apps/earn-protocol/components/organisms/Charts/ArkHistoricalYieldChart.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/ArkHistoricalYieldChart.tsx
@@ -72,7 +72,6 @@ export const ArkHistoricalYieldChart = ({
       style={{
         marginTop: 'var(--spacing-space-medium)',
         flexDirection: 'column',
-        paddingBottom: 0,
         position: 'relative',
       }}
     >

--- a/apps/earn-protocol/components/organisms/Charts/PositionHistoricalChart.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/PositionHistoricalChart.tsx
@@ -11,7 +11,6 @@ import {
 } from '@summerfi/app-types'
 
 import { HistoricalChart } from '@/components/organisms/Charts/components/Historical'
-import { POINTS_REQUIRED_FOR_CHART } from '@/constants/charts'
 
 type PositionHistoricalChartProps = {
   chartData: HistoryChartData
@@ -42,20 +41,13 @@ export const PositionHistoricalChart = ({
     return chartData.data[timeframe ?? defaultTimeframe]
   }, [chartData, timeframe])
 
-  const chartHidden = parsedData.length < POINTS_REQUIRED_FOR_CHART[timeframe ?? defaultTimeframe]
-
   return (
     <Card
       style={{
         marginTop: 'var(--spacing-space-medium)',
         flexDirection: 'column',
-        paddingBottom: 0,
+        padding: 0,
         position: 'relative',
-        ...(chartHidden && {
-          // so much hacks just because the legend is used as a separate UI element
-          // will need to refactor this
-          paddingLeft: 0,
-        }),
       }}
       className={classNames.positionHistoricalChartWrapper}
     >

--- a/apps/earn-protocol/components/organisms/Charts/components/Historical.module.css
+++ b/apps/earn-protocol/components/organisms/Charts/components/Historical.module.css
@@ -1,0 +1,11 @@
+.historicalChartWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}

--- a/apps/earn-protocol/components/organisms/Charts/components/Historical.module.css.d.ts
+++ b/apps/earn-protocol/components/organisms/Charts/components/Historical.module.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "historicalChartWrapper": string;
+};
+export = styles;
+

--- a/apps/earn-protocol/components/organisms/Charts/components/Historical.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/components/Historical.tsx
@@ -17,7 +17,6 @@ import dayjs from 'dayjs'
 import {
   ComposedChart,
   Customized,
-  Legend,
   Line,
   ResponsiveContainer,
   Tooltip,
@@ -35,6 +34,8 @@ import {
 } from '@/constants/charts'
 import { useDeviceType } from '@/contexts/DeviceContext/DeviceContext'
 import { formatChartCryptoValue } from '@/features/forecast/chart-formatters'
+
+import historicalChartStyles from './Historical.module.css'
 
 type HistoricalChartProps = {
   data?: unknown[]
@@ -73,145 +74,141 @@ export const HistoricalChart = ({
   const chartHidden = !data || data.length < POINTS_REQUIRED_FOR_CHART[timeframe]
 
   return (
-    <RechartResponsiveWrapper height="340px">
-      {chartHidden && (
-        <NotEnoughData
-          style={{
-            width: '80%',
-            backgroundColor: 'var(--color-surface-subtle)',
-          }}
-        />
-      )}
-      <ResponsiveContainer
-        width={chartHidden ? '30%' : '100%'}
-        height="100%"
-        style={
-          chartHidden
-            ? {
-                marginLeft: '70%',
-              }
-            : {
-                marginLeft: '-50px',
-              }
-        }
-      >
-        <ComposedChart
-          data={data}
-          margin={{
-            top: chartHidden ? 0 : 20,
-            right: 0,
-            left: 10,
-            bottom: 10,
-          }}
-          onMouseMove={({ activePayload }) => {
-            if (activePayload && !chartHidden) {
-              setHighlightedData((prevData) => ({
-                ...prevData,
-                ...activePayload.reduce(
-                  (acc, { dataKey, value, payload: { timestamp } }) => ({
-                    ...acc,
-                    timestamp,
-                    timeframe,
-                    [dataKey]: `${formatCryptoBalance(value)} ${positionToken}`,
-                  }),
-                  {},
-                ),
-              }))
-            }
-          }}
-          onMouseLeave={() => {
-            setHighlightedData(legendBaseData)
-          }}
-          dataKey="netValue"
-        >
-          <XAxis
-            dataKey="timestampParsed"
-            fontSize={12}
-            tickMargin={10}
-            tickFormatter={(timestamp: string) => {
-              return timestamp.split(' ')[0]
-            }}
-            hide={chartHidden}
-          />
-          <YAxis
-            strokeWidth={0}
-            tickFormatter={(label: string) => formatChartCryptoValue(Number(label))}
-            interval="preserveStartEnd"
-            scale="linear"
-            width={65}
-            domain={[
-              (dataMin: number) => {
-                return Math.max(dataMin - Number(dataMin * 0.001), 0)
-              },
-              (dataMax: number) => {
-                return dataMax + Number(dataMax * 0.001)
-              },
-            ]}
-            hide={chartHidden}
-          />
-          {/* Tooltip is needed for the chart cross to work */}
-          <Tooltip
-            formatter={() => {
-              return ''
-            }}
-            itemStyle={{
-              display: 'none',
-            }}
-            labelStyle={{
-              color: 'white',
-              fontSize: '12px',
-            }}
-            labelFormatter={(label: string) => {
-              const parsedTimestamp = dayjs(label)
-              const formattedDate = parsedTimestamp.format(
-                ['7d', '30d'].includes(timeframe)
-                  ? CHART_TIMESTAMP_FORMAT_DETAILED
-                  : CHART_TIMESTAMP_FORMAT_SHORT,
-              )
-
-              return formattedDate
-            }}
-            contentStyle={{
-              borderRadius: '14px',
+    <div className={historicalChartStyles.historicalChartWrapper}>
+      <RechartResponsiveWrapper height="340px">
+        {chartHidden && (
+          <NotEnoughData
+            style={{
               backgroundColor: 'var(--color-surface-subtle)',
-              border: 'none',
             }}
           />
-          {!chartHidden ? <Customized component={<ChartCross />} /> : null}
-          <Line
-            dot={false}
-            type="monotone"
+        )}
+        <ResponsiveContainer
+          width={chartHidden ? '0' : '100%'}
+          height="100%"
+          style={
+            chartHidden
+              ? {
+                  marginLeft: '0',
+                }
+              : {
+                  marginLeft: '-20px',
+                }
+          }
+        >
+          <ComposedChart
+            data={data}
+            margin={{
+              top: chartHidden ? 0 : 20,
+              right: 0,
+              left: 10,
+              bottom: 10,
+            }}
+            onMouseMove={({ activePayload }) => {
+              if (activePayload && !chartHidden) {
+                setHighlightedData((prevData) => ({
+                  ...prevData,
+                  ...activePayload.reduce(
+                    (acc, { dataKey, value, payload: { timestamp } }) => ({
+                      ...acc,
+                      timestamp,
+                      timeframe,
+                      [dataKey]: `${formatCryptoBalance(value)} ${positionToken}`,
+                    }),
+                    {},
+                  ),
+                }))
+              }
+            }}
+            onMouseLeave={() => {
+              setHighlightedData(legendBaseData)
+            }}
             dataKey="netValue"
-            stroke="#FF80BF"
-            activeDot={false}
-            connectNulls
-            animationDuration={400}
-            animateNewValues
-            hide={chartHidden}
-          />
-          <Line
-            dot={false}
-            type="stepAfter"
-            dataKey="depositedValue"
-            stroke="#FF49A4"
-            activeDot={false}
-            connectNulls
-            animationDuration={400}
-            animateNewValues
-            hide={chartHidden}
-          />
-          <Legend
-            content={
-              <HistoricalLegend tokenSymbol={tokenSymbol} highlightedData={highlightedData} />
-            }
-            iconType="circle"
-            iconSize={10}
-            align={isMobile ? 'center' : 'right'}
-            verticalAlign={isMobile ? 'bottom' : 'top'}
-            layout="vertical"
-          />
-        </ComposedChart>
-      </ResponsiveContainer>
-    </RechartResponsiveWrapper>
+          >
+            <XAxis
+              dataKey="timestampParsed"
+              fontSize={12}
+              tickMargin={10}
+              tickFormatter={(timestamp: string) => {
+                return timestamp.split(' ')[0]
+              }}
+              hide={chartHidden}
+            />
+            <YAxis
+              strokeWidth={0}
+              tickFormatter={(label: string) => formatChartCryptoValue(Number(label))}
+              interval="preserveStartEnd"
+              scale="linear"
+              width={65}
+              domain={[
+                (dataMin: number) => {
+                  return Math.max(dataMin - Number(dataMin * 0.001), 0)
+                },
+                (dataMax: number) => {
+                  return dataMax + Number(dataMax * 0.001)
+                },
+              ]}
+              hide={chartHidden}
+            />
+            {/* Tooltip is needed for the chart cross to work */}
+            <Tooltip
+              formatter={() => {
+                return ''
+              }}
+              itemStyle={{
+                display: 'none',
+              }}
+              labelStyle={{
+                color: 'white',
+                fontSize: '12px',
+              }}
+              labelFormatter={(label: string) => {
+                const parsedTimestamp = dayjs(label)
+                const formattedDate = parsedTimestamp.format(
+                  ['7d', '30d'].includes(timeframe)
+                    ? CHART_TIMESTAMP_FORMAT_DETAILED
+                    : CHART_TIMESTAMP_FORMAT_SHORT,
+                )
+
+                return formattedDate
+              }}
+              contentStyle={{
+                borderRadius: '14px',
+                backgroundColor: 'var(--color-surface-subtle)',
+                border: 'none',
+              }}
+            />
+            {!chartHidden ? <Customized component={<ChartCross />} /> : null}
+            <Line
+              dot={false}
+              type="monotone"
+              dataKey="netValue"
+              stroke="#FF80BF"
+              activeDot={false}
+              connectNulls
+              animationDuration={400}
+              animateNewValues
+              hide={chartHidden}
+            />
+            <Line
+              dot={false}
+              type="stepAfter"
+              dataKey="depositedValue"
+              stroke="#FF49A4"
+              activeDot={false}
+              connectNulls
+              animationDuration={400}
+              animateNewValues
+              hide={chartHidden}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </RechartResponsiveWrapper>
+      <HistoricalLegend
+        tokenSymbol={tokenSymbol}
+        highlightedData={highlightedData}
+        isMobile={isMobile}
+      />
+    </div>
   )
 }

--- a/apps/earn-protocol/components/organisms/Charts/components/HistoricalLegend.module.css
+++ b/apps/earn-protocol/components/organisms/Charts/components/HistoricalLegend.module.css
@@ -1,9 +1,16 @@
 .historicalLegendWrapper {
   margin-left: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  gap: var(--spacing-space-medium);
 }
 @media (min-width: 768px) {
   .historicalLegendWrapper {
-    margin-left: 80px;
+    flex-direction: column;
+    margin-left: 40px;
+    min-width: 190px;
   }
 }
 

--- a/apps/earn-protocol/components/organisms/Charts/components/HistoricalLegend.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/components/HistoricalLegend.tsx
@@ -1,17 +1,17 @@
-import { type ReactNode } from 'react'
+import { type FC, type ReactNode } from 'react'
 import { Icon, Text } from '@summerfi/app-earn-ui'
 import { type TokenSymbolsList } from '@summerfi/app-types'
-import { DefaultLegendContent, type LegendProps } from 'recharts'
 
 import { historicalPerformanceLabelMap } from '@/components/organisms/Charts/labels'
 
 import historicalLegendStyles from './HistoricalLegend.module.css'
 
-type HistoricalLegendProps = LegendProps & {
+type HistoricalLegendProps = {
   tokenSymbol: TokenSymbolsList
   highlightedData: {
     [key in keyof typeof historicalPerformanceLabelMap]: string | number
   }
+  isMobile: boolean
 }
 
 const LegendBlock = ({
@@ -42,17 +42,39 @@ const LegendBlock = ({
   </div>
 )
 
-export const HistoricalLegend = ({
-  payload,
-  ref: _ref,
+export const HistoricalLegend: FC<HistoricalLegendProps> = ({
   tokenSymbol,
   highlightedData,
-  ...rest
-}: HistoricalLegendProps) => {
-  const emptyLegendIcon = <circle cx="0" cy="0" r="0" fill="transparent" />
-  const earningsBlock = {
-    legendIcon: emptyLegendIcon,
-    value: (
+  isMobile,
+}) => {
+  return (
+    <div
+      className={historicalLegendStyles.historicalLegendWrapper}
+      style={{
+        textAlign: isMobile ? 'center' : 'right',
+        marginTop: isMobile ? 'var(--general-space-32)' : '0',
+      }}
+    >
+      <LegendBlock
+        color="#FF80BF"
+        title={historicalPerformanceLabelMap.netValue}
+        value={
+          <>
+            <Icon tokenName={tokenSymbol} size={20} />
+            <Text variant="p1semi">{highlightedData.netValue}</Text>
+          </>
+        }
+      />
+      <LegendBlock
+        color="#FF49A4"
+        title={historicalPerformanceLabelMap.depositedValue}
+        value={
+          <>
+            <Icon tokenName={tokenSymbol} size={20} />
+            <Text variant="p1semi">{highlightedData.depositedValue}</Text>
+          </>
+        }
+      />
       <LegendBlock
         color="var(--color-background-interactive-disabled)"
         title={historicalPerformanceLabelMap.earnings}
@@ -63,11 +85,6 @@ export const HistoricalLegend = ({
           </>
         }
       />
-    ),
-  }
-  const sumrEarnedBlock = {
-    legendIcon: emptyLegendIcon,
-    value: (
       <LegendBlock
         color="white"
         title={historicalPerformanceLabelMap.sumrEarned}
@@ -78,34 +95,6 @@ export const HistoricalLegend = ({
           </>
         }
       />
-    ),
-  }
-  const nextPayload = [
-    ...(payload?.map(({ dataKey, inactive: _inactive, ...entry }) => ({
-      ...entry,
-      legendIcon: emptyLegendIcon,
-      value: (
-        <LegendBlock
-          color={entry.color as string}
-          title={historicalPerformanceLabelMap[entry.value as string] ?? entry.value}
-          value={
-            <>
-              <Icon tokenName={tokenSymbol} size={20} />
-              <Text variant="p1semi">
-                {highlightedData[dataKey as keyof typeof highlightedData] ?? entry.value}
-              </Text>
-            </>
-          }
-        />
-      ),
-    })) ?? []),
-    earningsBlock,
-    sumrEarnedBlock,
-  ]
-
-  return (
-    <div className={historicalLegendStyles.historicalLegendWrapper}>
-      <DefaultLegendContent payload={nextPayload} {...rest} />
     </div>
   )
 }

--- a/apps/earn-protocol/components/organisms/Charts/components/Yields.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/components/Yields.tsx
@@ -4,7 +4,6 @@ import { type ArksHistoricalChartData, type TimeframesType } from '@summerfi/app
 import {
   Area,
   ComposedChart,
-  Legend,
   Line,
   ReferenceArea,
   ResponsiveContainer,
@@ -14,6 +13,8 @@ import {
 } from 'recharts'
 
 import { formatChartPercentageValue } from '@/features/forecast/chart-formatters'
+
+import { YieldsLegend } from './YieldsLegend'
 
 type YieldsChartProps = {
   data: ArksHistoricalChartData['data'][TimeframesType]
@@ -44,137 +45,128 @@ export const YieldsChart = ({
   const [highlightedProtocol, setHighlightedProtocol] = useState<string>()
 
   return (
-    <RechartResponsiveWrapper height="550px">
-      <ResponsiveContainer width="100%" height="90%">
-        <ComposedChart
-          data={data}
-          onMouseDown={selectionHandlers?.handleMouseDown}
-          onMouseMove={selectionHandlers?.handleMouseMove}
-          onMouseUp={selectionHandlers?.handleMouseUp}
-          margin={{
-            top: 50,
-            right: 0,
-            left: 0,
-            bottom: 10,
-          }}
-        >
-          <defs>
-            <linearGradient id="summerYieldGradient" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#FF49A4" stopOpacity={0.8} />
-              <stop offset="100%" stopColor="#333333" stopOpacity={0.4} />
-            </linearGradient>
-          </defs>
-          <XAxis
-            dataKey="timestamp"
-            fontSize={12}
-            interval="preserveStartEnd"
-            tickMargin={10}
-            tickFormatter={(timestamp: string) => {
-              return timestamp.split(' ')[0]
+    <>
+      <RechartResponsiveWrapper height="450px">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            data={data}
+            onMouseDown={selectionHandlers?.handleMouseDown}
+            onMouseMove={selectionHandlers?.handleMouseMove}
+            onMouseUp={selectionHandlers?.handleMouseUp}
+            margin={{
+              top: 50,
+              right: 0,
+              left: 0,
+              bottom: 10,
             }}
-            style={{
-              userSelect: 'none',
-            }}
-          />
-          <YAxis
-            strokeWidth={0}
-            tickFormatter={(label: string) => `${formatChartPercentageValue(Number(label))}`}
-            style={{
-              userSelect: 'none',
-            }}
-          />
-          <Tooltip
-            formatter={(val) => `${formatChartPercentageValue(Number(val), true)}`}
-            wrapperStyle={{
-              zIndex: 1000,
-              backgroundColor: 'var(--color-surface-subtle)',
-              borderRadius: '5px',
-              padding: '10px',
-              display: isSelectingZoom ? 'none' : 'block',
-            }}
-            labelStyle={{
-              fontSize: '16px',
-              fontWeight: '700',
-              marginTop: '10px',
-              marginBottom: '10px',
-            }}
-            contentStyle={{
-              backgroundColor: 'transparent',
-              border: 'none',
-              fontSize: '13px',
-              lineHeight: '11px',
-              letterSpacing: '-0.5px',
-            }}
-          />
-          {dataNames.map((dataName, dataIndex) => {
-            return dataName === summerVaultName ? (
-              <Area
-                key={dataName}
-                type={data.length > 100 ? 'linear' : 'natural'}
-                animationDuration={300}
-                animationBegin={dataIndex * 50}
-                animationEasing="ease-out"
-                connectNulls
-                dataKey={dataName}
-                strokeWidth={highlightedProtocol === dataName ? 2 : 1}
-                stroke={colors[dataName as keyof typeof colors]}
-                opacity={highlightedProtocol && highlightedProtocol !== dataName ? 0.1 : 1}
-                fillOpacity={1}
-                style={{
-                  transition: 'opacity 0.3s',
-                }}
-                fill="url(#summerYieldGradient)"
-              />
-            ) : (
-              <Line
-                key={dataName}
-                type={data.length > 100 ? 'linear' : 'natural'}
-                animationId={dataIndex}
-                animationDuration={300}
-                animationBegin={dataIndex * 50}
-                animationEasing="ease-out"
-                dataKey={dataName}
-                stroke={colors[dataName as keyof typeof colors]}
-                strokeWidth={highlightedProtocol === dataName ? 2 : 1}
-                style={{
-                  transition: 'opacity 0.3s',
-                }}
-                opacity={highlightedProtocol && highlightedProtocol !== dataName ? 0.1 : 1}
-                dot={false}
-                connectNulls
-              />
-            )
-          })}
-          {isSelectingZoom && selectionZoomStart !== null && selectionZoomEnd !== null && (
-            <ReferenceArea
-              x1={data[selectionZoomStart]?.timestamp}
-              x2={data[selectionZoomEnd]?.timestamp}
-              strokeOpacity={0.3}
-              fillOpacity={0.2}
-              fill="#FF49A4"
-              stroke="#FF49A4"
+          >
+            <defs>
+              <linearGradient id="summerYieldGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#FF49A4" stopOpacity={0.8} />
+                <stop offset="100%" stopColor="#333333" stopOpacity={0.4} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="timestamp"
+              fontSize={12}
+              interval="preserveStartEnd"
+              tickMargin={10}
+              tickFormatter={(timestamp: string) => {
+                return timestamp.split(' ')[0]
+              }}
+              style={{
+                userSelect: 'none',
+              }}
             />
-          )}
-          <Legend
-            onMouseEnter={({ dataKey }) => {
-              setHighlightedProtocol(dataKey as string)
-            }}
-            onMouseLeave={() => {
-              setHighlightedProtocol(undefined)
-            }}
-            wrapperStyle={{
-              userSelect: 'none',
-              padding: '20px 40px 0',
-              fontSize: '14px',
-            }}
-            iconType="circle"
-            iconSize={10}
-            align="center"
-            layout="horizontal"
-            height={60}
-          />
-        </ComposedChart>
-      </ResponsiveContainer>
-    </RechartResponsiveWrapper>
+            <YAxis
+              strokeWidth={0}
+              tickFormatter={(label: string) => `${formatChartPercentageValue(Number(label))}`}
+              style={{
+                userSelect: 'none',
+              }}
+            />
+            <Tooltip
+              formatter={(val) => `${formatChartPercentageValue(Number(val), true)}`}
+              wrapperStyle={{
+                zIndex: 1000,
+                backgroundColor: 'var(--color-surface-subtle)',
+                borderRadius: '5px',
+                padding: '10px',
+                display: isSelectingZoom ? 'none' : 'block',
+              }}
+              labelStyle={{
+                fontSize: '16px',
+                fontWeight: '700',
+                marginTop: '10px',
+                marginBottom: '10px',
+              }}
+              contentStyle={{
+                backgroundColor: 'transparent',
+                border: 'none',
+                fontSize: '13px',
+                lineHeight: '11px',
+                letterSpacing: '-0.5px',
+              }}
+            />
+            {dataNames.map((dataName, dataIndex) => {
+              return dataName === summerVaultName ? (
+                <Area
+                  key={dataName}
+                  type={data.length > 100 ? 'linear' : 'natural'}
+                  animationDuration={300}
+                  animationBegin={dataIndex * 50}
+                  animationEasing="ease-out"
+                  connectNulls
+                  dataKey={dataName}
+                  strokeWidth={highlightedProtocol === dataName ? 2 : 1}
+                  stroke={colors[dataName as keyof typeof colors]}
+                  opacity={highlightedProtocol && highlightedProtocol !== dataName ? 0.1 : 1}
+                  fillOpacity={1}
+                  style={{
+                    transition: 'opacity 0.3s',
+                  }}
+                  fill="url(#summerYieldGradient)"
+                />
+              ) : (
+                <Line
+                  key={dataName}
+                  type={data.length > 100 ? 'linear' : 'natural'}
+                  animationId={dataIndex}
+                  animationDuration={300}
+                  animationBegin={dataIndex * 50}
+                  animationEasing="ease-out"
+                  dataKey={dataName}
+                  stroke={colors[dataName as keyof typeof colors]}
+                  strokeWidth={highlightedProtocol === dataName ? 2 : 1}
+                  style={{
+                    transition: 'opacity 0.3s',
+                  }}
+                  opacity={highlightedProtocol && highlightedProtocol !== dataName ? 0.1 : 1}
+                  dot={false}
+                  connectNulls
+                />
+              )
+            })}
+            {isSelectingZoom && selectionZoomStart !== null && selectionZoomEnd !== null && (
+              <ReferenceArea
+                x1={data[selectionZoomStart]?.timestamp}
+                x2={data[selectionZoomEnd]?.timestamp}
+                strokeOpacity={0.3}
+                fillOpacity={0.2}
+                fill="#FF49A4"
+                stroke="#FF49A4"
+              />
+            )}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </RechartResponsiveWrapper>
+      <YieldsLegend
+        dataNames={dataNames}
+        colors={colors}
+        highlightedProtocol={highlightedProtocol}
+        onMouseEnter={setHighlightedProtocol}
+        onMouseLeave={() => setHighlightedProtocol(undefined)}
+      />
+    </>
   )
 }

--- a/apps/earn-protocol/components/organisms/Charts/components/YieldsLegend.module.css
+++ b/apps/earn-protocol/components/organisms/Charts/components/YieldsLegend.module.css
@@ -1,0 +1,27 @@
+.legendWrapper {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--general-space-8);
+  padding-top: var(--general-space-12);
+  user-select: none;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: var(--general-space-8);
+  cursor: pointer;
+  transition: opacity 0.3s;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-circle);
+}
+
+.legendItemText {
+  color: var(--color-text-primary);
+  font-size: 14px;
+}

--- a/apps/earn-protocol/components/organisms/Charts/components/YieldsLegend.module.css.d.ts
+++ b/apps/earn-protocol/components/organisms/Charts/components/YieldsLegend.module.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  readonly "dot": string;
+  readonly "legendItem": string;
+  readonly "legendItemText": string;
+  readonly "legendWrapper": string;
+};
+export = styles;
+

--- a/apps/earn-protocol/components/organisms/Charts/components/YieldsLegend.tsx
+++ b/apps/earn-protocol/components/organisms/Charts/components/YieldsLegend.tsx
@@ -1,0 +1,53 @@
+import { type FC } from 'react'
+import { Text } from '@summerfi/app-earn-ui'
+
+import classNames from './YieldsLegend.module.css'
+
+type YieldsLegendProps = {
+  dataNames: string[]
+  colors: { [key: string]: string }
+  highlightedProtocol?: string
+  onMouseEnter: (dataKey: string) => void
+  onMouseLeave: () => void
+}
+
+export const YieldsLegend: FC<YieldsLegendProps> = ({
+  dataNames,
+  colors,
+  highlightedProtocol,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  return (
+    <div className={classNames.legendWrapper}>
+      {dataNames.map((dataName) => (
+        <div
+          key={dataName}
+          className={classNames.legendItem}
+          onMouseEnter={() => onMouseEnter(dataName)}
+          onMouseLeave={onMouseLeave}
+          style={{
+            opacity: highlightedProtocol && highlightedProtocol !== dataName ? 0.1 : 1,
+          }}
+        >
+          <div
+            className={classNames.dot}
+            style={{
+              backgroundColor: colors[dataName],
+              border:
+                highlightedProtocol === dataName ? '2px solid var(--color-text-primary)' : 'none',
+            }}
+          />
+          <Text
+            as="p"
+            variant="p3"
+            className={classNames.legendItemText}
+            style={{ color: colors[dataName] }}
+          >
+            {dataName}
+          </Text>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioOverview/PortfolioOverview.tsx
@@ -182,7 +182,15 @@ export const PortfolioOverview = ({
           </Card>
         ))}
         <Card style={{ flexDirection: 'column' }} variant="cardSecondary">
-          <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+              flexWrap: 'wrap',
+              gap: 'var(--spacing-space-small)',
+            }}
+          >
             <Text as="h5" variant="h5">
               Positions
             </Text>

--- a/apps/earn-protocol/features/vault-details/components/VaultDetailsAdvancedYield/VaultDetailsAdvancedYield.tsx
+++ b/apps/earn-protocol/features/vault-details/components/VaultDetailsAdvancedYield/VaultDetailsAdvancedYield.tsx
@@ -85,7 +85,7 @@ export const VaultDetailsAdvancedYield: FC<VaultDetailsAdvancedYieldProps> = ({
         variant="p2semi"
         style={{
           marginBottom: 'var(--spacing-space-medium)',
-          marginTop: 'var(--spacing-space-medium)',
+          marginTop: 'var(--spacing-space-x-large)',
         }}
       >
         Individual Yield Data


### PR DESCRIPTION
# Chart Legend Refactoring and UI Improvements

## Changes
- Extracted chart legend into a separate `YieldsLegend` component for better maintainability
- Improved legend styling with custom CSS module implementation
- Adjusted chart height from 550px to 450px for better proportions
- Removed padding-bottom from ArkHistoricalYieldChart container
- Increased top margin for "Individual Yield Data" section

## Benefits
- Better component separation and reusability
- Enhanced legend interactivity with hover states
- Improved visual hierarchy and spacing
- More consistent styling using CSS modules

## Testing
- Verify chart legend hover interactions work correctly
- Check chart responsiveness at different viewport sizes
- Ensure all protocol data points are correctly displayed
- Validate chart tooltips and interactions

## Screenshots
[Add screenshots showing the new legend implementation and layout changes]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a custom legend for yield charts, enhancing data visualization and interactivity.

- **Style**
  - Updated chart and legend styling for improved appearance and clarity.
  - Reduced the chart container height for a more compact layout.
  - Increased spacing above the "Individual Yield Data" heading for better readability.
  - Improved responsive layout and spacing in chart legends and portfolio overview sections.

- **Refactor**
  - Replaced the default chart legend with a newly designed custom legend component.
  - Restructured historical and yield charts for clearer layout and separation of legend components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->