### PR TITLE
feat: Integrate user account type checks and filter vaults based on account type

### DIFF
--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useUser } from '@account-kit/react'
 import {
   AccountKitAccountType,
   ControlsDepositWithdraw,
   getDisplayToken,
   getMigrationLandingPageUrl,
+  isUserSmartAccount,
   ProjectedEarningsCombined,
   Sidebar,
   SidebarFootnote,
@@ -54,6 +56,7 @@ import { getMigrationBestVaultApy } from '@/features/migration/helpers/get-migra
 import { mapMigrationResponse } from '@/features/migration/helpers/map-migration-response'
 import { type MigrationEarningsDataByChainId } from '@/features/migration/types'
 import { TransakWidget } from '@/features/transak/components/TransakWidget/TransakWidget'
+import { filterOutSonicFromVaults } from '@/helpers/filter-out-sonic-from-vaults'
 import { getResolvedForecastAmountParsed } from '@/helpers/get-resolved-forecast-amount-parsed'
 import { revalidatePositionData } from '@/helpers/revalidation-handlers'
 import { useAppSDK } from '@/hooks/use-app-sdk'
@@ -104,6 +107,8 @@ export const VaultOpenViewComponent = ({
   const { publicClient } = useNetworkAlignedClient()
   const { deviceType } = useDeviceType()
   const { isMobileOrTablet } = useMobileCheck(deviceType)
+  const userAAKit = useUser()
+  const userIsSmartAccount = isUserSmartAccount(userAAKit)
 
   const { features } = useSystemConfig()
 
@@ -356,6 +361,14 @@ export const VaultOpenViewComponent = ({
     type: 'default',
   })
 
+  const filteredVaults = useMemo(() => {
+    if (userIsSmartAccount) {
+      return filterOutSonicFromVaults(vaults)
+    }
+
+    return vaults
+  }, [vaults, userIsSmartAccount])
+
   const { tosSidebarProps } = useTermsOfServiceSidebar({ tosState, handleGoBack: backToInit })
 
   useEffect(() => {
@@ -499,7 +512,7 @@ export const VaultOpenViewComponent = ({
       <VaultOpenGrid
         isMobileOrTablet={isMobileOrTablet}
         vault={vault}
-        vaults={vaults}
+        vaults={filteredVaults}
         medianDefiYield={medianDefiYield}
         displaySimulationGraph={displaySimulationGraph}
         sumrPrice={estimatedSumrPrice}

--- a/apps/earn-protocol/helpers/filter-out-sonic-from-vaults.ts
+++ b/apps/earn-protocol/helpers/filter-out-sonic-from-vaults.ts
@@ -1,0 +1,12 @@
+import { type SDKVaultsListType } from '@summerfi/app-types'
+import { Network } from '@summerfi/subgraph-manager-common'
+
+/**
+ * Temporarly method to filter out Sonic vaults from the list of vaults.
+ * This is a temporary solution to avoid issues with SCA accounts on Sonic Mainnet.
+ * TODO: Remove this method when SCA accounts are supported on Sonic Mainnet.
+ * @param vaults - The list of vaults to filter.
+ * @returns The filtered list of vaults.
+ */
+export const filterOutSonicFromVaults = (vaults: SDKVaultsListType): SDKVaultsListType =>
+  vaults.filter((item) => item.protocol.network !== Network.SonicMainnet)

--- a/packages/app-earn-ui/src/account-kit/helpers/is-user-eoa.ts
+++ b/packages/app-earn-ui/src/account-kit/helpers/is-user-eoa.ts
@@ -1,0 +1,10 @@
+import { type UseUserResult } from '@account-kit/react'
+
+import { AccountKitAccountType } from '@/account-kit/types'
+
+/**
+ * Checks if user has an externally owned account (EOA).
+ * @param user - User object from AccountKit
+ * @returns `true` if EOA, `false` otherwise
+ */
+export const isUserEOA = (user: UseUserResult): boolean => user?.type === AccountKitAccountType.EOA

--- a/packages/app-earn-ui/src/account-kit/helpers/is-user-smart-account.ts
+++ b/packages/app-earn-ui/src/account-kit/helpers/is-user-smart-account.ts
@@ -1,0 +1,11 @@
+import { type UseUserResult } from '@account-kit/react'
+
+import { AccountKitAccountType } from '@/account-kit/types'
+
+/**
+ * Checks if user has a smart contract account (SCA).
+ * @param user - User object from AccountKit
+ * @returns `true` if smart contract account, `false` otherwise
+ */
+export const isUserSmartAccount = (user: UseUserResult): boolean =>
+  user?.type === AccountKitAccountType.SCA

--- a/packages/app-earn-ui/src/index.ts
+++ b/packages/app-earn-ui/src/index.ts
@@ -262,3 +262,5 @@ export {
 } from './account-kit/config'
 export { accountType, overridesGasSponsorship } from './account-kit/constants'
 export { AccountKitAccountType } from './account-kit/types'
+export { isUserEOA } from './account-kit/helpers/is-user-eoa'
+export { isUserSmartAccount } from './account-kit/helpers/is-user-smart-account'

--- a/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
+++ b/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
@@ -989,17 +989,6 @@ export const StaticTokensData: TokenListData = {
       logoURI:
         'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
     },
-    // another instance of USDC on sonic, with the same address but different symbol to ease handling
-    // since 3rd party usually refer to USDC on sonic as USDC instead of USDC.e
-    {
-      name: 'Bridged USDC',
-      address: '0x29219dd400f2bf60e5a23d13be72b486d4038894',
-      symbol: 'USDC',
-      decimals: 6,
-      chainId: ChainIds.Sonic,
-      logoURI:
-        'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
-    },
     {
       name: 'Wrapped Ether',
       address: '0x50c42deacd8fc9773493ed674b675be577f2634b',

--- a/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
+++ b/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
@@ -989,6 +989,17 @@ export const StaticTokensData: TokenListData = {
       logoURI:
         'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
     },
+    // another instance of USDC on sonic, with the same address but different symbol to ease handling
+    // since 3rd party usually refer to USDC on sonic as USDC instead of USDC.e
+    {
+      name: 'Bridged USDC',
+      address: '0x29219dd400f2bf60e5a23d13be72b486d4038894',
+      symbol: 'USDC',
+      decimals: 6,
+      chainId: ChainIds.Sonic,
+      logoURI:
+        'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
+    },
     {
       name: 'Wrapped Ether',
       address: '0x50c42deacd8fc9773493ed674b675be577f2634b',


### PR DESCRIPTION
# Add Sonic network filtering for smart contract accounts

## Description
Implements temporary filtering of Sonic network vaults for smart contract accounts to avoid compatibility issues, while adding proper account type detection helpers.

## Changes
- Add `filterOutSonicFromVaults` helper function to temporarily exclude Sonic vaults for SCA users
- Add `isUserSmartAccount` and `isUserEOA` helper functions for account type detection
- Update VaultOpenViewComponent to filter vaults based on user account type
- Update VaultsListView to apply Sonic filtering for smart contract accounts
- Export new account type helper functions from app-earn-ui package

## Benefits
1. Prevents compatibility issues for smart contract accounts on Sonic network
2. Improves user experience by hiding incompatible vaults
3. Provides reusable account type detection utilities
4. Maintains backward compatibility for EOA users

## Testing
- Verify Sonic vaults are hidden for smart contract accounts
- Confirm Sonic vaults remain visible for EOA users
- Test account type detection functions

## Next steps
- Remove Sonic filtering when SCA accounts are fully supported on Sonic Mainnet
- Monitor for any issues with the temporary filtering solution

## Additional Notes
This is a temporary solution to handle SCA compatibility issues on Sonic Mainnet. The filtering should be removed once SCA accounts are fully supported on the Sonic network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault lists now adapt based on user account type, hiding certain vaults for smart account users.
  * Added new helper tools for determining user account types.

* **Bug Fixes**
  * Improved filtering of vaults to prevent display issues for smart account users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->