### PR TITLE
fix: adjust reward ratios in RewardsService for summer earn rewards

### DIFF
--- a/background-jobs/update-summer-earn-rewards-apr/src/rewards-service.ts
+++ b/background-jobs/update-summer-earn-rewards-apr/src/rewards-service.ts
@@ -105,7 +105,7 @@ export class RewardsService {
     backoffFactor: 2,
   }
   private readonly REWARD_RATIO_MAP = {
-    reul: 0.4,
+    reul: 0.5,
     xsilo: 0.49,
     '*': 0.97,
   }

--- a/background-jobs/update-summer-earn-rewards-apr/src/rewards-service.ts
+++ b/background-jobs/update-summer-earn-rewards-apr/src/rewards-service.ts
@@ -105,9 +105,9 @@ export class RewardsService {
     backoffFactor: 2,
   }
   private readonly REWARD_RATIO_MAP = {
-    reul: 0.7,
+    reul: 0.4,
     xsilo: 0.49,
-    '*': 0.997,
+    '*': 0.97,
   }
   private readonly ONE_HOUR_IN_SECONDS = 3600
   private readonly logger: Logger


### PR DESCRIPTION
## Description
- Euler rewards ratio changed to 0.5 - we target to sell with 50% discount

## Changes
- Euler rewards ratio changed to 0.5 - we target to sell with 50% discount


## Benefits
1. [List the benefits of these changes]
2.
3.

## Testing
[Describe how these changes were tested or how they can be tested]

## Next steps
- [List any follow-up actions or considerations]

## Additional Notes
[Any additional information, context, or notes for reviewers]

Please review and provide any feedback or suggestions for improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted reward multipliers for specific tokens, leading to updated reward rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->