### PR TITLE
Insti asset allocation panel init

### DIFF
--- a/apps/earn-protocol-institutions/app/[institutionId]/(tabs)/vaults/[network]/[vaultAddress]/asset-relocation/page.tsx
+++ b/apps/earn-protocol-institutions/app/[institutionId]/(tabs)/vaults/[network]/[vaultAddress]/asset-relocation/page.tsx
@@ -1,5 +1,39 @@
+import { REVALIDATION_TAGS, REVALIDATION_TIMES } from '@summerfi/app-earn-ui'
+import { humanNetworktoSDKNetwork } from '@summerfi/app-utils'
+import { unstable_cache as unstableCache } from 'next/cache'
+
+import { getVaultDetails } from '@/app/server-handlers/sdk/get-vault-details'
 import { PanelAssetRelocation } from '@/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation'
 
-export default function InstitutionVaultAssetRelocationPage() {
-  return <PanelAssetRelocation />
+export default async function InstitutionVaultAssetRelocationPage({
+  params,
+}: {
+  params: Promise<{ institutionId: string; vaultAddress: string; network: string }>
+}) {
+  const { institutionId, vaultAddress, network } = await params
+
+  const parsedNetwork = humanNetworktoSDKNetwork(network)
+  // tags yet to be determined
+  const cacheConfig = {
+    revalidate: REVALIDATION_TIMES.PORTFOLIO_DATA,
+    tags: [REVALIDATION_TAGS.PORTFOLIO_DATA, parsedNetwork],
+  }
+
+  const [vault] = await Promise.all([
+    unstableCache(
+      getVaultDetails,
+      [parsedNetwork],
+      cacheConfig,
+    )({
+      institutionID: institutionId,
+      vaultAddress,
+      network: parsedNetwork,
+    }),
+  ])
+
+  if (!vault) {
+    return <div>Vault not found</div>
+  }
+
+  return <PanelAssetRelocation vault={vault} />
 }

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.module.css
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.module.css
@@ -1,0 +1,59 @@
+.panelAssetRelocationWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-space-medium-large);
+
+  .contentWrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-space-medium-large);
+
+    .tableWrapper {
+      overflow-x: auto;
+
+      .table {
+        min-width: max-content;
+      }
+    }
+
+    .inputContainer {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+
+      .inputWrapper {
+        max-width: 130px;
+        height: 28px;
+        padding: var(--spacing-space-2x-small) var(--spacing-space-x-small);
+        border-radius: var(--radius-small);
+        font-size: 12px;
+        text-align: right;
+      }
+
+      /* Target number inputs with the inputWrapper class */
+      .inputWrapper[type='number']::-webkit-outer-spin-button,
+      .inputWrapper[type='number']::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      .inputWrapper[type='number'] {
+        -moz-appearance: textfield;
+      }
+    }
+
+    .summary {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: var(--spacing-space-medium);
+    }
+
+    .buttons {
+      display: flex;
+      justify-content: flex-end;
+      gap: var(--spacing-space-medium);
+    }
+  }
+}

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.module.css.d.ts
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.module.css.d.ts
@@ -1,0 +1,12 @@
+declare const styles: {
+  readonly "buttons": string;
+  readonly "contentWrapper": string;
+  readonly "inputContainer": string;
+  readonly "inputWrapper": string;
+  readonly "panelAssetRelocationWrapper": string;
+  readonly "summary": string;
+  readonly "table": string;
+  readonly "tableWrapper": string;
+};
+export = styles;
+

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.tsx
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.tsx
@@ -1,11 +1,131 @@
-import { Card, Text } from '@summerfi/app-earn-ui'
+'use client'
 
-export const PanelAssetRelocation = () => {
+import { type FC, useCallback, useMemo, useState } from 'react'
+import { Button, Card, Table, Text } from '@summerfi/app-earn-ui'
+import { type SDKVaultType } from '@summerfi/app-types'
+import { formatCryptoBalance, formatWithSeparators } from '@summerfi/app-utils'
+
+import { assetRelocationColumns } from './columns'
+import { assetRelocationMapper } from './mapper'
+
+import styles from './PanelAssetRelocation.module.css'
+
+const initialBalanceState = (vault: SDKVaultType) => {
+  return vault.arks.reduce<{ [key: string]: string }>((acc, ark) => {
+    if (ark.id) {
+      acc[ark.id] = ''
+    }
+
+    return acc
+  }, {})
+}
+
+interface PanelAssetRelocationProps {
+  vault: SDKVaultType
+}
+
+export const PanelAssetRelocation: FC<PanelAssetRelocationProps> = ({ vault }) => {
+  const [balanceAddChange, setBalanceAddChange] = useState(initialBalanceState(vault))
+  const [balanceRemoveChange, setBalanceRemoveChange] = useState(initialBalanceState(vault))
+
+  const onChange = useCallback(
+    ({
+      id,
+      balanceChange,
+      type,
+    }: {
+      id: string
+      balanceChange: string
+      type: 'add' | 'remove'
+    }) => {
+      // Only allow positive numbers (greater than 0) or empty string
+      const sanitizedValue =
+        balanceChange === '' || parseFloat(balanceChange) > 0 ? balanceChange : ''
+
+      if (type === 'add') {
+        setBalanceAddChange((prev) => ({ ...prev, [id]: sanitizedValue }))
+      } else {
+        setBalanceRemoveChange((prev) => ({ ...prev, [id]: sanitizedValue }))
+      }
+    },
+    [],
+  )
+
+  const onCancel = useCallback(() => {
+    setBalanceAddChange(initialBalanceState(vault))
+    setBalanceRemoveChange(initialBalanceState(vault))
+  }, [vault])
+
+  const onConfirm = useCallback(() => {
+    // TODO: Implement the confirm logic
+    // eslint-disable-next-line no-console
+    console.log('confirm')
+  }, [])
+
+  const totalBalance = useMemo(
+    () => vault.arks.reduce((acc, ark) => acc + Number(ark.inputTokenBalance), 0),
+    [vault.arks],
+  )
+
+  const netBalanceChange = vault.arks.reduce((acc, ark) => {
+    const arkBalanceChange = Number(balanceAddChange[ark.id]) - Number(balanceRemoveChange[ark.id])
+
+    return acc + arkBalanceChange
+  }, 0)
+
+  const rows = assetRelocationMapper({
+    vault,
+    onChange,
+    balanceAddChange,
+    balanceRemoveChange,
+  })
+
+  const buttonsDisabled = netBalanceChange === 0
+
   return (
-    <Card variant="cardSecondary">
+    <Card variant="cardSecondary" className={styles.panelAssetRelocationWrapper}>
       <Text as="h5" variant="h5">
         Asset rellocation
       </Text>
+      <Card className={styles.contentWrapper}>
+        <Table
+          rows={rows}
+          columns={assetRelocationColumns}
+          wrapperClassName={styles.tableWrapper}
+          tableClassName={styles.table}
+        />
+        <div className={styles.summary}>
+          <Text as="p" variant="p3semi">
+            Total Balance
+          </Text>
+          <Text as="p" variant="p3semi">
+            {formatCryptoBalance(totalBalance)}
+          </Text>
+        </div>
+        <div className={styles.summary}>
+          <Text as="p" variant="p3semi">
+            Net Balance Change
+          </Text>
+          <Text
+            as="p"
+            variant="p3semi"
+            style={{
+              color:
+                netBalanceChange >= 0 ? 'var(--color-text-primary)' : 'var(--color-text-critical)',
+            }}
+          >
+            {formatWithSeparators(netBalanceChange, { cutOffNegative: false })}
+          </Text>
+        </div>
+        <div className={styles.buttons}>
+          <Button variant="secondarySmall" disabled={buttonsDisabled} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primarySmall" disabled={buttonsDisabled} onClick={onConfirm}>
+            Confirm
+          </Button>
+        </div>
+      </Card>
     </Card>
   )
 }

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/columns.ts
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/columns.ts
@@ -1,0 +1,22 @@
+export const assetRelocationColumns = [
+  {
+    title: 'Market',
+    key: 'market',
+  },
+  {
+    title: 'Balance',
+    key: 'balance',
+  },
+  {
+    title: 'Remove from market',
+    key: 'remove-from-market',
+  },
+  {
+    title: 'Add to market',
+    key: 'add-to-market',
+  },
+  {
+    title: 'New balance',
+    key: 'new-balance',
+  },
+]

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/mapper.tsx
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/mapper.tsx
@@ -1,0 +1,64 @@
+import { getProtocolLabel, Input, TableCellText } from '@summerfi/app-earn-ui'
+import { type SDKVaultType } from '@summerfi/app-types'
+import { formatCryptoBalance } from '@summerfi/app-utils'
+
+import styles from './PanelAssetRelocation.module.css'
+
+export const assetRelocationMapper = ({
+  vault,
+  onChange,
+  balanceAddChange,
+  balanceRemoveChange,
+}: {
+  vault: SDKVaultType
+  onChange: ({
+    id,
+    balanceChange,
+    type,
+  }: {
+    id: string
+    balanceChange: string
+    type: 'add' | 'remove'
+  }) => void
+  balanceAddChange: { [key: string]: string }
+  balanceRemoveChange: { [key: string]: string }
+}) => {
+  return vault.arks
+    .sort((a, b) => Number(b.inputTokenBalance) - Number(a.inputTokenBalance))
+    .map((ark) => {
+      const protocol = ark.name?.split('-') ?? ['n/a']
+      const protocolLabel = getProtocolLabel(protocol)
+
+      return {
+        content: {
+          market: <TableCellText>{protocolLabel}</TableCellText>,
+          balance: <TableCellText>{formatCryptoBalance(ark.inputTokenBalance)}</TableCellText>,
+          'remove-from-market': (
+            <Input
+              variant="withBorder"
+              wrapperClassName={styles.inputContainer}
+              inputWrapperClassName={styles.inputWrapper}
+              onChange={(e) =>
+                onChange({ id: ark.id, balanceChange: e.target.value, type: 'remove' })
+              }
+              value={balanceRemoveChange[ark.id]}
+              type="number"
+            />
+          ),
+          'add-to-market': (
+            <Input
+              variant="withBorder"
+              wrapperClassName={styles.inputContainer}
+              inputWrapperClassName={styles.inputWrapper}
+              onChange={(e) => onChange({ id: ark.id, balanceChange: e.target.value, type: 'add' })}
+              value={balanceAddChange[ark.id]}
+              type="number"
+            />
+          ),
+          'new-balance': (
+            <TableCellText>{formatCryptoBalance(ark.inputTokenBalance)}</TableCellText>
+          ),
+        },
+      }
+    })
+}

--- a/packages/app-earn-ui/src/components/atoms/Input/Input.tsx
+++ b/packages/app-earn-ui/src/components/atoms/Input/Input.tsx
@@ -30,6 +30,7 @@ export const Input: FC<
     button?: ReactNode
     buttonStyles?: CSSProperties
     inputWrapperStyles?: CSSProperties
+    inputWrapperClassName?: string
   }
 > = ({
   variant = 'default',
@@ -44,6 +45,7 @@ export const Input: FC<
   value,
   buttonStyles,
   inputWrapperStyles,
+  inputWrapperClassName,
   ...rest
 }) => {
   return (
@@ -62,6 +64,7 @@ export const Input: FC<
         className={[
           icon ? inputStyles.withIconOffset : '',
           getAtomClassList({ className, variant: inputStyles[variant] }),
+          inputWrapperClassName,
         ].join(' ')}
         {...rest}
         value={value}

--- a/packages/app-utils/src/formatters/format-with-separators.ts
+++ b/packages/app-utils/src/formatters/format-with-separators.ts
@@ -10,6 +10,7 @@ import { formatToBigNumber } from './format-to-big-number'
  * @param options - Formatting options
  * @param options.precision - Number of decimal places to show (default: 0)
  * @param options.roundMode - Rounding mode to use (default: ROUND_DOWN)
+ * @param options.cutOffNegative - Whether to cut off negative numbers (default: true)
  * @returns Formatted string with thousands and decimal separators
  */
 export const formatWithSeparators = (
@@ -17,11 +18,13 @@ export const formatWithSeparators = (
   {
     precision = 0,
     roundMode = BigNumber.ROUND_DOWN,
-  }: { precision?: number; roundMode?: BigNumber.RoundingMode } = {},
+    cutOffNegative = true,
+  }: { precision?: number; roundMode?: BigNumber.RoundingMode; cutOffNegative?: boolean } = {},
 ): string => {
   const resolvedAmount = formatToBigNumber(amount)
 
-  if (resolvedAmount.lt(new BigNumber('0.01')) && !resolvedAmount.eq(zero)) return '<0.01'
+  if (cutOffNegative && resolvedAmount.lt(new BigNumber('0.01')) && !resolvedAmount.eq(zero))
+    return '<0.01'
 
   return resolvedAmount.toFormat(precision, roundMode)
 }


### PR DESCRIPTION
# Implement asset relocation panel for institutions app

## Description
Implements a comprehensive asset relocation panel for the institutions app with interactive balance management, real-time calculations, and proper data fetching with caching.

## Changes
- Created new asset relocation page with server-side data fetching:
  - Added vault details fetching with proper caching using unstable_cache
  - Implemented network parameter parsing and validation
  - Added error handling for vault not found scenarios
- Built comprehensive PanelAssetRelocation component:
  - Interactive table with market balance display and input fields
  - Real-time balance change calculations with add/remove functionality
  - Input validation to ensure only positive numbers or empty values
  - Dynamic button state management based on net balance changes
- Added supporting components and utilities:
  - Created asset relocation columns and mapper for table structure
  - Enhanced Input component with inputWrapperClassName prop
  - Updated formatWithSeparators utility with cutOffNegative option
  - Added comprehensive CSS styling with responsive design

## Benefits
1. Enables institutions to manage asset allocation across different markets
2. Provides real-time feedback on balance changes and net impact
3. Improves user experience with proper input validation and visual feedback
4. Maintains data consistency with server-side caching

## Testing
- Verify asset relocation table displays correctly with vault data
- Test input validation for positive numbers only
- Confirm real-time calculations update properly
- Validate caching behavior for vault details
- Test responsive design on different screen sizes

## Next steps
- Implement the confirm logic for actual asset relocation
- Add transaction confirmation and error handling
- Consider adding confirmation dialogs for large balance changes

## Additional Notes
The component currently logs to console on confirm - actual implementation pending backend integration.