### PR TITLE
Refactor Merkl rewards integration and add data retrieval method

### DIFF
--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerMerklRewards.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerMerklRewards.ts
@@ -3,33 +3,7 @@ import type {
   MerklClaimTransactionInfo,
   ToggleAQasMerklRewardsOperatorTransactionInfo,
 } from '@summerfi/sdk-common'
-
-/**
- * @name MerklReward
- * @description Represents a Merkl reward for a user
- */
-export interface MerklReward {
-  /** The token address for the reward */
-  token: {
-    chainId: number
-    address: string
-    symbol: string
-    decimals: number
-    price: number
-  }
-  /** The merkle root for the reward */
-  root: string
-  /** The recipient address */
-  recipient: string
-  /** The reward amount */
-  amount: string
-  /** The claimed amount */
-  claimed: string
-  /** The pending amount */
-  pending: string
-  /** The merkle proofs for claiming */
-  proofs: string[]
-}
+import type { MerklReward } from '../types/MerklTypes'
 
 /**
  * @name IArmadaManagerMerklRewards

--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerVaults.ts
@@ -143,4 +143,13 @@ export interface IArmadaManagerVaults {
       }[]
     }
   }>
+
+  getMerklRewardsData(params: { chainId: ChainId; vaultIds: IArmadaVaultId[] }): Promise<{
+    byFleetAddress: {
+      [fleetAddress: string]: {
+        token: IToken
+        dailyEmission: string
+      }[]
+    }
+  }>
 }

--- a/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
+++ b/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
@@ -1,0 +1,106 @@
+/**
+ * Represents a single opportunity response
+ */
+
+export type MerklOpportunityResponse = {
+  rewardsRecord: MerklRewardsRecord
+}
+
+/**
+ * Array of opportunities responses
+ */
+export type MerklOpportunitiesResponse = Array<MerklOpportunityResponse>
+
+/**
+ * Complete rewards record structure
+ */
+export interface MerklRewardsRecord {
+  /** Unique identifier for the rewards record */
+  id: string
+  /** Total rewards value */
+  total: number
+  /** Timestamp when the record was created */
+  timestamp: string
+  /** Array of individual reward breakdowns */
+  breakdowns: MerklRewardsBreakdown[]
+}
+
+/**
+ * Individual reward breakdown entry
+ */
+export interface MerklRewardsBreakdown {
+  /** Token information for this reward */
+  token: MerklRewardsToken
+  /** Amount of tokens as string (to handle large numbers) */
+  amount: string
+  /** USD value of the reward amount */
+  value: number
+  /** Type of distribution mechanism */
+  distributionType: string
+  /** Unique identifier for this breakdown */
+  id: string
+  /** Timestamp when this reward was recorded */
+  timestamp: string
+  /** ID of the campaign this reward belongs to */
+  campaignId: string
+  /** ID of the daily rewards record this belongs to */
+  dailyRewardsRecordId: string
+}
+
+/**
+ * Token information for rewards
+ */
+export interface MerklRewardsToken {
+  /** Unique identifier for the token */
+  id: string
+  /** Human-readable name of the token */
+  name: string
+  /** Chain ID where the token exists */
+  chainId: number
+  /** Contract address of the token */
+  address: string
+  /** Number of decimal places for the token */
+  decimals: number
+  /** Token symbol (e.g., "SUMR") */
+  symbol: string
+  /** Display symbol for UI purposes */
+  displaySymbol: string
+  /** URL to the token's icon image */
+  icon: string
+  /** Whether the token is verified */
+  verified: boolean
+  /** Whether this is a test token */
+  isTest: boolean
+  /** Token type classification */
+  type: string
+  /** Whether this is a native blockchain token */
+  isNative: boolean
+  /** Current price of the token (can be null) */
+  price: number | null
+}
+
+/**
+ * Represents a Merkl reward for a user
+ */
+export interface MerklReward {
+  /** The token address for the reward */
+  token: {
+    chainId: number
+    address: string
+    symbol: string
+    decimals: number
+    price: number
+  }
+  /** The merkle root for the reward */
+  root: string
+  /** The recipient address */
+  recipient: string
+  /** The reward amount */
+  amount: string
+  /** The claimed amount */
+  claimed: string
+  /** The pending amount */
+  pending: string
+  /** The merkle proofs for claiming */
+  proofs: string[]
+}

--- a/sdk/armada-protocol-common/src/index.ts
+++ b/sdk/armada-protocol-common/src/index.ts
@@ -61,7 +61,12 @@ export {
   getLayerZeroConfig,
   getDeploymentsJsonConfig,
 } from './deployments/index'
+export type { IArmadaManagerMerklRewards } from './common/interfaces/IArmadaManagerMerklRewards'
 export type {
-  IArmadaManagerMerklRewards,
   MerklReward,
-} from './common/interfaces/IArmadaManagerMerklRewards'
+  MerklRewardsBreakdown,
+  MerklRewardsRecord,
+  MerklOpportunitiesResponse,
+  MerklOpportunityResponse,
+  MerklRewardsToken,
+} from './common/types/MerklTypes'

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
@@ -1768,7 +1768,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
 
     const byFleetAddress = responses.reduce(
       (acc, response, index) => {
-        const fleetAddress = vaultIds[index].fleetAddress.value
+        const fleetAddress = vaultIds[index].fleetAddress.value.toLowerCase()
         if (!acc[fleetAddress]) {
           acc[fleetAddress] = []
         }
@@ -1799,8 +1799,8 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       },
     )
 
-    return Promise.resolve({
+    return {
       byFleetAddress,
-    })
+    }
   }
 }

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
@@ -5,6 +5,7 @@ import {
   createWithdrawTransaction,
   type IArmadaManagerUtils,
   createVaultSwitchTransaction,
+  type MerklOpportunitiesResponse,
 } from '@summerfi/armada-protocol-common'
 import type { IBlockchainClientProvider } from '@summerfi/blockchain-client-common'
 import { AdmiralsQuartersAbi } from '@summerfi/armada-protocol-abis'
@@ -40,6 +41,7 @@ import { BigNumber } from 'bignumber.js'
 import type { IArmadaSubgraphManager } from '@summerfi/subgraph-manager-common'
 import { calculateRewardApy } from './utils/calculate-summer-yield'
 import type { IDeploymentProvider } from '../..'
+import { bigint } from 'zod'
 
 export class ArmadaManagerVaults implements IArmadaManagerVaults {
   private _supportedChains: IChainInfo[]
@@ -1502,20 +1504,25 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     const fleetERC4626Contract = fleetContract.asErc4626()
     const fleetERC20Contract = fleetERC4626Contract.asErc20()
 
-    const [config, token, totalDeposits, totalShares, apys, rewardsApys] = await Promise.all([
-      fleetContract.config(),
-      fleetERC20Contract.getToken(),
-      fleetERC4626Contract.totalAssets(),
-      fleetERC20Contract.totalSupply(),
-      this.getVaultsApys({
-        chainId: params.vaultId.chainInfo.chainId,
-        vaultIds: [params.vaultId],
-      }),
-      this.getVaultsRewardsApys({
-        chainId: params.vaultId.chainInfo.chainId,
-        vaultIds: [params.vaultId],
-      }),
-    ])
+    const [config, token, totalDeposits, totalShares, apys, rewardsApys, merklRewards] =
+      await Promise.all([
+        fleetContract.config(),
+        fleetERC20Contract.getToken(),
+        fleetERC4626Contract.totalAssets(),
+        fleetERC20Contract.totalSupply(),
+        this.getVaultsApys({
+          chainId: params.vaultId.chainInfo.chainId,
+          vaultIds: [params.vaultId],
+        }),
+        this.getVaultsRewardsApys({
+          chainId: params.vaultId.chainInfo.chainId,
+          vaultIds: [params.vaultId],
+        }),
+        this.getMerklRewardsData({
+          chainId: params.vaultId.chainInfo.chainId,
+          vaultIds: [params.vaultId],
+        }),
+      ])
     const { depositCap } = config
 
     const apysForVault = apys.byFleetAddress[params.vaultId.fleetAddress.value.toLowerCase()]
@@ -1530,6 +1537,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       totalShares: totalShares,
       apy: apysForVault.apy,
       rewardsApys: rewardsApys.byFleetAddress[params.vaultId.fleetAddress.value.toLowerCase()],
+      merklRewards: merklRewards.byFleetAddress[params.vaultId.fleetAddress.value.toLowerCase()],
     })
   }
 
@@ -1727,5 +1735,73 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     return {
       byFleetAddress,
     }
+  }
+
+  async getMerklRewardsData(
+    params: Parameters<IArmadaManagerVaults['getMerklRewardsData']>[0],
+  ): ReturnType<IArmadaManagerVaults['getMerklRewardsData']> {
+    const { vaultIds } = params
+    // get vaults data by creating promises list and executing with promise all
+    const vaultsData = await Promise.all(
+      vaultIds.map((vaultId) =>
+        this._subgraphManager.getVault({
+          chainId: params.chainId,
+          vaultId: vaultId.fleetAddress.value,
+        }),
+      ),
+    )
+    // get rewards manager addresses of the provided vaults
+    const rewardsManagerAddresses = vaultsData
+      .map((vault) => vault.vault?.rewardsManager.id)
+      .filter((id): id is string => !!id)
+    // find opportunities by querying merkl api using rewards manager address as id
+    const url = 'https://api.merkl.xyz/v4/opportunities?identifier={{identifier}}'
+    const responses: MerklOpportunitiesResponse[] = await Promise.all(
+      rewardsManagerAddresses.map((address) =>
+        fetch(url.replace('{{identifier}}', address)).then((res) => {
+          if (!res.ok) {
+            throw new Error(`Failed to fetch rewards for address ${address}`)
+          }
+          return res.json()
+        }),
+      ),
+    )
+
+    const byFleetAddress = responses.reduce(
+      (acc, response, index) => {
+        const fleetAddress = vaultIds[index].fleetAddress.value
+        if (!acc[fleetAddress]) {
+          acc[fleetAddress] = []
+        }
+        acc[fleetAddress].push({
+          dailyEmission: response
+            .reduce((dailyEmission, opportunity) => {
+              const sumrReward = opportunity.rewardsRecord.breakdowns.find(
+                (b) => b.token.symbol === 'SUMR',
+              )
+              if (sumrReward) {
+                dailyEmission += BigInt(sumrReward.amount)
+              }
+              return dailyEmission
+            }, 0n)
+            .toString(),
+          token: this._tokensManager.getTokenBySymbol({
+            chainInfo: getChainInfoByChainId(params.chainId),
+            symbol: 'SUMR',
+          }),
+        })
+        return acc
+      },
+      {} as {
+        [fleetAddress: string]: {
+          token: IToken
+          dailyEmission: string
+        }[]
+      },
+    )
+
+    return Promise.resolve({
+      byFleetAddress,
+    })
   }
 }

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
@@ -41,7 +41,6 @@ import { BigNumber } from 'bignumber.js'
 import type { IArmadaSubgraphManager } from '@summerfi/subgraph-manager-common'
 import { calculateRewardApy } from './utils/calculate-summer-yield'
 import type { IDeploymentProvider } from '../..'
-import { bigint } from 'zod'
 
 export class ArmadaManagerVaults implements IArmadaManagerVaults {
   private _supportedChains: IChainInfo[]
@@ -1751,19 +1750,19 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       ),
     )
     // get rewards manager addresses of the provided vaults
-    const rewardsManagerAddresses = vaultsData
-      .map((vault) => vault.vault?.rewardsManager.id)
-      .filter((id): id is string => !!id)
+    const rewardsManagerAddresses = vaultsData.map((vault) => vault.vault?.rewardsManager.id)
     // find opportunities by querying merkl api using rewards manager address as id
     const url = 'https://api.merkl.xyz/v4/opportunities?identifier={{identifier}}'
     const responses: MerklOpportunitiesResponse[] = await Promise.all(
       rewardsManagerAddresses.map((address) =>
-        fetch(url.replace('{{identifier}}', address)).then((res) => {
-          if (!res.ok) {
-            throw new Error(`Failed to fetch rewards for address ${address}`)
-          }
-          return res.json()
-        }),
+        address
+          ? fetch(url.replace('{{identifier}}', address)).then((res) => {
+              if (!res.ok) {
+                throw new Error(`Failed to fetch rewards for address ${address}`)
+              }
+              return res.json()
+            })
+          : Promise.resolve(undefined),
       ),
     )
 

--- a/sdk/armada-protocol-service/src/common/implementation/http/merkl/campaigns.http
+++ b/sdk/armada-protocol-service/src/common/implementation/http/merkl/campaigns.http
@@ -9,5 +9,5 @@ GET https://api.merkl.xyz/v4/opportunities/campaigns
   ?opportunityId={{opportunityId}}
 
 ### by Id
-@campaignId = 6882942589603688379
+@campaignId = 11740145657796578250
 GET https://api.merkl.xyz/v4/campaigns/{{campaignId}}

--- a/sdk/sdk-common/src/common/implementation/ArmadaVaultInfo.ts
+++ b/sdk/sdk-common/src/common/implementation/ArmadaVaultInfo.ts
@@ -33,6 +33,10 @@ export class ArmadaVaultInfo extends PoolInfo implements IArmadaVaultInfo {
     token: IToken
     apy: IPercentage | null
   }>
+  readonly merklRewards: Array<{
+    token: IToken
+    dailyEmission: string
+  }>
 
   /** FACTORY */
   static createFrom(params: ArmadaVaultInfoParameters): ArmadaVaultInfo {
@@ -50,6 +54,7 @@ export class ArmadaVaultInfo extends PoolInfo implements IArmadaVaultInfo {
     this.totalShares = params.totalShares
     this.apy = params.apy
     this.rewardsApys = params.rewardsApys
+    this.merklRewards = params.merklRewards
   }
 }
 

--- a/sdk/sdk-common/src/common/interfaces/IArmadaVaultInfo.ts
+++ b/sdk/sdk-common/src/common/interfaces/IArmadaVaultInfo.ts
@@ -35,6 +35,11 @@ export interface IArmadaVaultInfo extends IPoolInfo, IArmadaVaultInfoData {
     token: IToken
     apy: IPercentage | null
   }>
+  /** Vault Merkl rewards apy */
+  readonly merklRewards: Array<{
+    token: IToken
+    dailyEmission: string
+  }>
 
   // Re-declaring the properties to narrow the types
   readonly type: PoolType.Armada
@@ -55,6 +60,12 @@ export const ArmadaVaultInfoDataSchema = z.object({
     z.object({
       token: z.custom<IToken>((val) => isToken(val)),
       apy: z.custom<IPercentage | null>((val) => isPercentage(val) || val === null),
+    }),
+  ),
+  merklRewards: z.array(
+    z.object({
+      token: z.custom<IToken>((val) => isToken(val)),
+      dailyEmission: z.string(),
     }),
   ),
   type: z.literal(PoolType.Armada),

--- a/sdk/sdk-common/tests/ArmadaVaultInfo.spec.ts
+++ b/sdk/sdk-common/tests/ArmadaVaultInfo.spec.ts
@@ -56,6 +56,7 @@ describe('SDK Common | Armada | ArmadaVaultInfo', () => {
           value: 0.05,
         }),
         rewardsApys: [],
+        merklRewards: [],
       })
 
       expect(poolInfo).toBeDefined()

--- a/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
@@ -9,10 +9,11 @@ import {
   Wallet,
 } from '@summerfi/sdk-common'
 
-import { SDKApiUrl, userAddress } from './utils/testConfig'
+import { SDKApiUrl, testWalletAddress } from './utils/testConfig'
 import assert from 'assert'
 
 jest.setTimeout(300000)
+const simulateOnly = true
 
 const chainId = ChainIds.Base
 const ethFleet = Address.createFromEthereum({ value: '0x2bb9ad69feba5547b7cd57aafe8457d40bf834af' })
@@ -24,7 +25,7 @@ const eurcFleet = Address.createFromEthereum({
 })
 const rpcUrl = process.env.E2E_SDK_FORK_URL_BASE
 
-describe('Armada Protocol Vault', () => {
+describe('Armada Protocol - Vault', () => {
   const sdk: SDKManager = makeSDK({
     apiDomainUrl: SDKApiUrl,
   })
@@ -38,10 +39,10 @@ describe('Armada Protocol Vault', () => {
   const user = User.createFrom({
     chainInfo,
     wallet: Wallet.createFrom({
-      address: userAddress,
+      address: testWalletAddress,
     }),
   })
-  console.log(`Running on ${chainInfo.name} for user ${userAddress.value}`)
+  console.log(`Running on ${chainInfo.name} for user ${testWalletAddress.value}`)
 
   it(`should get all user positions: ${fleetAddress.value}`, async () => {
     const positions = await sdk.armada.users.getUserPositions({
@@ -82,6 +83,10 @@ describe('Armada Protocol Vault', () => {
                 token: reward.token.toString(),
                 apy: reward.apy?.toString(),
               })),
+              merklRewards: vaultInfo.merklRewards.map((reward) => ({
+                token: reward.token.toString(),
+                dailyEmission: reward.dailyEmission,
+              })),
             },
             null,
             2,
@@ -113,6 +118,10 @@ describe('Armada Protocol Vault', () => {
           rewardsApys: vaultInfo.rewardsApys.map((reward) => ({
             token: reward.token.toString(),
             apy: reward.apy?.toString(),
+          })),
+          merklRewards: vaultInfo.merklRewards.map((reward) => ({
+            token: reward.token.toString(),
+            dailyEmission: reward.dailyEmission,
           })),
         },
         null,

--- a/sdk/sdk-e2e/package.json
+++ b/sdk/sdk-e2e/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "e2e": "jest --roots e2e",
+    "e2e:vault": "jest --roots e2e -- ./e2e/armadaProtocol.vault.test.ts",
     "e2e:deposit": "jest --roots e2e -- ./e2e/armadaProtocol.deposit.test.ts",
     "e2e:withdraw": "jest --roots e2e -- ./e2e/armadaProtocol.withdraw.test.ts",
     "e2e:claim": "jest --roots e2e -- ./e2e/armadaProtocol.claim.test.ts",


### PR DESCRIPTION
Streamline interfaces related to Merkl rewards and introduce a new method to fetch Merkl rewards data for specified vaults. This enhances the integration and improves data handling for rewards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault details now include Merkl rewards (per-token daily emission); SDK can fetch Merkl rewards for selected vaults and exposes a new Merkl rewards retrieval API.
* **Refactor**
  * Merkl-related types consolidated and exported from a central types module.
* **Documentation**
  * Merkl campaigns example value updated.
* **Tests**
  * Vault info tests and e2e outputs updated to include merklRewards.
* **Chores**
  * Added an npm script to run the vault e2e test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->