### PR TITLE
feat: add support for additional chain IDs in SiloRewardFetcher

### DIFF
--- a/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/SiloRewardFetcher.ts
+++ b/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/SiloRewardFetcher.ts
@@ -24,6 +24,9 @@ export class SiloRewardFetcher implements IRewardFetcher {
   private readonly logger: Logger
   private readonly chainIdToSiloNetworkName: Partial<Record<ChainId, string>> = {
     [ChainId.SONIC]: 'sonic',
+    [ChainId.ARBITRUM]: 'arbitrum',
+    [ChainId.MAINNET]: 'ethereum',
+    [ChainId.BASE]: 'base',
   }
   private readonly REQUEST_DELAY_MS = 100 // Delay between requests to be gentle on the API
 


### PR DESCRIPTION
## Description
This PR adds support for three additional Silo networks (Arbitrum, Ethereum Mainnet, and Base) to the reward fetching system. Previously, only the Sonic network was supported for fetching Silo vault reward data.

## Changes
- Added Arbitrum network mapping (`arbitrum`) to `chainIdToSiloNetworkName` in `SiloRewardFetcher`
- Added Ethereum Mainnet network mapping (`ethereum`) to `chainIdToSiloNetworkName` in `SiloRewardFetcher`
- Added Base network mapping (`base`) to `chainIdToSiloNetworkName` in `SiloRewardFetcher`

## Benefits
1. **Expanded Network Coverage**: Users can now fetch reward rates for Silo vaults across four major networks instead of just Sonic
2. **Improved Data Completeness**: The system can now aggregate reward information from a broader set of DeFi protocols and networks
3. **Enhanced User Experience**: Multi-chain users will see more comprehensive reward data for their positions across different networks
4. **Future-Proofing**: Establishes a pattern for easily adding additional Silo-supported networks as they become available

## Testing
- Verify that the reward fetcher correctly maps each `ChainId` to its corresponding Silo API network identifier
- Test API calls to `https://v2.silo.finance/api/detailed-vault/{network}-{vault}` for each new network
- Confirm that invalid network/vault combinations are handled gracefully with existing error handling
- Validate that reward rate calculations work correctly across all supported networks

## Next steps
- Monitor API response times and success rates for the new networks
- Consider adding integration tests for each supported network
- Document the supported Silo networks in relevant documentation
- Evaluate adding other Silo-supported networks (e.g., Polygon, Optimism) based on user demand

## Additional Notes
The existing error handling and retry logic will work seamlessly with the new networks. The Silo API endpoint structure remains consistent across networks, so no additional changes to the request/response handling were needed.

Please review and provide any feedback or suggestions for improvement.