### PR TITLE
fix: Make pool and vault optional in ArkDetailsType for better flexibility

### DIFF
--- a/packages/app-types/types/src/earn-protocol/index.ts
+++ b/packages/app-types/types/src/earn-protocol/index.ts
@@ -159,7 +159,8 @@ export type ArkDetailsType = {
   type: string
   asset: string
   marketAsset: string
-  pool: string
+  pool?: string
+  vault?: string
   chainId: number
 }
 

--- a/packages/app-utils/src/helpers/get-ark-product-id.ts
+++ b/packages/app-utils/src/helpers/get-ark-product-id.ts
@@ -8,7 +8,9 @@ export const getArkProductId = (
   }
   const parsedDetails = JSON.parse(ark.details as string) as ArkDetailsType
 
-  if (!('pool' in parsedDetails)) {
+  const resolvedPool = parsedDetails.pool || parsedDetails.vault
+
+  if (!resolvedPool) {
     return false
   }
 
@@ -22,7 +24,7 @@ export const getArkProductId = (
     protocol = 'Fluid'
   }
   const assetAddress = ark.inputToken.id.toLowerCase()
-  const poolAddress = parsedDetails.pool.toLowerCase()
+  const poolAddress = resolvedPool.toLowerCase()
   const chainId = String(parsedDetails.chainId).toLowerCase()
 
   return `${protocol}-${assetAddress}-${poolAddress}-${chainId}`


### PR DESCRIPTION
# Ark Protocol Integration Enhancement

## Changes
- Made `pool` field optional in `ArkDetailsType` interface
- Added `vault` field to `ArkDetailsType` interface
- Updated `getArkProductId` to handle both pool and vault identifiers

## Details
The changes improve flexibility in handling Ark protocol product identifiers by:
- Supporting both pool and vault-based products
- Maintaining backward compatibility with existing pool-based products
- Using a fallback mechanism to resolve product IDs

## Testing
- Verify product ID generation works for both pool and vault-based products
- Ensure backward compatibility with existing pool-based products

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for handling both "pool" and "vault" identifiers when generating product IDs, improving flexibility for different data formats.

- **Bug Fixes**
  - Resolved issues where product IDs could not be generated if only a "vault" identifier was present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->