### PR TITLE
Disable prefetching for links across multiple components

### DIFF
--- a/apps/earn-protocol-landing-page/app/institutions/page.tsx
+++ b/apps/earn-protocol-landing-page/app/institutions/page.tsx
@@ -33,7 +33,7 @@ const FinalCTAElement = ({
       <Text variant="p2semi" as="p">
         {title}
       </Text>
-      <Link href={url}>
+      <Link href={url} prefetch={false}>
         <WithArrow variant="p2semi">{urlLabel}</WithArrow>
       </Link>
     </div>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/LandingPageBanners.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/LandingPageBanners.tsx
@@ -24,6 +24,7 @@ export const LandingPageBanners = () => {
               paddingLeft: 'var(--general-space-4)',
             }}
             target="_blank"
+            prefetch={false}
           >
             Read more
           </Link>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/LandingPageHero.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/LandingPageHero.tsx
@@ -53,7 +53,7 @@ export const LandingPageHero = ({
         <div className={landingPageHeroStyles.heroHeaderPartB}>{headerPartB}</div>
       </div>
       <HomepageCarousel vaultsList={vaultsList} vaultsApyByNetworkMap={vaultsApyByNetworkMap} />
-      <Link href="/earn">
+      <Link href="/earn" prefetch={false}>
         <Text className={landingPageHeroStyles.viewAllStrategies} variant="p3semi">
           {vaultsList?.length ? (
             <WithArrow style={{ color: 'white' }}>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/ProtocolScroller.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/ProtocolScroller.tsx
@@ -95,7 +95,11 @@ const ProtocolScrollerItem = ({ protocolIcon, protocol, tvl, url }: ProtocolScro
     return insides
   }
 
-  return <Link href={url}>{insides}</Link>
+  return (
+    <Link href={url} prefetch={false}>
+      {insides}
+    </Link>
+  )
 }
 
 export const ProtocolScroller = ({

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/BuildBySummerFi.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/BuildBySummerFi.tsx
@@ -35,7 +35,7 @@ const BuildBySummerFiHeader = () => {
         </Text>
       </div>
       <div className={buildBySummerFiStyles.buildBySummerFiBottomLink}>
-        <Link href={`${INTERNAL_LINKS.summerPro}/about`} target="_blank">
+        <Link href={`${INTERNAL_LINKS.summerPro}/about`} target="_blank" prefetch={false}>
           <WithArrow>
             <Text variant="p2semi">View leadership</Text>
           </WithArrow>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/HigherYieldsBlock.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/HigherYieldsBlock.tsx
@@ -62,10 +62,11 @@ const HigherYieldsSection = ({
         {description}
       </Text>
       <div className={higherYieldsBlockStyles.higherYieldsSectionCTA}>
-        <Link href={ctaUrl}>
+        <Link href={ctaUrl} prefetch={false}>
           <Button variant="primarySmall">{ctaLabel}</Button>
         </Link>
         <Link
+          prefetch={false}
           href={secondaryCtaUrl}
           className={higherYieldsBlockStyles.higherYieldsSectionSecondaryButton}
         >

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/StartEarningNow.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/StartEarningNow.tsx
@@ -69,7 +69,7 @@ export const StartEarningNow = () => {
             'Withdraw anytime',
           ]}
           cta={
-            <Link href="/earn">
+            <Link href="/earn" prefetch={false}>
               <Button variant="primarySmall" className={clsx(startEarningNowStyles.ctaButton)}>
                 <Text variant="p3semi">Sign up</Text>
               </Button>
@@ -92,7 +92,7 @@ export const StartEarningNow = () => {
           ]}
           cta={
             migrationsEnabled ? (
-              <Link href="/earn">
+              <Link href="/earn" prefetch={false}>
                 <Button variant="primarySmall" className={clsx(startEarningNowStyles.ctaButton)}>
                   <Text variant="p3semi">Migrate</Text>
                 </Button>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/SummerFiProBox.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/SummerFiProBox.tsx
@@ -16,15 +16,15 @@ export const SummerFiProBox = () => {
           </Text>
         </div>
         <Text variant="p3semi" className={summerFiProBoxStyles.summerProInfoBoxLinks}>
-          <Link href={`${INTERNAL_LINKS.summerPro}/multiply`} target="_blank">
+          <Link href={`${INTERNAL_LINKS.summerPro}/multiply`} target="_blank" prefetch={false}>
             Multiply
           </Link>
           &nbsp;・&nbsp;
-          <Link href={`${INTERNAL_LINKS.summerPro}/borrow`} target="_blank">
+          <Link href={`${INTERNAL_LINKS.summerPro}/borrow`} target="_blank" prefetch={false}>
             Borrow
           </Link>
           &nbsp;・&nbsp;
-          <Link href={`${INTERNAL_LINKS.summerPro}/earn`} target="_blank">
+          <Link href={`${INTERNAL_LINKS.summerPro}/earn`} target="_blank" prefetch={false}>
             Yield Loops
           </Link>
         </Text>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/SummerFiProSection.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/SummerFiProSection.tsx
@@ -33,7 +33,7 @@ const SummerFiProSectionBlock = ({
         </div>
       </div>
       <div className={summerFiProSectionStyles.summerFiProSectionCardCta}>
-        <Link href={ctaUrl} target="_blank">
+        <Link href={ctaUrl} target="_blank" prefetch={false}>
           <WithArrow>
             <Text variant="p3semi">{ctaLabel}</Text>
           </WithArrow>
@@ -76,7 +76,7 @@ export const SummerFiProSection = () => {
         />
       </div>
       <div className={summerFiProSectionStyles.summerFiProSectionBottomLink}>
-        <Link href={INTERNAL_LINKS.summerPro} target="_blank">
+        <Link href={INTERNAL_LINKS.summerPro} target="_blank" prefetch={false}>
           <WithArrow>
             <Text variant="p2semi">Go to Summer.fi Pro</Text>
           </WithArrow>

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/SumrToken.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/content/SumrToken.tsx
@@ -33,7 +33,7 @@ export const SumrToken = () => {
           Protocol, Stake & Delegate your voting power or be a Delegate and vote on behalf of
           others. Earn $SUMR and help contribute to the value created by the Lazy Summer Protocol.
         </Text>
-        <Link href="/earn/sumr">
+        <Link href="/earn/sumr" prefetch={false}>
           <Button variant="secondarySmall">Get $SUMR</Button>
         </Link>
       </div>

--- a/apps/earn-protocol-landing-page/components/layout/Navigation/NavigationWrapper.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/Navigation/NavigationWrapper.tsx
@@ -22,7 +22,7 @@ export const NavigationWrapper: FC = () => {
       logoSmall="/img/branding/dot-dark.svg"
       links={getNavigationItems({})}
       walletConnectionComponent={
-        <Link href="/earn">
+        <Link href="/earn" prefetch={false}>
           <Button
             variant={isBeachClub ? 'beachClubMedium' : 'primaryMedium'}
             onClick={() => {}}

--- a/apps/earn-protocol-landing-page/features/beach-club/components/BeachClubEarnBig/BeachClubEarnBig.tsx
+++ b/apps/earn-protocol-landing-page/features/beach-club/components/BeachClubEarnBig/BeachClubEarnBig.tsx
@@ -54,7 +54,7 @@ export const BeachClubEarnBig = () => {
             >
               {paragraph.description}
             </Text>
-            <Link href={paragraph.link.href} target="_blank">
+            <Link href={paragraph.link.href} target="_blank" prefetch={false}>
               <WithArrow as="p" variant="p3semi" style={{ color: 'var(--beach-club-link)' }}>
                 {paragraph.link.label}
               </WithArrow>

--- a/apps/earn-protocol-landing-page/features/beach-club/components/BeachClubHeading/BeachClubHeading.tsx
+++ b/apps/earn-protocol-landing-page/features/beach-club/components/BeachClubHeading/BeachClubHeading.tsx
@@ -25,7 +25,7 @@ export const BeachClubHeading = () => {
         Share Lazy Summer and earn more while you relax. Soon it will be Summer. Time to chill, not
         chase yields.
       </Text>
-      <Link href="/earn/portfolio?tab=beach-club">
+      <Link href="/earn/portfolio?tab=beach-club" prefetch={false}>
         <Button variant="beachClubLarge" style={{ minWidth: 'unset', maxWidth: '180px' }}>
           Share your code
         </Button>

--- a/apps/earn-protocol-landing-page/next.config.ts
+++ b/apps/earn-protocol-landing-page/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: (phase: string) => NextConfig = (phase) => ({
       'zod',
     ],
   },
-  output: phase !== PHASE_DEVELOPMENT_SERVER ? 'export' : 'standalone',
+  output: phase !== PHASE_DEVELOPMENT_SERVER ? 'export' : 'export',
   reactStrictMode: false,
   ...(phase !== PHASE_DEVELOPMENT_SERVER
     ? {

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationItems.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationItems.tsx
@@ -24,7 +24,7 @@ export const NavigationItems = ({ items, currentPath }: NavigationItemsProps): R
   return (
     <div className={navigationItemsStyles.navigationItemsWrapper}>
       {items.map((item) => (
-        <Link href={item.url} key={`NavItems_${item.id}`} prefetch={item.prefetchDisabled}>
+        <Link href={item.url} key={`NavItems_${item.id}`} prefetch={!item.prefetchDisabled}>
           <div className={navigationItemsStyles.navigationItemsItem}>
             <div className={navigationItemsStyles.navigationItemsIconWrapper}>
               <Icon iconName={item.icon} size={item.iconSize ?? 32} />

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenu.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenu.tsx
@@ -44,7 +44,7 @@ export const NavigationMenu = ({ links, currentPath }: NavigationMenuType): Reac
                 className={clsx({
                   [navigationMenuStyles.active]: link.link === currentPath,
                 })}
-                prefetch={Boolean(link.disabled ?? link.prefetchDisabled)}
+                prefetch={!(link.disabled ?? link.prefetchDisabled)}
               >
                 {link.label}
               </Link>

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
@@ -94,7 +94,7 @@ export const NavigationMenuMobile = ({
                 className={clsx({
                   [navigationMenuMobileStyles.activeLink]: currentPath === link.link,
                 })}
-                prefetch={Boolean(link.disabled)}
+                prefetch={Boolean(!link.disabled)}
               >
                 <Button
                   variant="textSecondaryLarge"

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
@@ -94,7 +94,7 @@ export const NavigationMenuMobile = ({
                 className={clsx({
                   [navigationMenuMobileStyles.activeLink]: currentPath === link.link,
                 })}
-                prefetch={Boolean(!link.disabled)}
+                prefetch={!(link.disabled ?? link.prefetchDisabled)}
               >
                 <Button
                   variant="textSecondaryLarge"

--- a/packages/app-earn-ui/src/components/layout/Navigation/get-navigation-items.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/get-navigation-items.tsx
@@ -3,7 +3,7 @@ import { SupportBox } from '@/components/layout/Navigation/SupportBox'
 
 export const getNavigationItems = ({
   userWalletAddress,
-  isEarnApp,
+  isEarnApp = false,
 }: {
   userWalletAddress?: string
   isEarnApp?: boolean
@@ -12,6 +12,7 @@ export const getNavigationItems = ({
     label: 'Earn',
     id: 'earn',
     link: !isEarnApp ? `/earn` : `/`,
+    prefetchDisabled: !isEarnApp,
   },
   ...(userWalletAddress
     ? [


### PR DESCRIPTION
Disable prefetching for links to improve performance and reduce unnecessary network requests across various components. This change applies to multiple instances of the Link component throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected prefetching behavior for navigation and call-to-action links throughout the Earn Protocol landing page and app UI, ensuring links only prefetch when appropriate.
- **Chores**
	- Updated configuration to always use static export mode for the landing page, including during development.
- **New Features**
	- Added control to enable or disable prefetching on navigation items based on app context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->