### PR TITLE
Trigger E2E regression tests whe releasing prod

### DIFF
--- a/.github/workflows/release-earn-apps.yaml
+++ b/.github/workflows/release-earn-apps.yaml
@@ -56,3 +56,16 @@ jobs:
           git rebase dev
           git push origin main
           git status
+      
+      - name: Trigger prod-release e2e tests in e2e-tests repository
+        env:
+          E2E_TESTS_PAT: ${{ secrets.E2E_TESTS_PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.E2E_TESTS_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OasisDEX/e2e-tests/actions/workflows/ci_lazy_prod_release_trigger_sleep.yml/dispatches \
+            -d "{\"ref\":\"main\", \"inputs\":{\"run_id\":\"${{ github.run_id }}\", \"repository\":\"${{ github.repository }}\"}}"
+          echo 'See test results in https://github.com/OasisDEX/e2e-tests/actions/workflows/ci_lazy_prod_release_trigger_sleep.yml --> Job with RUN_ID ${{ github.run_id }} in the logs.'


### PR DESCRIPTION
## Description
Triggering E2E regression tests when releasing prod

## Changes
- Adding trigger in release-earn-apps.yaml file

## Benefits
1. Spotting issues that only occur on production after a release, like SDK mismatch preventing users from depositing, etc.


Please review and provide any feedback or suggestions for improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the release workflow to automatically trigger end-to-end tests in a separate repository after each production release. Users are now directed to the relevant workflow run logs for test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->