### PR TITLE
chore: Update USDC symbol on Sonic in StaticTokensList for consistency

### DIFF
--- a/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
+++ b/sdk/tokens-service/src/implementation/static/StaticTokensList.ts
@@ -983,7 +983,7 @@ export const StaticTokensData: TokenListData = {
     {
       name: 'Bridged USDC',
       address: '0x29219dd400f2bf60e5a23d13be72b486d4038894',
-      symbol: 'USDC.e',
+      symbol: 'USDC',
       decimals: 6,
       chainId: ChainIds.Sonic,
       logoURI:


### PR DESCRIPTION
# Update Sonic USDC token symbol

## Description
Updates the token symbol for bridged USDC on Sonic network from 'USDC.e' to 'USDC' for consistency with other networks.

## Changes
- Changed USDC token symbol from 'USDC.e' to 'USDC' in StaticTokensList.ts
- Updated token configuration for Sonic network bridged USDC

## Benefits
1. Consistent token symbol naming across all networks
2. Improved user experience with standardized USDC representation
3. Better integration with external services that expect 'USDC' symbol

## Testing
- Verify USDC token displays correctly on Sonic network
- Test token balance and transaction functionality
- Confirm symbol consistency across UI components

## Next steps
- Monitor for any issues with token symbol change
- Consider updating other bridged token symbols if needed

## Additional Notes
This change affects the token display in the SDK tokens service and may impact UI components that rely on the token symbol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the symbol for "Bridged USDC" on the Sonic chain from "USDC.e" to "USDC".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->