### PR TITLE
Beach club navigation link adjustment

### DIFF
--- a/apps/earn-protocol/components/layout/Navigation/NavigationWrapper.tsx
+++ b/apps/earn-protocol/components/layout/Navigation/NavigationWrapper.tsx
@@ -38,6 +38,8 @@ export const NavigationWrapper: FC = () => {
   return (
     <>
       <Navigation
+        isEarnApp
+        userWalletAddress={userWalletAddress}
         currentPath={currentPath}
         logo="/earn/img/branding/logo-dark.svg"
         logoSmall="/earn/img/branding/dot-dark.svg"

--- a/packages/app-earn-ui/src/components/layout/Navigation/Navigation.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/Navigation.tsx
@@ -17,6 +17,7 @@ import { useMobileCheck } from '@/hooks/use-mobile-check'
 import navigationStyles from '@/components/layout/Navigation/Navigation.module.css'
 
 export interface EarnNavigationProps {
+  isEarnApp?: boolean
   currentPath: string
   logo: string
   logoSmall: string
@@ -40,9 +41,11 @@ export interface EarnNavigationProps {
   onLogoClick?: () => void
   startTheGame?: () => void
   featuresConfig?: EarnAppConfigType['features']
+  userWalletAddress?: string
 }
 
 export const Navigation: FC<EarnNavigationProps> = ({
+  isEarnApp = false,
   logo,
   logoSmall,
   links,
@@ -55,6 +58,7 @@ export const Navigation: FC<EarnNavigationProps> = ({
   onLogoClick,
   startTheGame,
   featuresConfig,
+  userWalletAddress,
 }) => {
   const [tempCurrentPath, setTempCurrentPath] = useState(currentPath)
   const [mobileMenuOpened, setMobileMenuOpened] = useState(false)
@@ -105,6 +109,8 @@ export const Navigation: FC<EarnNavigationProps> = ({
           configComponent={configComponent}
           startTheGame={startTheGame}
           featuresConfig={featuresConfig}
+          userWalletAddress={userWalletAddress}
+          isEarnApp={isEarnApp}
         />
       </header>
       {(isMobile || isTablet) && (
@@ -130,6 +136,8 @@ export const Navigation: FC<EarnNavigationProps> = ({
                 mobileWalletConnectionComponents?.secondary ?? walletConnectionComponent
               }
               signUpComponent={signupComponent}
+              userWalletAddress={userWalletAddress}
+              isEarnApp={isEarnApp}
             />
           </MobileDrawerDefaultWrapper>
         </MobileDrawer>

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationActions.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationActions.tsx
@@ -17,6 +17,8 @@ interface NavigationActionsProps {
   toggleMobileMenu: () => void
   startTheGame?: () => void
   featuresConfig?: EarnAppConfigType['features']
+  userWalletAddress?: string
+  isEarnApp?: boolean
 }
 
 export const NavigationActions = ({
@@ -26,10 +28,17 @@ export const NavigationActions = ({
   configComponent,
   startTheGame,
   featuresConfig,
+  userWalletAddress,
+  isEarnApp,
 }: NavigationActionsProps): React.ReactNode => {
   const beachClubEnabled = !!featuresConfig?.BeachClub
 
   const host = typeof window !== 'undefined' ? window.location.origin : ''
+
+  const resolvedBeachClubLink =
+    isEarnApp && userWalletAddress
+      ? `${host}/earn/portfolio/${userWalletAddress}?tab=beach-club`
+      : `${host}${INTERNAL_LINKS.beachClub}`
 
   return (
     <div>
@@ -40,7 +49,7 @@ export const NavigationActions = ({
           </div>
         )}
         {beachClubEnabled && (
-          <Link href={`${host}${INTERNAL_LINKS.beachClub}`}>
+          <Link href={resolvedBeachClubLink}>
             <Text
               as="div"
               variant="p2semiColorfulBeachClub"

--- a/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
+++ b/packages/app-earn-ui/src/components/layout/Navigation/NavigationMenuMobile.tsx
@@ -23,6 +23,8 @@ type NavigationMobileMenuType = {
   walletConnectionComponent?: ReactNode
   secondaryWalletConnectionComponent?: ReactNode
   featuresConfig?: EarnAppConfigType['features']
+  userWalletAddress?: string
+  isEarnApp?: boolean
 }
 
 export const NavigationMenuMobile = ({
@@ -34,9 +36,16 @@ export const NavigationMenuMobile = ({
   walletConnectionComponent,
   secondaryWalletConnectionComponent,
   featuresConfig,
+  userWalletAddress,
+  isEarnApp,
 }: NavigationMobileMenuType): React.ReactNode => {
   const beachClubEnabled = !!featuresConfig?.BeachClub
   const host = typeof window !== 'undefined' ? window.location.origin : ''
+
+  const resolvedBeachClubLink =
+    isEarnApp && userWalletAddress
+      ? `${host}/earn/portfolio/${userWalletAddress}?tab=beach-club`
+      : `${host}${INTERNAL_LINKS.beachClub}`
 
   return (
     <>
@@ -59,7 +68,7 @@ export const NavigationMenuMobile = ({
       <div className={navigationMenuMobileStyles.linksListWrapper}>
         <div className={navigationMenuMobileStyles.linksList}>
           {beachClubEnabled && (
-            <Link href={`${host}${INTERNAL_LINKS.beachClub}`}>
+            <Link href={resolvedBeachClubLink}>
               <Button
                 variant="textSecondaryLarge"
                 disabled={false}


### PR DESCRIPTION
# Add context-aware beach club navigation

## Description
Adds `isEarnApp` and `userWalletAddress` props to navigation components to enable dynamic beach club link routing based on user context.

## Changes
- Added `isEarnApp` and `userWalletAddress` props to Navigation components
- Implemented dynamic beach club link resolution in both desktop and mobile navigation
- Updated link generation to use portfolio path when in earn app context
- Added proper prop passing through component hierarchy

## Benefits
1. Enables context-aware navigation for beach club links
2. Improves user experience by directing to portfolio view when appropriate
3. Maintains backward compatibility with existing navigation behavior

## Testing
- Verify beach club links work correctly in both earn app and non-earn app contexts
- Test navigation with and without wallet connection
- Ensure mobile and desktop navigation behave consistently

## Next steps
- Consider adding similar context-aware routing for other navigation items
- Monitor user behavior with new navigation patterns

## Additional Notes
The changes maintain the existing navigation structure while adding new functionality. No breaking changes were introduced as all new props are optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Navigation now personalizes the Beach Club link to direct users to their own portfolio page when available.
- **Enhancements**
  - Improved navigation experience by dynamically generating user-specific links in both desktop and mobile menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->