### PR TITLE
Add manual wallet address submission for referral codes in ReferralTable

### DIFF
--- a/apps/earn-protocol/app/api/secure/referral-handlers/route.ts
+++ b/apps/earn-protocol/app/api/secure/referral-handlers/route.ts
@@ -31,11 +31,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid form data' }, { status: 400 })
   }
 
-  if (
-    manualWalletAddress &&
-    typeof manualWalletAddress !== 'string' &&
-    !isAddress(manualWalletAddress)
-  ) {
+  if (manualWalletAddress && !isAddress(manualWalletAddress)) {
     return NextResponse.json({ error: 'Invalid manual wallet address' }, { status: 400 })
   }
 

--- a/apps/earn-protocol/app/secure/referral-handlers/ReferralTable.tsx
+++ b/apps/earn-protocol/app/secure/referral-handlers/ReferralTable.tsx
@@ -47,9 +47,7 @@ export function ReferralTable({ referralsList, refreshView }: ReferralTableProps
     await refreshView()
   }
 
-  const handleManualWalletAddressCodeSubmit = async (ev: React.FormEvent<HTMLFormElement>) => {
-    ev.preventDefault()
-
+  const handleManualWalletAddressCodeSubmit = async () => {
     if (!manualWalletAddress) {
       // eslint-disable-next-line no-alert
       alert('Please enter a wallet address')
@@ -57,7 +55,9 @@ export function ReferralTable({ referralsList, refreshView }: ReferralTableProps
       return
     }
 
-    const alreadyExists = referralsList.filter((referral) => referral.id === manualWalletAddress)
+    const alreadyExists = referralsList.filter(
+      (referral) => referral.id === manualWalletAddress.toLowerCase(),
+    )
 
     if (alreadyExists.length > 0) {
       // eslint-disable-next-line no-alert
@@ -130,6 +130,9 @@ export function ReferralTable({ referralsList, refreshView }: ReferralTableProps
               alignContent: 'center',
               gap: '1rem',
             }}
+            onSubmit={(e) => {
+              e.preventDefault()
+            }}
           >
             <input
               type="text"
@@ -145,7 +148,7 @@ export function ReferralTable({ referralsList, refreshView }: ReferralTableProps
               }}
             />
             <Button
-              onClick={handleManualWalletAddressCodeSubmit}
+              onClick={() => handleManualWalletAddressCodeSubmit()}
               variant="primarySmall"
               style={{ padding: '8px 16px' }}
               disabled={isUpdating || !manualWalletAddress}


### PR DESCRIPTION
Introduce functionality to manually submit wallet addresses for referral codes, enhancing user experience by allowing direct association of wallet addresses with referral codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually assign a referral code to a wallet address via a new input form above the referral table.

* **Improvements**
  * Unified and streamlined the referral code submission process for both manual wallet address entries and custom code edits.
  * Enhanced error handling and user feedback for invalid or duplicate wallet addresses.

* **UI Updates**
  * Updated the referral table interface to include a new form and improved button behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->