### PR TITLE
refactor: Enhance user insertion logic with conditional updates in referral processing

### DIFF
--- a/background-jobs/update-beach-club-rewards-function/src/__tests__/processor.test.ts
+++ b/background-jobs/update-beach-club-rewards-function/src/__tests__/processor.test.ts
@@ -55,6 +55,7 @@ describe('ReferralProcessor', () => {
         executeTakeFirst: jest.fn().mockResolvedValue({ count: '2' }),
         onConflict: jest.fn().mockReturnThis(),
         doNothing: jest.fn().mockReturnThis(),
+        executeQuery: jest.fn().mockResolvedValue({ rows: [] }),
       })
     })
 

--- a/background-jobs/update-beach-club-rewards-function/src/processor.ts
+++ b/background-jobs/update-beach-club-rewards-function/src/processor.ts
@@ -273,12 +273,8 @@ export class ReferralProcessor {
               referral_timestamp = EXCLUDED.referral_timestamp
             WHERE EXCLUDED.referrer_id IS NOT NULL
               AND EXCLUDED.referral_timestamp IS NOT NULL
+              AND users.referrer_id IS NULL
               AND users.created_at > EXCLUDED.referral_timestamp
-              AND (
-                users.referrer_id IS DISTINCT FROM EXCLUDED.referrer_id OR
-                users.referral_chain IS DISTINCT FROM EXCLUDED.referral_chain OR
-                users.referral_timestamp IS DISTINCT FROM EXCLUDED.referral_timestamp
-              )
           `.compile(trx),
         )
       }


### PR DESCRIPTION
## Description
Optimize referral user creation/update flow to be idempotent, performant, and chronologically correct by using a single SQL statement with conflict handling that only backfills referral data when appropriate. Improve type safety in transactional code.

## Changes
- Updated `processNewUsersInTransaction` to use a single `INSERT ... ON CONFLICT (id) DO UPDATE` with a WHERE clause that:
  - requires `EXCLUDED.referrer_id` and `EXCLUDED.referral_timestamp`,
  - updates only when `users.referrer_id IS NULL`,
  - and only if `users.created_at > EXCLUDED.referral_timestamp` (referral happened before user creation).
- Replaced prior multi-step logic with concise conflict handling for safe, idempotent backfills.
- Improved type safety by typing the transaction parameter as `Kysely<DB>` in `processNewUsersInTransaction`.

## Benefits
1. Idempotent and safe backfill: avoids duplicate user errors and never overwrites existing referrers.
2. Correct chronology enforcement: only applies referral data when the referral predates user creation.
3. Better performance: single round-trip SQL with conflict handling.

## Testing
- Unit-test the SQL behavior:
  - New user (no conflict) → created with expected fields.
  - Existing user without `referrer_id`, referral timestamp before `created_at` → fields backfilled.
  - Existing user without `referrer_id`, referral timestamp after `created_at` → no update.
  - Existing user with `referrer_id` already set → no update.
  - Re-run with identical payloads → no-op.
- Integration-test `processLatest` over windows that replay users to confirm idempotency and no PK conflicts.
- Verify types compile with `Kysely<DB>` and run existing build/tests.

## Next steps
- Add metrics for insert vs conflict-update counts to monitor production behavior.
- Review indexing for `users(id, created_at)` and access patterns.
- Document the referral backfill rule for contributors and ops.

## Additional Notes
- Update-on-conflict rule: apply only when `referrer_id` and `referral_timestamp` are non-null, the user currently has no `referrer_id`, and the referral happened before the user’s `created_at`.
- All operations run inside a transaction (`Kysely<DB>`) to maintain atomicity.

Please review and provide any feedback or suggestions for improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Here are the updated release notes:

* **New Features**
  * Added a new `upsertUser` method to the `DatabaseService` class that performs an upsert operation on the `users` table, conditionally updating referral information when appropriate.
* **Refactor**
  * Updated the `processNewUsersInTransaction` method in the `ReferralProcessor` class to use the new `upsertUser` method, replacing the previous direct insert with `onConflict().doNothing()` approach.
* **Tests**
  * Enhanced the test setup for the `ReferralProcessor` by adding a mock implementation for the `executeQuery` method within the mocked transaction execution context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->