### PR TITLE
Fix import path for AddressValue and ChainId in merkl-distributor-addresses.ts

### DIFF
--- a/sdk/armada-protocol-service/src/common/implementation/configs/merkl-distributor-addresses.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/configs/merkl-distributor-addresses.ts
@@ -1,4 +1,4 @@
-import type { AddressValue, ChainId } from '@summerfi/sdk-common/index'
+import type { AddressValue, ChainId } from '@summerfi/sdk-common'
 
 // Contract addresses for Merkl distributor on supported chains
 export const MERKL_DISTRIBUTOR_ADDRESSES: Partial<Record<ChainId, AddressValue>> = {


### PR DESCRIPTION
Correct the import path for AddressValue and ChainId to ensure proper functionality in the merkl-distributor-addresses.ts file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated import statements for improved consistency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->