### PR TITLE
Merkl fees handling

### DIFF
--- a/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
+++ b/apps/earn-protocol/components/layout/PortfolioPageView/PortfolioPageView.tsx
@@ -22,6 +22,7 @@ import { type LatestActivityPagination } from '@/app/server-handlers/tables-data
 import { type RebalanceActivityPagination } from '@/app/server-handlers/tables-data/rebalance-activity/types'
 import { useSystemConfig } from '@/contexts/SystemConfigContext/SystemConfigContext'
 import { BeachClubPalmBackground } from '@/features/beach-club/components/BeachClubPalmBackground/BeachClubPalmBackground'
+import { beachClubDefaultState, beachClubReducer } from '@/features/beach-club/state'
 import { claimDelegateReducer, claimDelegateState } from '@/features/claim-and-delegate/state'
 import { type ClaimDelegateExternalData } from '@/features/claim-and-delegate/types'
 import { type MigrationEarningsDataByChainId } from '@/features/migration/types'
@@ -86,6 +87,13 @@ export const PortfolioPageView: FC<PortfolioPageViewProps> = ({
     ...claimDelegateState,
     delegatee: rewardsData.sumrStakeDelegate.delegatedTo,
     walletAddress,
+    merklIsAuthorizedPerChain: rewardsData.sumrToClaim.merklIsAuthorizedPerChain,
+  })
+
+  const [beachClubState, beachClubDispatch] = useReducer(beachClubReducer, {
+    ...beachClubDefaultState,
+    walletAddress,
+    merklIsAuthorizedPerChain: rewardsData.sumrToClaim.merklIsAuthorizedPerChain,
   })
 
   const beachClubEnabled = !!features?.BeachClub
@@ -175,7 +183,13 @@ export const PortfolioPageView: FC<PortfolioPageViewProps> = ({
             label: 'Beach Club',
             icon: <Icon iconName="beach_club_icon" size={24} />,
             content: (
-              <PortfolioBeachClub walletAddress={walletAddress} beachClubData={beachClubData} />
+              <PortfolioBeachClub
+                walletAddress={walletAddress}
+                beachClubData={beachClubData}
+                merklIsAuthorizedPerChain={rewardsData.sumrToClaim.merklIsAuthorizedPerChain}
+                state={beachClubState}
+                dispatch={beachClubDispatch}
+              />
             ),
             activeColor: 'var(--beach-club-tab-underline)',
           },

--- a/apps/earn-protocol/constants/delay-per-network.ts
+++ b/apps/earn-protocol/constants/delay-per-network.ts
@@ -1,0 +1,12 @@
+import { SupportedNetworkIds } from '@summerfi/app-types'
+
+/**
+ * Delay per network in milliseconds
+ * @description Delay per network in milliseconds
+ */
+export const delayPerNetwork = {
+  [SupportedNetworkIds.Base]: 4000,
+  [SupportedNetworkIds.ArbitrumOne]: 4000,
+  [SupportedNetworkIds.Mainnet]: 13000,
+  [SupportedNetworkIds.SonicMainnet]: 4000,
+} as const

--- a/apps/earn-protocol/features/beach-club/components/BeachClubRewards/BeachClubRewards.tsx
+++ b/apps/earn-protocol/features/beach-club/components/BeachClubRewards/BeachClubRewards.tsx
@@ -1,9 +1,11 @@
-import { type FC, useMemo } from 'react'
+import { type Dispatch, type FC, useMemo } from 'react'
 import { Card, Icon, TabBar, Text } from '@summerfi/app-earn-ui'
 
 import { type BeachClubData } from '@/app/server-handlers/beach-club/get-user-beach-club-data'
 import { BeachClubBoatChallenge } from '@/features/beach-club/components/BeachClubBoatChallenge/BeachClubBoatChallenge'
 import { BeachClubTvlChallenge } from '@/features/beach-club/components/BeachClubTvlChallenge/BeachClubTvlChallenge'
+import { type BeachClubReducerAction, type BeachClubState } from '@/features/beach-club/types'
+import { type MerklIsAuthorizedPerChain } from '@/features/claim-and-delegate/types'
 
 import classNames from './BeachClubRewards.module.css'
 
@@ -15,15 +17,31 @@ enum ReferAndEarnTab {
 interface BeachClubRewardsProps {
   beachClubData: BeachClubData
   walletAddress: string
+  merklIsAuthorizedPerChain: MerklIsAuthorizedPerChain
+  state: BeachClubState
+  dispatch: Dispatch<BeachClubReducerAction>
 }
 
-export const BeachClubRewards: FC<BeachClubRewardsProps> = ({ beachClubData, walletAddress }) => {
+export const BeachClubRewards: FC<BeachClubRewardsProps> = ({
+  beachClubData,
+  walletAddress,
+  merklIsAuthorizedPerChain,
+  state,
+  dispatch,
+}) => {
   const tabsOptions = useMemo(
     () => [
       {
         label: 'TVL Challenges',
         id: ReferAndEarnTab.TVL_CHALLENGES,
-        content: <BeachClubTvlChallenge beachClubData={beachClubData} />,
+        content: (
+          <BeachClubTvlChallenge
+            beachClubData={beachClubData}
+            merklIsAuthorizedPerChain={merklIsAuthorizedPerChain}
+            state={state}
+            dispatch={dispatch}
+          />
+        ),
         activeColor: 'var(--beach-club-tab-underline)',
       },
       {
@@ -35,7 +53,7 @@ export const BeachClubRewards: FC<BeachClubRewardsProps> = ({ beachClubData, wal
         activeColor: 'var(--beach-club-tab-underline)',
       },
     ],
-    [beachClubData, walletAddress],
+    [beachClubData, walletAddress, merklIsAuthorizedPerChain, state, dispatch],
   )
 
   return (

--- a/apps/earn-protocol/features/beach-club/components/BeachClubTvlChallenge/BeachClubTvlChallenge.tsx
+++ b/apps/earn-protocol/features/beach-club/components/BeachClubTvlChallenge/BeachClubTvlChallenge.tsx
@@ -1,9 +1,38 @@
-import { type FC, useMemo } from 'react'
-import { BeachClubRewardSimulation, Icon, Text, Tooltip } from '@summerfi/app-earn-ui'
-import { formatCryptoBalance, formatFiatBalance } from '@summerfi/app-utils'
+import { type Dispatch, type FC, useMemo, useState } from 'react'
+import { toast } from 'react-toastify'
+import { useChain } from '@account-kit/react'
+import {
+  BeachClubRewardSimulation,
+  Button,
+  Icon,
+  MobileDrawer,
+  Modal,
+  SDKChainIdToAAChainMap,
+  Text,
+  Tooltip,
+  useClientChainId,
+  useMobileCheck,
+} from '@summerfi/app-earn-ui'
+import { SupportedNetworkIds, UiTransactionStatuses } from '@summerfi/app-types'
+import {
+  chainIdToSDKNetwork,
+  formatCryptoBalance,
+  formatFiatBalance,
+  sdkNetworkToHumanNetwork,
+} from '@summerfi/app-utils'
 
 import { type BeachClubData } from '@/app/server-handlers/beach-club/get-user-beach-club-data'
+import { delayPerNetwork } from '@/constants/delay-per-network'
+import { useDeviceType } from '@/contexts/DeviceContext/DeviceContext'
 import { BeachClubTvlChallengeRewardCard } from '@/features/beach-club/components/BeachClubTvlChallengeRewardCard/BeachClubTvlChallengeRewardCard'
+import { getBeachClubClaimFeesButtonLabel } from '@/features/beach-club/helpers/get-beach-club-claim-fees-button-label'
+import { useClaimBeachClubFeesTransaction } from '@/features/beach-club/hooks/use-claim-beach-club-fees-transaction'
+import { type BeachClubReducerAction, type BeachClubState } from '@/features/beach-club/types'
+import { ClaimDelegateOptInMerkl } from '@/features/claim-and-delegate/components/ClaimDelegateOptInMerkl/ClaimDelegateOptInMerkl'
+import { useMerklOptInTransaction } from '@/features/claim-and-delegate/hooks/use-merkl-opt-in-transaction'
+import { type MerklIsAuthorizedPerChain } from '@/features/claim-and-delegate/types'
+import { ERROR_TOAST_CONFIG, SUCCESS_TOAST_CONFIG } from '@/features/toastify/config'
+import { useNetworkAlignedClient } from '@/hooks/use-network-aligned-client'
 
 import { getBeachClubTvlRewardsCards } from './cards'
 
@@ -11,10 +40,95 @@ import classNames from './BeachClubTvlChallenge.module.css'
 
 interface BeachClubTvlChallengeProps {
   beachClubData: BeachClubData
+  merklIsAuthorizedPerChain: MerklIsAuthorizedPerChain
+  state: BeachClubState
+  dispatch: Dispatch<BeachClubReducerAction>
 }
 
-export const BeachClubTvlChallenge: FC<BeachClubTvlChallengeProps> = ({ beachClubData }) => {
+export const BeachClubTvlChallenge: FC<BeachClubTvlChallengeProps> = ({
+  beachClubData,
+  merklIsAuthorizedPerChain,
+  state,
+  dispatch,
+}) => {
+  const { deviceType } = useDeviceType()
+  const { isMobile } = useMobileCheck(deviceType)
   const currentGroupTvl = Number(beachClubData.total_deposits_referred_usd ?? 0)
+  const [isOptInOpen, setIsOptInOpen] = useState(false)
+
+  const { clientChainId } = useClientChainId()
+  const { publicClient } = useNetworkAlignedClient({
+    overrideNetwork: sdkNetworkToHumanNetwork(chainIdToSDKNetwork(clientChainId)),
+  })
+  const { setChain, isSettingChain } = useChain()
+  const merklIsAuthorizedOnBase = state.merklIsAuthorizedPerChain[SupportedNetworkIds.Base]
+  const handleOptInOpenClose = () => setIsOptInOpen((prev) => !prev)
+
+  const { merklOptInTransaction } = useMerklOptInTransaction({
+    onSuccess: () => {
+      setTimeout(() => {
+        dispatch({ type: 'update-merkl-status', payload: UiTransactionStatuses.COMPLETED })
+        dispatch({
+          type: 'update-merkl-is-authorized-per-chain',
+          payload: {
+            ...merklIsAuthorizedPerChain,
+            [clientChainId]: true,
+          },
+        })
+        toast.success('Merkl approval successful', SUCCESS_TOAST_CONFIG)
+        handleOptInOpenClose()
+      }, delayPerNetwork[clientChainId])
+    },
+    onError: () => {
+      dispatch({ type: 'update-merkl-status', payload: UiTransactionStatuses.FAILED })
+      toast.error('Merkl approval failed', ERROR_TOAST_CONFIG)
+    },
+    network: chainIdToSDKNetwork(clientChainId),
+    publicClient,
+  })
+
+  const { claimBeachClubFeesTransaction } = useClaimBeachClubFeesTransaction({
+    onSuccess: () => {
+      setTimeout(() => {
+        dispatch({ type: 'update-merkl-status', payload: UiTransactionStatuses.COMPLETED })
+        toast.success('Fees claimed successfully', SUCCESS_TOAST_CONFIG)
+        dispatch({ type: 'update-fees-claimed', payload: true })
+      }, delayPerNetwork[clientChainId])
+    },
+    onError: () => {
+      toast.error('Failed to claim fees', ERROR_TOAST_CONFIG)
+    },
+    network: chainIdToSDKNetwork(clientChainId),
+    publicClient,
+  })
+
+  const handleClaimFees = async () => {
+    await claimBeachClubFeesTransaction().catch((err) => {
+      toast.error('Failed to claim fees', ERROR_TOAST_CONFIG)
+      // eslint-disable-next-line no-console
+      console.error('Error claiming fees', err)
+    })
+  }
+
+  // chainId for now will always be Base as we support Merkl on base only
+  const handleMerklOptInAccept = (chainId: SupportedNetworkIds) => {
+    if (Number(clientChainId) !== Number(chainId)) {
+      setChain({ chain: SDKChainIdToAAChainMap[chainId] })
+
+      return
+    }
+    dispatch({ type: 'update-merkl-status', payload: UiTransactionStatuses.PENDING })
+    merklOptInTransaction().catch((err) => {
+      dispatch({ type: 'update-merkl-status', payload: UiTransactionStatuses.FAILED })
+      toast.error('Failed to approve Merkl', ERROR_TOAST_CONFIG)
+      // eslint-disable-next-line no-console
+      console.error('Error approving Merkl', err)
+    })
+  }
+
+  const feesRewards = beachClubData.rewards
+    .filter((reward) => reward.currency !== 'SUMR' && reward.currency !== 'points')
+    .reduce((acc, reward) => acc + Number(reward.balance_usd), 0)
 
   const stats = [
     {
@@ -31,11 +145,7 @@ export const BeachClubTvlChallenge: FC<BeachClubTvlChallengeProps> = ({ beachClu
     },
     {
       id: 3,
-      value: `$${formatFiatBalance(
-        beachClubData.rewards
-          .filter((reward) => reward.currency !== 'SUMR' && reward.currency !== 'points')
-          .reduce((acc, reward) => acc + Number(reward.balance_usd), 0),
-      )}`,
+      value: `$${formatFiatBalance(feesRewards)}`,
       description: (
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--general-space-4)' }}>
           Earned Fee&apos;s{' '}
@@ -47,6 +157,22 @@ export const BeachClubTvlChallenge: FC<BeachClubTvlChallengeProps> = ({ beachClu
           </Tooltip>
         </div>
       ),
+      cta: {
+        label: getBeachClubClaimFeesButtonLabel({ state }),
+        action: () => {
+          if (!isOptInOpen && !merklIsAuthorizedOnBase) {
+            handleOptInOpenClose()
+
+            return
+          }
+
+          handleClaimFees()
+        },
+        disabled:
+          isSettingChain ||
+          state.claimStatus === UiTransactionStatuses.PENDING ||
+          state.claimStatus === UiTransactionStatuses.COMPLETED,
+      },
     },
   ]
 
@@ -66,6 +192,18 @@ export const BeachClubTvlChallenge: FC<BeachClubTvlChallengeProps> = ({ beachClu
             <Text as="div" variant="p1semi" style={{ color: 'var(--earn-protocol-secondary-60)' }}>
               {stat.description}
             </Text>
+            {stat.cta && feesRewards > 0 && !state.feesClaimed && (
+              <Button
+                variant="beachClubMedium"
+                onClick={stat.cta.action}
+                style={{ marginTop: 'var(--spacing-space-large)' }}
+                disabled={stat.cta.disabled}
+              >
+                <Text as="p" variant="p4semi">
+                  {stat.cta.label}
+                </Text>
+              </Button>
+            )}
           </div>
         ))}
       </div>
@@ -89,6 +227,23 @@ export const BeachClubTvlChallenge: FC<BeachClubTvlChallengeProps> = ({ beachClu
         ))}
       </div>
       <BeachClubRewardSimulation tvl={currentGroupTvl} />
+      {isMobile ? (
+        <MobileDrawer isOpen={isOptInOpen} onClose={handleOptInOpenClose} height="auto">
+          <ClaimDelegateOptInMerkl
+            onAccept={() => handleMerklOptInAccept(SupportedNetworkIds.Base)}
+            onReject={handleOptInOpenClose}
+            merklStatus={state.merklStatus}
+          />
+        </MobileDrawer>
+      ) : (
+        <Modal openModal={isOptInOpen} closeModal={handleOptInOpenClose}>
+          <ClaimDelegateOptInMerkl
+            onAccept={() => handleMerklOptInAccept(SupportedNetworkIds.Base)}
+            onReject={handleOptInOpenClose}
+            merklStatus={state.merklStatus}
+          />
+        </Modal>
+      )}
     </div>
   )
 }

--- a/apps/earn-protocol/features/beach-club/helpers/get-beach-club-claim-fees-button-label.ts
+++ b/apps/earn-protocol/features/beach-club/helpers/get-beach-club-claim-fees-button-label.ts
@@ -1,0 +1,16 @@
+import { UiTransactionStatuses } from '@summerfi/app-types'
+
+import { type BeachClubState } from '@/features/beach-club/types'
+
+export const getBeachClubClaimFeesButtonLabel = ({ state }: { state: BeachClubState }) => {
+  switch (state.claimStatus) {
+    case UiTransactionStatuses.PENDING:
+      return 'Claiming...'
+    case UiTransactionStatuses.COMPLETED:
+      return 'Claimed'
+    case UiTransactionStatuses.FAILED:
+      return 'Retry'
+    default:
+      return 'Claim Fees'
+  }
+}

--- a/apps/earn-protocol/features/beach-club/hooks/use-claim-beach-club-fees-transaction.ts
+++ b/apps/earn-protocol/features/beach-club/hooks/use-claim-beach-club-fees-transaction.ts
@@ -1,0 +1,125 @@
+'use client'
+import { useSendUserOperation, useSmartAccountClient } from '@account-kit/react'
+import { accountType, useIsIframe } from '@summerfi/app-earn-ui'
+import { type SupportedSDKNetworks } from '@summerfi/app-types'
+import { type AddressValue, ChainIds } from '@summerfi/sdk-common'
+import { type PublicClient } from 'viem'
+
+import { getGasSponsorshipOverride } from '@/helpers/get-gas-sponsorship-override'
+import { useAppSDK } from '@/hooks/use-app-sdk'
+import { useSafeTransaction } from '@/hooks/use-safe-transaction'
+
+/**
+ * Hook to handle claim of beach club fees through a user operation transaction
+ * @param {Object} params - Hook parameters
+ * @param {() => void} params.onSuccess - Callback function called when the transaction succeeds
+ * @param {() => void} params.onError - Callback function called when the transaction fails
+ * @returns {Object} Object containing the claim transaction function, loading state, and error state
+ * @returns {() => Promise<unknown>} returns.claimBeachClubFeesTransaction - Function to execute the claim transaction
+ * @returns {boolean} returns.isLoading - Whether the transaction is currently being processed
+ * @returns {Error | null} returns.error - Error object if the transaction failed, null otherwise
+ */
+export const useClaimBeachClubFeesTransaction = ({
+  onSuccess,
+  onError,
+  network,
+  publicClient,
+}: {
+  onSuccess: () => void
+  onError: () => void
+  network: SupportedSDKNetworks
+  publicClient?: PublicClient
+}): {
+  claimBeachClubFeesTransaction: () => Promise<unknown>
+  isLoading: boolean
+  error: Error | null
+} => {
+  const {
+    getReferralFeesMerklClaimTx,
+    getCurrentUser,
+    getChainInfo,
+    getUserMerklRewards,
+    getTokenBySymbol,
+  } = useAppSDK()
+
+  const { client: smartAccountClient } = useSmartAccountClient({ type: accountType })
+
+  const { sendSafeWalletTransaction, waitingForTx } = useSafeTransaction({
+    network,
+    onSuccess,
+    onError,
+    publicClient,
+  })
+
+  const isIframe = useIsIframe()
+
+  const {
+    sendUserOperationAsync,
+    error: sendUserOperationError,
+    isSendingUserOperation,
+  } = useSendUserOperation({
+    client: smartAccountClient,
+    waitForTxn: true,
+    onSuccess,
+    onError,
+  })
+
+  const claimBeachClubFeesTransaction = async () => {
+    const user = getCurrentUser()
+    const chainInfo = getChainInfo()
+
+    const usdcToken = await getTokenBySymbol({
+      symbol: 'USDC',
+      chainId: ChainIds.Base,
+    })
+
+    // fees are claimed on base only and only for USDC
+    const rewards = await getUserMerklRewards({
+      user,
+      chainIds: [ChainIds.Base],
+      rewardsTokensAddresses: [usdcToken.address.value],
+    })
+
+    const rewardsOnBase = rewards.perChain[ChainIds.Base]
+
+    if (!rewardsOnBase) {
+      throw new Error('No fees to claim on Base')
+    }
+
+    const tx = await getReferralFeesMerklClaimTx({
+      user,
+      chainInfo,
+      rewardsTokensAddresses: rewardsOnBase.map((reward) => reward.token.address as AddressValue),
+    })
+
+    if (!tx) {
+      throw new Error('No fees to claim')
+    }
+
+    const txParams = {
+      target: tx[0].transaction.target.value,
+      data: tx[0].transaction.calldata,
+      value: BigInt(tx[0].transaction.value),
+    }
+
+    const resolvedOverrides = await getGasSponsorshipOverride({
+      smartAccountClient,
+      txParams,
+    })
+
+    if (isIframe) {
+      return sendSafeWalletTransaction(txParams)
+    }
+
+    return await sendUserOperationAsync({
+      uo: txParams,
+      overrides: resolvedOverrides,
+    })
+  }
+
+  return {
+    claimBeachClubFeesTransaction,
+    isLoading: isSendingUserOperation || !!waitingForTx,
+    error: sendUserOperationError,
+  }
+}

--- a/apps/earn-protocol/features/beach-club/state.ts
+++ b/apps/earn-protocol/features/beach-club/state.ts
@@ -1,0 +1,41 @@
+import { type MerklIsAuthorizedPerChain } from '@/features/claim-and-delegate/types'
+
+import { type BeachClubReducerAction, type BeachClubState } from './types'
+
+export const beachClubDefaultState: BeachClubState = {
+  merklStatus: undefined,
+  claimStatus: undefined,
+  walletAddress: '0x0', // dummy, invalid address for init
+  merklIsAuthorizedPerChain: {} as MerklIsAuthorizedPerChain,
+  feesClaimed: false,
+}
+
+export const beachClubReducer = (
+  prevState: BeachClubState,
+  action: BeachClubReducerAction,
+): BeachClubState => {
+  switch (action.type) {
+    case 'update-claim-status':
+      return {
+        ...prevState,
+        claimStatus: action.payload,
+      }
+    case 'update-merkl-status':
+      return {
+        ...prevState,
+        merklStatus: action.payload,
+      }
+    case 'update-merkl-is-authorized-per-chain':
+      return {
+        ...prevState,
+        merklIsAuthorizedPerChain: action.payload,
+      }
+    case 'update-fees-claimed':
+      return {
+        ...prevState,
+        feesClaimed: action.payload,
+      }
+    default:
+      return prevState
+  }
+}

--- a/apps/earn-protocol/features/beach-club/types.ts
+++ b/apps/earn-protocol/features/beach-club/types.ts
@@ -1,3 +1,7 @@
+import { type UiTransactionStatuses } from '@summerfi/app-types'
+
+import { type MerklIsAuthorizedPerChain } from '@/features/claim-and-delegate/types'
+
 export type BeachClubReferralList = {
   address: string
   tvl: string
@@ -34,3 +38,29 @@ export type BeachClubRecruitedUsersPagination = {
     itemsPerPage: number
   }
 }
+
+export type BeachClubState = {
+  claimStatus: UiTransactionStatuses | undefined
+  merklStatus: UiTransactionStatuses | undefined
+  walletAddress: string
+  merklIsAuthorizedPerChain: MerklIsAuthorizedPerChain
+  feesClaimed: boolean
+}
+
+export type BeachClubReducerAction =
+  | {
+      type: 'update-merkl-status'
+      payload: UiTransactionStatuses | undefined
+    }
+  | {
+      type: 'update-claim-status'
+      payload: UiTransactionStatuses | undefined
+    }
+  | {
+      type: 'update-merkl-is-authorized-per-chain'
+      payload: MerklIsAuthorizedPerChain
+    }
+  | {
+      type: 'update-fees-claimed'
+      payload: boolean
+    }

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateCompletedStep/ClaimDelegateCompletedStep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateCompletedStep/ClaimDelegateCompletedStep.tsx
@@ -11,7 +11,7 @@ import {
   useLocalConfig,
   WithArrow,
 } from '@summerfi/app-earn-ui'
-import { SupportedNetworkIds } from '@summerfi/app-types'
+import { SupportedNetworkIds, UiTransactionStatuses } from '@summerfi/app-types'
 import {
   ADDRESS_ZERO,
   formatCryptoBalance,
@@ -26,7 +26,6 @@ import { useDecayFactor } from '@/features/claim-and-delegate/hooks/use-decay-fa
 import {
   type ClaimDelegateExternalData,
   type ClaimDelegateState,
-  ClaimDelegateTxStatuses,
 } from '@/features/claim-and-delegate/types'
 import { PortfolioTabs } from '@/features/portfolio/types'
 
@@ -189,7 +188,7 @@ export const ClaimDelegateCompletedStep: FC<ClaimDelegateCompletedStepProps> = (
   const estimatedSumrPrice = Number(sumrNetApyConfig.dilutedValuation) / SUMR_CAP
 
   const sumrClaimedStepBefore =
-    state.claimStatus === ClaimDelegateTxStatuses.COMPLETED
+    state.claimStatus === UiTransactionStatuses.COMPLETED
       ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         externalData.sumrToClaim.aggregatedRewards.perChain[SupportedNetworkIds.Base] ?? 0
       : 0
@@ -226,7 +225,7 @@ export const ClaimDelegateCompletedStep: FC<ClaimDelegateCompletedStepProps> = (
     <div className={classNames.claimDelegateStakeDelegateCompletedSubstepWrapper}>
       <div className={classNames.mainContent}>
         <ClaimedCard
-          hasClaimed={state.claimStatus === ClaimDelegateTxStatuses.COMPLETED}
+          hasClaimed={state.claimStatus === UiTransactionStatuses.COMPLETED}
           externalData={externalData}
           chainId={chain.id}
           estimatedSumrPrice={estimatedSumrPrice}

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateFormHeader/ClaimDelegateFormHeader.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateFormHeader/ClaimDelegateFormHeader.tsx
@@ -1,12 +1,9 @@
 import { type FC } from 'react'
 import { Icon, Text } from '@summerfi/app-earn-ui'
+import { UiTransactionStatuses } from '@summerfi/app-types'
 import clsx from 'clsx'
 
-import {
-  type ClaimDelegateState,
-  ClaimDelegateSteps,
-  ClaimDelegateTxStatuses,
-} from '@/features/claim-and-delegate/types'
+import { type ClaimDelegateState, ClaimDelegateSteps } from '@/features/claim-and-delegate/types'
 
 import classNames from './ClaimDelegateFormHeader.module.css'
 
@@ -48,7 +45,7 @@ const getIsCompleted = ({
 }) =>
   idx < steps.findIndex((item) => item.value === state.step) ||
   (state.step === ClaimDelegateSteps.DELEGATE &&
-    state.delegateStatus === ClaimDelegateTxStatuses.COMPLETED)
+    state.delegateStatus === UiTransactionStatuses.COMPLETED)
 
 interface ClaimDelegateFormHeaderProps {
   state: ClaimDelegateState

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateOptInMerkl/ClaimDelegateOptInMerkl.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateOptInMerkl/ClaimDelegateOptInMerkl.tsx
@@ -1,32 +1,27 @@
 import { type FC } from 'react'
 import { Button, Card, Text } from '@summerfi/app-earn-ui'
+import { UiTransactionStatuses } from '@summerfi/app-types'
 import Link from 'next/link'
-
-import {
-  type ClaimDelegateState,
-  ClaimDelegateTxStatuses,
-} from '@/features/claim-and-delegate/types'
 
 import { getDelegateOptInMerklButtonLabel } from './helpers'
 
 import classNames from './ClaimDelegateOptInMerkl.module.css'
 
 interface ClaimDelegateOptInMerklProps {
-  state: ClaimDelegateState
   onAccept: () => void
   onReject: () => void
+  merklStatus?: UiTransactionStatuses
 }
 
 export const ClaimDelegateOptInMerkl: FC<ClaimDelegateOptInMerklProps> = ({
-  state,
   onAccept,
   onReject,
+  merklStatus,
 }) => {
-  const buttonLabel = getDelegateOptInMerklButtonLabel({ merklStatus: state.merklStatus })
+  const buttonLabel = getDelegateOptInMerklButtonLabel({ merklStatus })
 
   const isDisabled =
-    state.merklStatus === ClaimDelegateTxStatuses.PENDING ||
-    state.merklStatus === ClaimDelegateTxStatuses.COMPLETED
+    merklStatus === UiTransactionStatuses.PENDING || merklStatus === UiTransactionStatuses.COMPLETED
 
   return (
     <Card variant="cardSecondary" className={classNames.claimDelegateOptInMerklWrapper}>

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateOptInMerkl/helpers.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateOptInMerkl/helpers.ts
@@ -1,16 +1,16 @@
-import { ClaimDelegateTxStatuses } from '@/features/claim-and-delegate/types'
+import { UiTransactionStatuses } from '@summerfi/app-types'
 
 export const getDelegateOptInMerklButtonLabel = ({
   merklStatus,
 }: {
-  merklStatus?: ClaimDelegateTxStatuses
+  merklStatus?: UiTransactionStatuses
 }) => {
   switch (merklStatus) {
-    case ClaimDelegateTxStatuses.FAILED:
+    case UiTransactionStatuses.FAILED:
       return 'Try again'
-    case ClaimDelegateTxStatuses.PENDING:
+    case UiTransactionStatuses.PENDING:
       return 'Approving...'
-    case ClaimDelegateTxStatuses.COMPLETED:
+    case UiTransactionStatuses.COMPLETED:
       return 'Approved'
     default:
       return 'Approve'

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeStep/ClaimDelegateStakeStep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeStep/ClaimDelegateStakeStep.tsx
@@ -19,7 +19,7 @@ import {
   useUserWallet,
   WithArrow,
 } from '@summerfi/app-earn-ui'
-import { SupportedNetworkIds } from '@summerfi/app-types'
+import { SupportedNetworkIds, UiTransactionStatuses } from '@summerfi/app-types'
 import {
   ADDRESS_ZERO,
   formatCryptoBalance,
@@ -43,7 +43,6 @@ import {
   ClaimDelegateStakeType,
   type ClaimDelegateState,
   ClaimDelegateSteps,
-  ClaimDelegateTxStatuses,
 } from '@/features/claim-and-delegate/types'
 import { ERROR_TOAST_CONFIG, SUCCESS_TOAST_CONFIG } from '@/features/toastify/config'
 import { revalidateUser } from '@/helpers/revalidation-handlers'
@@ -170,7 +169,7 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
 
   const { stakeSumrTransaction, approveSumrTransaction, prepareTxs } = useStakeSumrTransaction({
     onStakeSuccess: () => {
-      dispatch({ type: 'update-staking-status', payload: ClaimDelegateTxStatuses.COMPLETED })
+      dispatch({ type: 'update-staking-status', payload: UiTransactionStatuses.COMPLETED })
       dispatch({ type: 'update-step', payload: ClaimDelegateSteps.COMPLETED })
 
       toast.success('Staked $SUMR tokens successfully', SUCCESS_TOAST_CONFIG)
@@ -178,18 +177,18 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
     onApproveSuccess: () => {
       dispatch({
         type: 'update-staking-approve-status',
-        payload: ClaimDelegateTxStatuses.COMPLETED,
+        payload: UiTransactionStatuses.COMPLETED,
       })
 
       toast.success('Approved staking $SUMR tokens successfully', SUCCESS_TOAST_CONFIG)
     },
     onStakeError: () => {
-      dispatch({ type: 'update-staking-status', payload: ClaimDelegateTxStatuses.FAILED })
+      dispatch({ type: 'update-staking-status', payload: UiTransactionStatuses.FAILED })
 
       toast.error('Failed to stake $SUMR tokens', ERROR_TOAST_CONFIG)
     },
     onApproveError: () => {
-      dispatch({ type: 'update-staking-approve-status', payload: ClaimDelegateTxStatuses.FAILED })
+      dispatch({ type: 'update-staking-approve-status', payload: UiTransactionStatuses.FAILED })
 
       toast.error('Failed to approve staking $SUMR tokens', ERROR_TOAST_CONFIG)
     },
@@ -198,13 +197,13 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
   const { unstakeSumrTransaction } = useUnstakeSumrTransaction({
     amount: formatDecimalToBigInt(amountRawUnstake),
     onSuccess: () => {
-      dispatch({ type: 'update-staking-status', payload: ClaimDelegateTxStatuses.COMPLETED })
+      dispatch({ type: 'update-staking-status', payload: UiTransactionStatuses.COMPLETED })
       dispatch({ type: 'update-step', payload: ClaimDelegateSteps.COMPLETED })
 
       toast.success('Unstaked $SUMR tokens successfully', SUCCESS_TOAST_CONFIG)
     },
     onError: () => {
-      dispatch({ type: 'update-staking-status', payload: ClaimDelegateTxStatuses.FAILED })
+      dispatch({ type: 'update-staking-status', payload: UiTransactionStatuses.FAILED })
 
       toast.error('Failed to unstake $SUMR tokens', ERROR_TOAST_CONFIG)
     },
@@ -236,13 +235,10 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
       return
     }
 
-    if (
-      approveSumrTransaction &&
-      state.stakingApproveStatus !== ClaimDelegateTxStatuses.COMPLETED
-    ) {
+    if (approveSumrTransaction && state.stakingApproveStatus !== UiTransactionStatuses.COMPLETED) {
       dispatch({
         type: 'update-staking-approve-status',
-        payload: ClaimDelegateTxStatuses.PENDING,
+        payload: UiTransactionStatuses.PENDING,
       })
 
       dispatch({
@@ -259,7 +255,7 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
     }
 
     if (stakeSumrTransaction) {
-      dispatch({ type: 'update-staking-status', payload: ClaimDelegateTxStatuses.PENDING })
+      dispatch({ type: 'update-staking-status', payload: UiTransactionStatuses.PENDING })
 
       await stakeSumrTransaction()
         .catch((err) => {
@@ -281,7 +277,7 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
       return
     }
 
-    dispatch({ type: 'update-staking-status', payload: ClaimDelegateTxStatuses.PENDING })
+    dispatch({ type: 'update-staking-status', payload: UiTransactionStatuses.PENDING })
 
     dispatch({
       type: 'update-stake-change-amount',
@@ -321,16 +317,16 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
   const stakedAmountUSD = formatFiatBalance(stakedAmountRaw * estimatedSumrPrice)
 
   const isLoading =
-    state.stakingStatus === ClaimDelegateTxStatuses.PENDING ||
-    state.stakingApproveStatus === ClaimDelegateTxStatuses.PENDING ||
-    state.delegateStatus === ClaimDelegateTxStatuses.PENDING
+    state.stakingStatus === UiTransactionStatuses.PENDING ||
+    state.stakingApproveStatus === UiTransactionStatuses.PENDING ||
+    state.delegateStatus === UiTransactionStatuses.PENDING
 
   const { stakedAmount } = externalData.sumrStakeDelegate
 
   const withApproval = !!approveSumrTransaction
 
   const hasNoDelegatee =
-    state.delegateStatus === ClaimDelegateTxStatuses.COMPLETED
+    state.delegateStatus === UiTransactionStatuses.COMPLETED
       ? state.delegatee === ADDRESS_ZERO
       : externalData.sumrStakeDelegate.delegatedTo === ADDRESS_ZERO
 
@@ -534,7 +530,7 @@ export const ClaimDelegateStakeStep: FC<ClaimDelegateStakeStepProps> = ({
                 dispatch({ type: 'update-stake-type', payload: _tab.id as ClaimDelegateStakeType })
                 if (
                   [state.stakingApproveStatus, state.stakingStatus].includes(
-                    ClaimDelegateTxStatuses.FAILED,
+                    UiTransactionStatuses.FAILED,
                   )
                 ) {
                   dispatch({ type: 'update-staking-status', payload: undefined })

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeStep/getStakeButtonLabel.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStakeStep/getStakeButtonLabel.ts
@@ -1,7 +1,8 @@
+import { UiTransactionStatuses } from '@summerfi/app-types'
+
 import {
   ClaimDelegateStakeType,
   type ClaimDelegateState,
-  ClaimDelegateTxStatuses,
 } from '@/features/claim-and-delegate/types'
 
 export const getStakeButtonLabel = ({
@@ -19,22 +20,22 @@ export const getStakeButtonLabel = ({
     return isMobile ? 'Change network' : 'Change network to Base'
   }
 
-  if (state.stakingApproveStatus === ClaimDelegateTxStatuses.PENDING) {
+  if (state.stakingApproveStatus === UiTransactionStatuses.PENDING) {
     return 'Approving...'
   }
 
-  if (state.stakingStatus === ClaimDelegateTxStatuses.PENDING) {
+  if (state.stakingStatus === UiTransactionStatuses.PENDING) {
     return state.stakeType === ClaimDelegateStakeType.ADD_STAKE ? 'Staking...' : 'Unstaking...'
   }
 
-  if ([state.stakingStatus, state.stakingApproveStatus].includes(ClaimDelegateTxStatuses.FAILED)) {
+  if ([state.stakingStatus, state.stakingApproveStatus].includes(UiTransactionStatuses.FAILED)) {
     return 'Retry'
   }
 
   if (
     withApproval &&
     state.stakeType === ClaimDelegateStakeType.ADD_STAKE &&
-    state.stakingApproveStatus !== ClaimDelegateTxStatuses.COMPLETED
+    state.stakingApproveStatus !== UiTransactionStatuses.COMPLETED
   ) {
     return 'Approve'
   }

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStep/ClaimDelegateStep.tsx
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStep/ClaimDelegateStep.tsx
@@ -16,7 +16,11 @@ import {
   useUserWallet,
   WithArrow,
 } from '@summerfi/app-earn-ui'
-import { type DropdownRawOption, SupportedNetworkIds } from '@summerfi/app-types'
+import {
+  type DropdownRawOption,
+  SupportedNetworkIds,
+  UiTransactionStatuses,
+} from '@summerfi/app-types'
 import {
   ADDRESS_ZERO,
   formatCryptoBalance,
@@ -38,7 +42,6 @@ import {
   type ClaimDelegateReducerAction,
   type ClaimDelegateState,
   ClaimDelegateSteps,
-  ClaimDelegateTxStatuses,
 } from '@/features/claim-and-delegate/types'
 import { PortfolioTabs } from '@/features/portfolio/types'
 import { ERROR_TOAST_CONFIG, SUCCESS_TOAST_CONFIG } from '@/features/toastify/config'
@@ -174,7 +177,7 @@ export const ClaimDelegateStep: FC<ClaimDelegateStepProps> = ({
 
   const { sumrDelegateTransaction } = useSumrDelegateTransaction({
     onSuccess: () => {
-      dispatch({ type: 'update-delegate-status', payload: ClaimDelegateTxStatuses.COMPLETED })
+      dispatch({ type: 'update-delegate-status', payload: UiTransactionStatuses.COMPLETED })
 
       toast.success('Delegate has been updated', SUCCESS_TOAST_CONFIG)
 
@@ -188,7 +191,7 @@ export const ClaimDelegateStep: FC<ClaimDelegateStepProps> = ({
       dispatch({ type: 'update-step', payload: ClaimDelegateSteps.STAKE })
     },
     onError: () => {
-      dispatch({ type: 'update-delegate-status', payload: ClaimDelegateTxStatuses.FAILED })
+      dispatch({ type: 'update-delegate-status', payload: UiTransactionStatuses.FAILED })
 
       toast.error('Failed to update delegate', ERROR_TOAST_CONFIG)
     },
@@ -227,7 +230,7 @@ export const ClaimDelegateStep: FC<ClaimDelegateStepProps> = ({
       }
     }
 
-    dispatch({ type: 'update-delegate-status', payload: ClaimDelegateTxStatuses.PENDING })
+    dispatch({ type: 'update-delegate-status', payload: UiTransactionStatuses.PENDING })
 
     await sumrDelegateTransaction(updateDelegatee)
       .catch((err) => {
@@ -242,19 +245,17 @@ export const ClaimDelegateStep: FC<ClaimDelegateStepProps> = ({
   const mappedSumrDelegatesData = mergeDelegatesData(delegates)
 
   const isChangeDelegateLoading =
-    state.delegateStatus === ClaimDelegateTxStatuses.PENDING &&
-    action === ClaimDelegateAction.CHANGE
+    state.delegateStatus === UiTransactionStatuses.PENDING && action === ClaimDelegateAction.CHANGE
 
   const isRemoveDelegateLoading =
-    state.delegateStatus === ClaimDelegateTxStatuses.PENDING &&
-    action === ClaimDelegateAction.REMOVE
+    state.delegateStatus === UiTransactionStatuses.PENDING && action === ClaimDelegateAction.REMOVE
 
   // self delegating is available on for EOA only
   // since we use tally that doesn't support SCA
   const isEoa = user?.type === AccountKitAccountType.EOA
 
   const sumrDelegatedTo =
-    state.delegateStatus === ClaimDelegateTxStatuses.COMPLETED && state.delegatee
+    state.delegateStatus === UiTransactionStatuses.COMPLETED && state.delegatee
       ? state.delegatee.toLowerCase()
       : externalData.sumrStakeDelegate.delegatedTo.toLowerCase()
 

--- a/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStep/getDelegateButtonLabel.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/components/ClaimDelegateStep/getDelegateButtonLabel.ts
@@ -1,7 +1,6 @@
-import {
-  type ClaimDelegateState,
-  ClaimDelegateTxStatuses,
-} from '@/features/claim-and-delegate/types'
+import { UiTransactionStatuses } from '@summerfi/app-types'
+
+import { type ClaimDelegateState } from '@/features/claim-and-delegate/types'
 
 import { ClaimDelegateAction } from './types'
 
@@ -22,11 +21,11 @@ export const getChangeDelegateButtonLabel = ({
     return 'Delegate'
   }
 
-  if (state.delegateStatus === ClaimDelegateTxStatuses.PENDING) {
+  if (state.delegateStatus === UiTransactionStatuses.PENDING) {
     return 'Delegating'
   }
 
-  if (state.delegateStatus === ClaimDelegateTxStatuses.FAILED) {
+  if (state.delegateStatus === UiTransactionStatuses.FAILED) {
     return 'Retry'
   }
 
@@ -50,11 +49,11 @@ export const getRemoveDelegateButtonLabel = ({
     return 'Remove delegation'
   }
 
-  if (state.delegateStatus === ClaimDelegateTxStatuses.PENDING) {
+  if (state.delegateStatus === UiTransactionStatuses.PENDING) {
     return 'Removing'
   }
 
-  if (state.delegateStatus === ClaimDelegateTxStatuses.FAILED) {
+  if (state.delegateStatus === UiTransactionStatuses.FAILED) {
     return 'Retry'
   }
 

--- a/apps/earn-protocol/features/claim-and-delegate/types.ts
+++ b/apps/earn-protocol/features/claim-and-delegate/types.ts
@@ -1,4 +1,4 @@
-import { type SupportedNetworkIds } from '@summerfi/app-types'
+import { type SupportedNetworkIds, type UiTransactionStatuses } from '@summerfi/app-types'
 import { type HumanReadableNetwork } from '@summerfi/app-utils'
 
 import { type SumrBalancesData } from '@/app/server-handlers/sumr-balances'
@@ -13,12 +13,6 @@ export enum ClaimDelegateSteps {
   DELEGATE = 'delegate',
   STAKE = 'stake',
   COMPLETED = 'completed',
-}
-
-export enum ClaimDelegateTxStatuses {
-  PENDING = 'pending',
-  COMPLETED = 'completed',
-  FAILED = 'failed',
 }
 
 export enum ClaimDelegateStakeType {
@@ -41,11 +35,11 @@ export type MerklIsAuthorizedPerChain = {
 export type ClaimDelegateState = {
   step: ClaimDelegateSteps
   delegatee: string | undefined
-  claimStatus: ClaimDelegateTxStatuses | undefined
-  merklStatus: ClaimDelegateTxStatuses | undefined
-  delegateStatus: ClaimDelegateTxStatuses | undefined
-  stakingStatus: ClaimDelegateTxStatuses | undefined
-  stakingApproveStatus: ClaimDelegateTxStatuses | undefined
+  claimStatus: UiTransactionStatuses | undefined
+  merklStatus: UiTransactionStatuses | undefined
+  delegateStatus: UiTransactionStatuses | undefined
+  stakingStatus: UiTransactionStatuses | undefined
+  stakingApproveStatus: UiTransactionStatuses | undefined
   stakeType: ClaimDelegateStakeType
   stakeChangeAmount: string | undefined
   walletAddress: string
@@ -67,23 +61,23 @@ export type ClaimDelegateReducerAction =
     }
   | {
       type: 'update-merkl-status'
-      payload: ClaimDelegateTxStatuses | undefined
+      payload: UiTransactionStatuses | undefined
     }
   | {
       type: 'update-claim-status'
-      payload: ClaimDelegateTxStatuses | undefined
+      payload: UiTransactionStatuses | undefined
     }
   | {
       type: 'update-delegate-status'
-      payload: ClaimDelegateTxStatuses | undefined
+      payload: UiTransactionStatuses | undefined
     }
   | {
       type: 'update-staking-status'
-      payload: ClaimDelegateTxStatuses | undefined
+      payload: UiTransactionStatuses | undefined
     }
   | {
       type: 'update-staking-approve-status'
-      payload: ClaimDelegateTxStatuses | undefined
+      payload: UiTransactionStatuses | undefined
     }
   | {
       type: 'update-stake-type'

--- a/apps/earn-protocol/features/portfolio/components/PortfolioBeachClub/PortfolioBeachClub.tsx
+++ b/apps/earn-protocol/features/portfolio/components/PortfolioBeachClub/PortfolioBeachClub.tsx
@@ -1,21 +1,29 @@
-import { type FC } from 'react'
+import { type Dispatch, type FC } from 'react'
 import { Text } from '@summerfi/app-earn-ui'
 
 import { type BeachClubData } from '@/app/server-handlers/beach-club/get-user-beach-club-data'
 import { BeachClubBigBanner } from '@/features/beach-club/components/BeachClubBigBannner/BeachClubBigBanner'
 import { BeachClubReferAndEarn } from '@/features/beach-club/components/BeachClubReferAndEarn/BeachClubReferAndEarn'
 import { BeachClubRewards } from '@/features/beach-club/components/BeachClubRewards/BeachClubRewards'
+import { type BeachClubReducerAction, type BeachClubState } from '@/features/beach-club/types'
+import { type MerklIsAuthorizedPerChain } from '@/features/claim-and-delegate/types'
 
 import classNames from './PortfolioBeachClub.module.css'
 
 interface PortfolioBeachClubProps {
   walletAddress: string
   beachClubData: BeachClubData
+  merklIsAuthorizedPerChain: MerklIsAuthorizedPerChain
+  state: BeachClubState
+  dispatch: Dispatch<BeachClubReducerAction>
 }
 
 export const PortfolioBeachClub: FC<PortfolioBeachClubProps> = ({
   walletAddress,
   beachClubData,
+  merklIsAuthorizedPerChain,
+  state,
+  dispatch,
 }) => {
   return (
     <div className={classNames.beachClubWrapper}>
@@ -27,7 +35,13 @@ export const PortfolioBeachClub: FC<PortfolioBeachClubProps> = ({
       </Text>
       <BeachClubBigBanner />
       <BeachClubReferAndEarn walletAddress={walletAddress} beachClubData={beachClubData} />
-      <BeachClubRewards beachClubData={beachClubData} walletAddress={walletAddress} />
+      <BeachClubRewards
+        beachClubData={beachClubData}
+        walletAddress={walletAddress}
+        merklIsAuthorizedPerChain={merklIsAuthorizedPerChain}
+        state={state}
+        dispatch={dispatch}
+      />
     </div>
   )
 }

--- a/packages/app-types/types/index.ts
+++ b/packages/app-types/types/index.ts
@@ -197,6 +197,7 @@ export {
   SupportedNetworkIds,
   SupportedSDKNetworks,
   UserActivityType,
+  UiTransactionStatuses,
 } from './src/earn-protocol'
 export { DeviceType } from './src/device-type'
 export type { DeviceInfo } from './src/device-type'

--- a/packages/app-types/types/src/earn-protocol/index.ts
+++ b/packages/app-types/types/src/earn-protocol/index.ts
@@ -76,6 +76,12 @@ export type EarnTransactionViewStates =
   | 'txError'
   | 'txSuccess'
 
+export enum UiTransactionStatuses {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
 export type EarnAllowanceTypes = 'deposit' | 'custom'
 
 export enum UserActivityType {

--- a/sdk/sdk-client-react/src/handlers/getReferralFeesMerklClaimTxHandler.ts
+++ b/sdk/sdk-client-react/src/handlers/getReferralFeesMerklClaimTxHandler.ts
@@ -1,0 +1,28 @@
+import type { ISDKManager } from '@summerfi/sdk-client'
+import { type AddressValue, type IChainInfo, type IUser } from '@summerfi/sdk-common'
+
+/**
+ * @name getReferralFeesMerklClaimTxHandler
+ * @description Generates a transaction to claim Merkl rewards for a referral on a specific chain
+ * @param params.user The user's address
+ * @param params.chainInfo The chain information
+ * @param params.rewardsTokensAddresses Optional array of token addresses to claim (default: all tokens)
+ */
+export const getReferralFeesMerklClaimTxHandler =
+  (sdk: ISDKManager) =>
+  async ({
+    user,
+    chainInfo,
+    rewardsTokensAddresses,
+  }: {
+    user: IUser
+    chainInfo: IChainInfo
+    rewardsTokensAddresses: AddressValue[]
+  }) => {
+    const position = await sdk.armada.users.getReferralFeesMerklClaimTx({
+      address: user.wallet.address.value,
+      chainId: chainInfo.chainId,
+      rewardsTokensAddresses: rewardsTokensAddresses,
+    })
+    return position
+  }

--- a/sdk/sdk-client-react/src/handlers/getUserMerklRewardsHandler.ts
+++ b/sdk/sdk-client-react/src/handlers/getUserMerklRewardsHandler.ts
@@ -1,0 +1,28 @@
+import type { ISDKManager } from '@summerfi/sdk-client'
+import { ChainId, type AddressValue, type IUser } from '@summerfi/sdk-common'
+
+/**
+ * @name getUserMerklRewardsHandler
+ * @description Gets Merkl rewards for a user across specified chains
+ * @param params.user The user's address
+ * @param params.chainIds Optional chain IDs to filter by (default: supported chains)
+ * @param params.rewardsTokensAddresses Optional array of token addresses to filter rewards (default: all tokens)
+ */
+export const getUserMerklRewardsHandler =
+  (sdk: ISDKManager) =>
+  async ({
+    user,
+    chainIds,
+    rewardsTokensAddresses,
+  }: {
+    user: IUser
+    chainIds: ChainId[]
+    rewardsTokensAddresses: AddressValue[]
+  }) => {
+    const position = await sdk.armada.users.getUserMerklRewards({
+      address: user.wallet.address.value,
+      chainIds,
+      rewardsTokensAddresses,
+    })
+    return position
+  }

--- a/sdk/sdk-client-react/src/hooks/useSDK.ts
+++ b/sdk/sdk-client-react/src/hooks/useSDK.ts
@@ -31,6 +31,8 @@ import { getMigratablePositionsHandlerApy } from '../handlers/getMigratablePosit
 import { getSpotPriceHandler } from '../handlers/getSpotPriceHandler'
 import { getSpotPricesHandler } from '../handlers/getSpotPricesHandler'
 import { getAuthorizeAsMerklRewardsOperatorTxHandler } from '../handlers/getAuthorizeAsMerklRewardsOperatorTxHandler'
+import { getReferralFeesMerklClaimTxHandler } from '../handlers/getReferralFeesMerklClaimTxHandler'
+import { getUserMerklRewardsHandler } from '../handlers/getUserMerklRewardsHandler'
 
 type UseSdk = {
   walletAddress?: string
@@ -106,6 +108,8 @@ export const useSDK = (params: UseSdk) => {
     () => getAuthorizeAsMerklRewardsOperatorTxHandler(sdk),
     [sdk],
   )
+  const getReferralFeesMerklClaimTx = useMemo(() => getReferralFeesMerklClaimTxHandler(sdk), [sdk])
+  const getUserMerklRewards = useMemo(() => getUserMerklRewardsHandler(sdk), [sdk])
 
   const memo = useMemo(
     () => ({
@@ -139,6 +143,8 @@ export const useSDK = (params: UseSdk) => {
       getSpotPrice,
       getSpotPrices,
       getAuthorizeAsMerklRewardsOperatorTx,
+      getReferralFeesMerklClaimTx,
+      getUserMerklRewards,
     }),
     [
       getCurrentUser,
@@ -171,6 +177,8 @@ export const useSDK = (params: UseSdk) => {
       getSpotPrice,
       getSpotPrices,
       getAuthorizeAsMerklRewardsOperatorTx,
+      getReferralFeesMerklClaimTx,
+      getUserMerklRewards,
     ],
   )
 


### PR DESCRIPTION
# Add Beach Club fees claiming functionality with Merkl integration

## Description
Implements Beach Club fees claiming functionality with Merkl opt-in modal integration, allowing users to claim their earned fees through a streamlined transaction flow.

## Changes
- Added Beach Club state management with reducer pattern for transaction status tracking
- Implemented Merkl opt-in modal integration in Beach Club TVL challenge component
- Added claim fees transaction hook with support for both regular and Safe Wallet transactions
- Created helper function for dynamic claim button labels based on transaction status
- Added delay per network constants for transaction confirmation timing
- Updated Beach Club rewards component to pass state and dispatch props
- Enhanced TVL challenge component with claim fees button and opt-in flow
- Added proper error handling and toast notifications for transaction feedback

## Benefits
1. Users can now claim their earned Beach Club fees directly from the UI
2. Improved user experience with Merkl opt-in flow for fee claiming
3. Better transaction status feedback with dynamic button labels
4. Support for both regular and Safe Wallet transaction types
5. Consistent transaction timing across different networks

## Testing
- Test fee claiming flow with and without Merkl authorization
- Verify transaction status updates and button label changes
- Test Safe Wallet integration in iframe environments
- Validate error handling and toast notifications
- Confirm network-specific delay timing

## Next steps
- Monitor fee claiming transaction success rates
- Consider adding additional fee token support beyond USDC
- Evaluate user feedback on the claiming flow

## Additional Notes
Currently supports fee claiming on Base network only with USDC tokens. The implementation includes proper gas sponsorship and transaction parameter handling for optimal user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Beach Club fees claiming with an opt-in flow, including mobile drawer and desktop modal.
  - Introduced network-aware handling for Beach Club actions with per-network timing to improve reliability.
- Improvements
  - Unified transaction status across claim/delegate/stake flows with clearer button labels (e.g., Approving…, Claiming…, Claimed, Retry).
  - Enhanced Beach Club rewards/TVL Challenge with authorization checks and actionable CTAs that reflect eligibility and progress.
  - More responsive UI updates and toasts for success and failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->