### PR TITLE
Disable staking on deposits for the front end apps and optimize withdrawals and switching logic

### DIFF
--- a/apps/earn-protocol/helpers/wait-for-transaction.ts
+++ b/apps/earn-protocol/helpers/wait-for-transaction.ts
@@ -12,7 +12,7 @@ export const waitForTransaction = async ({ publicClient, hash }: WaitForTransact
   })
 
   if (receipt.status === 'reverted') {
-    throw new Error('Transaction reverted')
+    throw new Error(`Transaction reverted with hash ${hash}`)
   }
 
   return receipt

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
@@ -162,7 +162,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     let swapToAmount: ITokenAmount | undefined
     let transactions: Awaited<ReturnType<IArmadaManagerVaults['getVaultSwitchTx']>>
 
-    const [beforeFleetShares, beforeStakedShares, calculatedSharesToWithdraw] = await Promise.all([
+    const [beforeFleetShares, beforeStakedShares, previewWithdrawSharesAmount] = await Promise.all([
       this._utils.getFleetShares({
         vaultId: params.sourceVaultId,
         user: params.user,
@@ -182,7 +182,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       beforeStakedShares: beforeStakedShares.toString(),
       beforeTotalShares: beforeFleetShares.add(beforeStakedShares).toString(),
       withdrawAmount: withdrawAmount.toString(),
-      calculatedSharesToWithdraw: calculatedSharesToWithdraw.toString(),
+      previewWithdrawSharesAmount: previewWithdrawSharesAmount.toString(),
       shouldSwap,
       sourceFleetToken: sourceFleetToken.toString(),
       destinationFleetToken: destinationFleetToken.toString(),
@@ -257,14 +257,17 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     // Are fleetShares available at all? (should be greater than dust)
     if (beforeFleetShares.toSolidityValue() > 0) {
       // Yes. Are fleetShares sufficient to meet the calculatedWithdrawShares?
-      if (beforeFleetShares.toSolidityValue() >= calculatedSharesToWithdraw.toSolidityValue()) {
+      if (beforeFleetShares.toSolidityValue() >= previewWithdrawSharesAmount.toSolidityValue()) {
         // Yes. Withdraw all from fleetShares
         LoggingService.debug('>>> Withdraw all from fleetShares')
 
-        const { approvalAmount, calculatedWithdrawAssets } = this._calculateWithdrawSharesData({
+        const {
+          finalWithdrawSharesApprovalAmount: finalWithdrawSharesApprovalAmount,
+          finalWithdrawAmount: finalWithdrawAmount,
+        } = this._calculateFinalWithdrawAmount({
           vaultId: params.sourceVaultId,
           fleetShares: beforeFleetShares,
-          withdrawShares: calculatedSharesToWithdraw,
+          withdrawShares: previewWithdrawSharesAmount,
           withdrawAmount,
         })
 
@@ -278,26 +281,26 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           this._allowanceManager.getApproval({
             chainInfo: params.sourceVaultId.chainInfo,
             spender: admiralsQuartersAddress,
-            amount: approvalAmount,
+            amount: finalWithdrawSharesApprovalAmount,
             owner: params.user.wallet.address,
           }),
           this._allowanceManager.getApproval({
             chainInfo: params.sourceVaultId.chainInfo,
             spender: admiralsQuartersAddress,
-            amount: calculatedWithdrawAssets,
+            amount: finalWithdrawAmount,
             owner: params.user.wallet.address,
           }),
           this._getExitWithdrawMulticall({
             vaultId: params.sourceVaultId,
             slippage: params.slippage,
-            amount: calculatedWithdrawAssets,
-            withdrawToken: calculatedWithdrawAssets.token,
+            amount: finalWithdrawAmount,
+            withdrawToken: finalWithdrawAmount.token,
             shouldSwap: false, //override as we do swap in deposit
             toEth: false,
           }),
           swapToAmount &&
             this._utils.getPriceImpact({
-              fromAmount: calculatedWithdrawAssets,
+              fromAmount: finalWithdrawAmount,
               toAmount: swapToAmount,
             }),
         ])
@@ -348,31 +351,30 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
         // No. Withdraw all fleetShares and the reminder from stakedShares
         LoggingService.debug('>>> Withdraw all fleetShares and the reminder from stakedShares')
 
-        // Approve the requested amount in shares
-        const [calculatedBeforeFleetAssets] = await Promise.all([
+        const [previewRedeemAssetsAmount] = await Promise.all([
           this._previewRedeem({
             vaultId: params.sourceVaultId,
             shares: beforeFleetShares,
           }),
         ])
 
-        const multicallArgs: HexData[] = []
-        const multicallOperations: string[] = []
+        const withdrawMulticallArgs: HexData[] = []
+        const withdrawMulticallOperations: string[] = []
         const unstakeWithdrawMulticallArgs: HexData[] = []
         const unstakeWithdrawMulticallOperations: string[] = []
 
-        const reminderFromStakedShares = calculatedSharesToWithdraw.subtract(beforeFleetShares)
+        const reminderFromStakedShares = previewWithdrawSharesAmount.subtract(beforeFleetShares)
         LoggingService.debug('- first take all fleet shares, then reminder from staked shares', {
           beforeFleetShares: beforeFleetShares.toString(),
-          calculatedBeforeFleetAssets: calculatedBeforeFleetAssets.toString(),
+          previewRedeemAssetsAmount: previewRedeemAssetsAmount.toString(),
           reminderShares: reminderFromStakedShares.toString(),
         })
 
-        const calculatedUnstakeWithdrawData = await this._calculateUnstakeWithdrawData({
+        const finalUnstakeAndWithdrawAmount = await this._calculateFinalUnstakeAndWithdrawAmount({
           vaultId: params.sourceVaultId,
-          shares: reminderFromStakedShares,
+          withdrawShares: reminderFromStakedShares,
           stakedShares: beforeStakedShares,
-          amount: withdrawAmount,
+          withdrawAmount: withdrawAmount,
         })
 
         const [
@@ -385,7 +387,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           this._allowanceManager.getApproval({
             chainInfo: params.sourceVaultId.chainInfo,
             spender: admiralsQuartersAddress,
-            amount: this._compensateAmount(reminderFromStakedShares, 'increase'),
+            amount: beforeFleetShares,
             owner: params.user.wallet.address,
           }),
           this._allowanceManager.getApproval({
@@ -397,14 +399,14 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           this._getExitWithdrawMulticall({
             vaultId: params.sourceVaultId,
             slippage: params.slippage,
-            amount: calculatedBeforeFleetAssets,
+            amount: previewRedeemAssetsAmount,
             withdrawToken: withdrawAmount.token,
             shouldSwap: false, //override as we do swap in deposit
             toEth: false, // in fleet it's always wrapped
           }),
           this._getUnstakeAndWithdrawCall({
             vaultId: params.sourceVaultId,
-            sharesValue: calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+            sharesValue: finalUnstakeAndWithdrawAmount.finalUnstakeAndWithdrawSharesValue,
           }),
           swapToAmount &&
             this._utils.getPriceImpact({
@@ -427,19 +429,21 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
         approvalForWithdraw = approvalToWithdrawSharesOnBehalf
         approvalForDeposit = approvalToDepositBasedWithdrawAmount
 
-        multicallArgs.push(...exitWithdrawMulticall.multicallArgs)
-        multicallOperations.push(...exitWithdrawMulticall.multicallOperations)
+        withdrawMulticallArgs.push(...exitWithdrawMulticall.multicallArgs)
+        withdrawMulticallOperations.push(...exitWithdrawMulticall.multicallOperations)
 
         unstakeWithdrawMulticallArgs.push(unstakeAndWithdrawCall.calldata)
         unstakeWithdrawMulticallOperations.push(
-          'unstakeAndWithdraw ' + calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+          'unstakeAndWithdraw ' + finalUnstakeAndWithdrawAmount.finalUnstakeAndWithdrawSharesValue,
         )
 
         // compose unstake withdraw deposit multicall
         const multicallCalldata = encodeFunctionData({
           abi: AdmiralsQuartersAbi,
           functionName: 'multicall',
-          args: [[...multicallArgs, ...unstakeWithdrawMulticallArgs, ...depositMulticallArgs]],
+          args: [
+            [...withdrawMulticallArgs, ...unstakeWithdrawMulticallArgs, ...depositMulticallArgs],
+          ],
         })
 
         const vaultSwitchTransaction = createVaultSwitchTransaction({
@@ -447,7 +451,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           calldata: multicallCalldata,
           description:
             'Vault Switch Operations: ' +
-            multicallOperations
+            withdrawMulticallOperations
               .concat(unstakeWithdrawMulticallOperations)
               .concat(depositMulticallOperations)
               .join(', '),
@@ -477,18 +481,19 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       const unstakeWithdrawMulticallArgs: HexData[] = []
       const unstakeWithdrawMulticallOperations: string[] = []
 
-      const calculatedUnstakeWithdrawData = await this._calculateUnstakeWithdrawData({
-        vaultId: params.sourceVaultId,
-        shares: calculatedSharesToWithdraw,
-        stakedShares: beforeStakedShares,
-        amount: withdrawAmount,
-      })
+      const { finalUnstakeAndWithdrawSharesApprovalAmount, finalUnstakeAndWithdrawSharesValue } =
+        await this._calculateFinalUnstakeAndWithdrawAmount({
+          vaultId: params.sourceVaultId,
+          withdrawShares: previewWithdrawSharesAmount,
+          stakedShares: beforeStakedShares,
+          withdrawAmount: withdrawAmount,
+        })
 
       // withdraw all from staked tokens
       const [unstakeAndWithdrawCall, priceImpact] = await Promise.all([
         this._getUnstakeAndWithdrawCall({
           vaultId: params.sourceVaultId,
-          sharesValue: calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+          sharesValue: finalUnstakeAndWithdrawSharesValue,
         }),
         swapToAmount &&
           this._utils.getPriceImpact({
@@ -498,13 +503,13 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       ])
       unstakeWithdrawMulticallArgs.push(unstakeAndWithdrawCall.calldata)
       unstakeWithdrawMulticallOperations.push(
-        'unstakeAndWithdraw ' + calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+        'unstakeAndWithdraw ' + finalUnstakeAndWithdrawSharesValue,
       )
       approvalForDeposit = await this._getApprovalBasedOnUnstakeWithdrawData({
         admiralsQuartersAddress,
         vaultId: params.sourceVaultId,
         user: params.user,
-        amount: calculatedUnstakeWithdrawData.calculatedUnstakeWithdrawAssets,
+        amount: finalUnstakeAndWithdrawSharesApprovalAmount,
       })
 
       // compose unstake withdraw deposit multicall
@@ -808,7 +813,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     let swapToAmount: ITokenAmount | undefined = undefined
     let transactions: Awaited<ReturnType<IArmadaManagerVaults['getWithdrawTx']>>
 
-    const [beforeFleetShares, beforeStakedShares, calculatedSharesToWithdraw] = await Promise.all([
+    const [beforeFleetShares, beforeStakedShares, previewWithdrawSharesAmount] = await Promise.all([
       this._utils.getFleetShares({
         vaultId: params.vaultId,
         user: params.user,
@@ -827,7 +832,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       beforeFleetShares: beforeFleetShares.toString(),
       beforeStakedShares: beforeStakedShares.toString(),
       withdrawAmount: withdrawAmount.toString(),
-      calculatedSharesToWithdraw: calculatedSharesToWithdraw.toString(),
+      previewWithdrawSharesAmount: previewWithdrawSharesAmount.toString(),
       toEth: toEth,
       swapToToken: swapToToken.toString(),
       shouldSwap,
@@ -841,14 +846,17 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     // Are fleetShares available at all? (should be greater than dust)
     if (beforeFleetShares.toSolidityValue() > 0) {
       // Yes. Are fleetShares sufficient to meet the calculatedWithdrawShares?
-      if (beforeFleetShares.toSolidityValue() >= calculatedSharesToWithdraw.toSolidityValue()) {
+      if (beforeFleetShares.toSolidityValue() >= previewWithdrawSharesAmount.toSolidityValue()) {
         // Yes. Withdraw all from fleetShares
         LoggingService.debug('>>> Withdraw all from fleetShares')
 
-        const { approvalAmount, calculatedWithdrawAssets } = this._calculateWithdrawSharesData({
+        const {
+          finalWithdrawSharesApprovalAmount: finalWithdrawSharesApprovalAmount,
+          finalWithdrawAmount: finalWithdrawAmount,
+        } = this._calculateFinalWithdrawAmount({
           vaultId: params.vaultId,
           fleetShares: beforeFleetShares,
-          withdrawShares: calculatedSharesToWithdraw,
+          withdrawShares: previewWithdrawSharesAmount,
           withdrawAmount,
         })
         // Approve the requested amount in shares
@@ -857,25 +865,25 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
             this._allowanceManager.getApproval({
               chainInfo: params.vaultId.chainInfo,
               spender: admiralsQuartersAddress,
-              amount: approvalAmount,
+              amount: finalWithdrawSharesApprovalAmount,
               owner: params.user.wallet.address,
             }),
             this._getExitWithdrawMulticall({
               vaultId: params.vaultId,
               slippage: params.slippage,
-              amount: calculatedWithdrawAssets,
+              amount: finalWithdrawAmount,
               // if withdraw is WETH and unwrapping to ETH,
               // we need to withdraw WETH for later deposit & unwrap operation
               withdrawToken:
-                calculatedWithdrawAssets.token.symbol === 'WETH' && toEth
-                  ? calculatedWithdrawAssets.token
+                finalWithdrawAmount.token.symbol === 'WETH' && toEth
+                  ? finalWithdrawAmount.token
                   : swapToToken,
               shouldSwap,
               toEth,
             }),
             swapToAmount &&
               this._utils.getPriceImpact({
-                fromAmount: calculatedWithdrawAssets,
+                fromAmount: finalWithdrawAmount,
                 toAmount: swapToAmount,
               }),
           ])
@@ -902,8 +910,8 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           description:
             'Withdraw Operations: ' + exitWithdrawMulticall.multicallOperations.join(', '),
           metadata: {
-            fromAmount: calculatedWithdrawAssets,
-            toAmount: swapToAmount || calculatedWithdrawAssets,
+            fromAmount: finalWithdrawAmount,
+            toAmount: swapToAmount || finalWithdrawAmount,
             slippage: params.slippage,
             priceImpact,
           },
@@ -917,30 +925,30 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
         // No. Withdraw all fleetShares and the reminder from stakedShares
         LoggingService.debug('>>> Withdraw all fleetShares and the reminder from stakedShares')
 
-        const [calculatedBeforeFleetAssets] = await Promise.all([
+        const [previewRedeemAssetsAmount] = await Promise.all([
           this._previewRedeem({
             vaultId: params.vaultId,
             shares: beforeFleetShares,
           }),
         ])
 
-        const multicallArgs: HexData[] = []
-        const multicallOperations: string[] = []
+        const withdrawMulticallArgs: HexData[] = []
+        const withdrawMulticallOperations: string[] = []
         const unstakeWithdrawMulticallArgs: HexData[] = []
         const unstakeWithdrawMulticallOperations: string[] = []
 
-        const reminderFromStakedShares = calculatedSharesToWithdraw.subtract(beforeFleetShares)
+        const reminderFromStakedShares = previewWithdrawSharesAmount.subtract(beforeFleetShares)
         LoggingService.debug('- first take all fleet shares, then reminder from staked shares', {
           beforeFleetShares: beforeFleetShares.toString(),
-          calculatedBeforeFleetAssets: calculatedBeforeFleetAssets.toString(),
+          previewRedeemAssetsAmount: previewRedeemAssetsAmount.toString(),
           reminderShares: reminderFromStakedShares.toString(),
         })
 
-        const calculatedUnstakeWithdrawData = await this._calculateUnstakeWithdrawData({
+        const finalUnstakeAndWithdrawAmount = await this._calculateFinalUnstakeAndWithdrawAmount({
           vaultId: params.vaultId,
-          shares: reminderFromStakedShares,
+          withdrawShares: reminderFromStakedShares,
           stakedShares: beforeStakedShares,
-          amount: withdrawAmount,
+          withdrawAmount: withdrawAmount,
         })
 
         const [
@@ -952,26 +960,26 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           this._allowanceManager.getApproval({
             chainInfo: params.vaultId.chainInfo,
             spender: admiralsQuartersAddress,
-            amount: reminderFromStakedShares,
+            amount: beforeFleetShares,
             owner: params.user.wallet.address,
           }),
           this._getExitWithdrawMulticall({
             vaultId: params.vaultId,
             slippage: params.slippage,
-            amount: calculatedBeforeFleetAssets,
+            amount: previewRedeemAssetsAmount,
             exitAll: true,
             // if withdraw is WETH and unwrapping to ETH,
             // we need to withdraw WETH for later deposit & unwrap operation
             withdrawToken:
-              calculatedBeforeFleetAssets.token.symbol === 'WETH' && toEth
-                ? calculatedBeforeFleetAssets.token // this is WETH
+              previewRedeemAssetsAmount.token.symbol === 'WETH' && toEth
+                ? previewRedeemAssetsAmount.token // this is WETH
                 : swapToToken,
             shouldSwap,
             toEth,
           }),
           this._getUnstakeAndWithdrawCall({
             vaultId: params.vaultId,
-            sharesValue: calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+            sharesValue: finalUnstakeAndWithdrawAmount.finalUnstakeAndWithdrawSharesValue,
           }),
           swapToAmount &&
             this._utils.getPriceImpact({
@@ -991,12 +999,12 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
           })
         }
 
-        multicallArgs.push(...exitWithdrawMulticall.multicallArgs)
-        multicallOperations.push(...exitWithdrawMulticall.multicallOperations)
+        withdrawMulticallArgs.push(...exitWithdrawMulticall.multicallArgs)
+        withdrawMulticallOperations.push(...exitWithdrawMulticall.multicallOperations)
 
         unstakeWithdrawMulticallArgs.push(unstakeAndWithdrawCall.calldata)
         unstakeWithdrawMulticallOperations.push(
-          'unstakeAndWithdraw ' + calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+          'unstakeAndWithdraw ' + finalUnstakeAndWithdrawAmount.finalUnstakeAndWithdrawSharesValue,
         )
 
         let approvalDepositSwapWithdraw: ApproveTransactionInfo | undefined
@@ -1042,14 +1050,14 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
         const multicallCalldata = encodeFunctionData({
           abi: AdmiralsQuartersAbi,
           functionName: 'multicall',
-          args: [[...multicallArgs, ...unstakeWithdrawMulticallArgs]],
+          args: [[...withdrawMulticallArgs, ...unstakeWithdrawMulticallArgs]],
         })
         const withdrawTransaction = createWithdrawTransaction({
           target: admiralsQuartersAddress,
           calldata: multicallCalldata,
           description:
             'Withdraw Operations: ' +
-            multicallOperations.concat(unstakeWithdrawMulticallOperations).join(', '),
+            withdrawMulticallOperations.concat(unstakeWithdrawMulticallOperations).join(', '),
           metadata: {
             fromAmount: withdrawAmount,
             toAmount: swapToAmount || withdrawAmount,
@@ -1074,18 +1082,18 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       const unstakeWithdrawMulticallArgs: HexData[] = []
       const unstakeWithdrawMulticallOperations: string[] = []
 
-      const calculatedUnstakeWithdrawData = await this._calculateUnstakeWithdrawData({
+      const finalUnstakeAndWithdrawAmount = await this._calculateFinalUnstakeAndWithdrawAmount({
         vaultId: params.vaultId,
-        shares: calculatedSharesToWithdraw,
+        withdrawShares: previewWithdrawSharesAmount,
         stakedShares: beforeStakedShares,
-        amount: withdrawAmount,
+        withdrawAmount: withdrawAmount,
       })
 
       // withdraw all from staked tokens
       const [unstakeAndWithdrawCall, priceImpact] = await Promise.all([
         this._getUnstakeAndWithdrawCall({
           vaultId: params.vaultId,
-          sharesValue: calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+          sharesValue: finalUnstakeAndWithdrawAmount.finalUnstakeAndWithdrawSharesValue,
         }),
         swapToAmount &&
           this._utils.getPriceImpact({
@@ -1095,7 +1103,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
       ])
       unstakeWithdrawMulticallArgs.push(unstakeAndWithdrawCall.calldata)
       unstakeWithdrawMulticallOperations.push(
-        'unstakeAndWithdraw ' + calculatedUnstakeWithdrawData.unstakeWithdrawSharesValue,
+        'unstakeAndWithdraw ' + finalUnstakeAndWithdrawAmount.finalUnstakeAndWithdrawSharesValue,
       )
 
       let approvalDepositSwapWithdraw: ApproveTransactionInfo | undefined
@@ -1432,26 +1440,28 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     })
   }
 
-  private _calculateWithdrawSharesData(params: {
+  private _calculateFinalWithdrawAmount(params: {
     vaultId: IArmadaVaultId
     fleetShares: ITokenAmount
     withdrawShares: ITokenAmount
     withdrawAmount: ITokenAmount
   }): {
     shouldWithdrawAll: boolean
-    approvalAmount: ITokenAmount
-    calculatedWithdrawAssets: ITokenAmount
+    finalWithdrawSharesApprovalAmount: ITokenAmount
+    finalWithdrawAmount: ITokenAmount
   } {
     // if the requested amount is close to all fleet shares, we make assumption to withdraw all
     const withdrawAllThreshold = 0.998
 
     const sharesToWithdraw = params.withdrawShares.toSolidityValue()
     const fleetShares = params.fleetShares.toSolidityValue()
-    const shouldWithdrawAll =
-      sharesToWithdraw === 0n ||
-      new BigNumber(fleetShares.toString())
-        .div(sharesToWithdraw.toString())
-        .gte(withdrawAllThreshold)
+    if (sharesToWithdraw <= 0n || fleetShares <= 0n) {
+      throw new Error('Cannot calculate final withdraw amount for 0 or negative shares')
+    }
+
+    const shouldWithdrawAll = new BigNumber(sharesToWithdraw.toString())
+      .div(fleetShares.toString())
+      .gte(withdrawAllThreshold)
     const approvalAmountValue = shouldWithdrawAll ? fleetShares : sharesToWithdraw
     const approvalAmount = TokenAmount.createFromBaseUnit({
       token: params.withdrawShares.token,
@@ -1460,7 +1470,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     // if we are withdrawing all, we set withdraw amount to 0 (all)
     // so the contract can calculate the exact amount
     // otherwise we use the requested withdraw amount
-    const calculatedWithdrawAssets = shouldWithdrawAll
+    const finalWithdrawAmount = shouldWithdrawAll
       ? TokenAmount.createFromBaseUnit({
           token: params.withdrawAmount.token,
           amount: '0',
@@ -1469,62 +1479,63 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
 
     LoggingService.debug('_calculateWithdrawSharesData', {
       shouldWithdrawAll,
-      approvalAmount: approvalAmount.toString(),
-      calculatedWithdrawAssets: calculatedWithdrawAssets.toString(),
+      finalWithdrawSharesApprovalAmount: approvalAmount.toString(),
+      finalWithdrawAmount: finalWithdrawAmount.toString(),
     })
 
     return {
       shouldWithdrawAll,
-      approvalAmount,
-      calculatedWithdrawAssets,
+      finalWithdrawSharesApprovalAmount: approvalAmount,
+      finalWithdrawAmount: finalWithdrawAmount,
     }
   }
 
-  private async _calculateUnstakeWithdrawData(params: {
+  private async _calculateFinalUnstakeAndWithdrawAmount(params: {
     vaultId: IArmadaVaultId
-    shares: ITokenAmount
     stakedShares: ITokenAmount
-    amount: ITokenAmount
+    withdrawShares: ITokenAmount
+    withdrawAmount: ITokenAmount
   }): Promise<{
     shouldWithdrawAll: boolean
-    calculatedUnstakeWithdrawAssets: ITokenAmount
-    unstakeWithdrawSharesValue: bigint
+    finalUnstakeAndWithdrawSharesApprovalAmount: ITokenAmount
+    finalUnstakeAndWithdrawSharesValue: bigint
   }> {
     // if the requested amount is close to all staked shares, we make assumption to withdraw all
     const withdrawAllThreshold = 0.998
 
-    const sharesToWithdraw = params.shares.toSolidityValue()
+    const sharesToWithdraw = params.withdrawShares.toSolidityValue()
     const stakedShares = params.stakedShares.toSolidityValue()
-    const shouldWithdrawAll =
-      stakedShares === 0n ||
-      new BigNumber(sharesToWithdraw.toString())
-        .div(stakedShares.toString())
-        .gte(withdrawAllThreshold)
-    const unstakeWithdrawSharesValue = shouldWithdrawAll ? 0n : sharesToWithdraw
+    if (sharesToWithdraw <= 0n || stakedShares <= 0n) {
+      throw new Error('Cannot calculate final unstake and withdraw amount for 0 or negative shares')
+    }
 
-    let calculatedUnstakeWithdrawAssets: ITokenAmount | undefined
+    const shouldWithdrawAll = new BigNumber(sharesToWithdraw.toString())
+      .div(stakedShares.toString())
+      .gte(withdrawAllThreshold)
+    const sharesValue = shouldWithdrawAll ? 0n : sharesToWithdraw
+
+    let approvalAmount: ITokenAmount | undefined
     if (shouldWithdrawAll) {
       const calculatedFullAmount = await this._previewRedeem({
         vaultId: params.vaultId,
-        shares: params.shares,
+        shares: params.withdrawShares,
       })
-
-      calculatedUnstakeWithdrawAssets = calculatedFullAmount
+      approvalAmount = calculatedFullAmount
     } else {
-      // if we are not withdrawing all, we need to approve the specific amount
-      calculatedUnstakeWithdrawAssets = params.amount
+      // if we are not withdrawing all, we need to approve the requested amount
+      approvalAmount = params.withdrawAmount
     }
 
     LoggingService.debug('_calculateWithdrawalDataForStakedShares', {
       shouldWithdrawAll,
-      unstakeWithdrawSharesAmount: unstakeWithdrawSharesValue.toString(),
-      unstakeWithdrawAssetsAmount: calculatedUnstakeWithdrawAssets.toString(),
+      finalUnstakeAndWithdrawSharesValue: sharesValue.toString(),
+      finalUnstakeAndWithdrawSharesApprovalAmount: approvalAmount.toString(),
     })
 
     return {
       shouldWithdrawAll,
-      calculatedUnstakeWithdrawAssets,
-      unstakeWithdrawSharesValue,
+      finalUnstakeAndWithdrawSharesValue: sharesValue,
+      finalUnstakeAndWithdrawSharesApprovalAmount: approvalAmount,
     }
   }
 

--- a/sdk/sdk-e2e/e2e/armadaProtocol.deposit.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.deposit.test.ts
@@ -55,6 +55,15 @@ describe('Armada Protocol Deposit', () => {
       userAddress,
       amountValue,
       swapToSymbol,
+      stake: true,
+    })
+    await runTests({
+      rpcUrl,
+      chainId,
+      fleetAddress,
+      userAddress,
+      amountValue,
+      swapToSymbol,
     })
   })
 

--- a/sdk/sdk-e2e/e2e/armadaProtocol.deposit.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.deposit.test.ts
@@ -45,7 +45,6 @@ describe('Armada Protocol Deposit', () => {
     const chainId = ChainIds.Base
     const fleetAddress = usdcFleetBase
     const userAddress = testWalletAddress
-    const amountValue = '1'
     const swapToSymbol = undefined
 
     await runTests({
@@ -53,7 +52,7 @@ describe('Armada Protocol Deposit', () => {
       chainId,
       fleetAddress,
       userAddress,
-      amountValue,
+      amountValue: '0.5',
       swapToSymbol,
       stake: true,
     })
@@ -62,7 +61,7 @@ describe('Armada Protocol Deposit', () => {
       chainId,
       fleetAddress,
       userAddress,
-      amountValue,
+      amountValue: '1.5',
       swapToSymbol,
     })
   })

--- a/sdk/sdk-e2e/e2e/armadaProtocol.switch.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.switch.test.ts
@@ -16,6 +16,7 @@ import { DEFAULT_SLIPPAGE_PERCENTAGE } from './utils/constants'
 import assert from 'assert'
 
 jest.setTimeout(300000)
+const simulateOnly = false
 
 const chainId = ChainIds.Base
 const ethFleet = Address.createFromEthereum({ value: '0x2bb9ad69feba5547b7cd57aafe8457d40bf834af' })
@@ -33,20 +34,9 @@ describe('Armada Protocol Switch', () => {
       chainId,
       sourceFleetAddress: usdcFleet,
       destinationFleetAddress: eurcFleet,
+      amountValue: '0.9999',
       rpcUrl,
     })
-    // await runTests({
-    //   chainInfo,
-    //   sourceFleetAddress: ethFleet,
-    //   destinationFleetAddress: eurcFleet,
-    //   rpcUrl,
-    // })
-    // await runTests({
-    //   chainInfo,
-    //   sourceFleetAddress: eurcFleet,
-    //   destinationFleetAddress: usdcFleet,
-    //   rpcUrl,
-    // })
   })
 
   async function runTests({
@@ -138,11 +128,16 @@ describe('Armada Protocol Switch', () => {
       transactions,
       rpcUrl: rpcUrl,
       privateKey: signerPrivateKey,
+      simulateOnly,
     })
     statuses.forEach((status) => {
       expect(status).toBe('success')
     })
 
+    if (simulateOnly) {
+      console.log('Simulation only - skipping post-switch position checks')
+      return
+    }
     const sourcePositionAfter = await sdk.armada.users.getUserPosition({
       user,
       fleetAddress: sourceFleetAddress,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.switch.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.switch.test.ts
@@ -34,7 +34,7 @@ describe('Armada Protocol Switch', () => {
       chainId,
       sourceFleetAddress: usdcFleet,
       destinationFleetAddress: eurcFleet,
-      amountValue: '0.9999',
+      amountValue: '1.9999',
       rpcUrl,
     })
   })

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -28,6 +28,8 @@ const selfManagedFleet = Address.createFromEthereum({
 const rpcUrl = process.env.E2E_SDK_FORK_URL_BASE
 
 describe('Armada Protocol - User', () => {
+  const fleetAddress = usdcFleet
+
   const sdk: SDKManager = makeSDK({
     apiDomainUrl: SDKApiUrl,
   })
@@ -36,7 +38,6 @@ describe('Armada Protocol - User', () => {
   }
 
   const chainInfo = getChainInfoByChainId(chainId)
-  const fleetAddress = usdcFleet
 
   const user = User.createFrom({
     chainInfo,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -36,7 +36,7 @@ describe('Armada Protocol - User', () => {
   }
 
   const chainInfo = getChainInfoByChainId(chainId)
-  const fleetAddress = selfManagedFleet
+  const fleetAddress = usdcFleet
 
   const user = User.createFrom({
     chainInfo,
@@ -51,7 +51,7 @@ describe('Armada Protocol - User', () => {
 
   console.log(`Running on ${chainInfo.name} for user ${testWalletAddress.value}`)
 
-  it.skip(`should get all user positions: ${fleetAddress.value}`, async () => {
+  it(`should get all user positions: ${fleetAddress.value}`, async () => {
     const positions = await sdk.armada.users.getUserPositions({
       user,
     })
@@ -97,10 +97,11 @@ describe('Armada Protocol - User', () => {
   })
 
   it(`should get user fleet and staked balance for vault: ${fleetAddress.value}`, async () => {
-    const _user = User.createFromEthereum(
-      ChainIds.Base,
-      '0x4eb7f19d6efcace59eaed70220da5002709f9b71',
-    )
+    // const _user = User.createFromEthereum(
+    //   ChainIds.Base,
+    //   '0x4eb7f19d6efcace59eaed70220da5002709f9b71',
+    // )
+    const _user = user
 
     const fleetAmountBefore = await sdk.armada.users.getFleetBalance({
       user: _user,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -57,7 +57,7 @@ describe('Armada Protocol - User', () => {
     })
     console.log('User positions:')
     positions.forEach((position) => {
-      console.log(`Position ${position.id.id} amount: ${position.amount.toString()}`)
+      console.log(`Position ${position.id.id}\n - amount: ${position.amount.toString()}`)
     })
   })
 
@@ -71,28 +71,25 @@ describe('Armada Protocol - User', () => {
       fleetAddress,
     })
     assert(position != null, 'User position not found')
-    console.log(`User position for fleet ${fleetAddress.value}: ${position.amount.toString()}`)
     console.log(
-      JSON.stringify(
-        {
-          id: position.id.id,
-          amount: position.amount.toString(),
-          deposits: position.deposits.map((deposit) => ({
-            amount: deposit.amount.toString(),
-          })),
-          withdrawals: position.withdrawals.map((withdrawal) => ({
-            amount: withdrawal.amount.toString(),
-          })),
-          rewards: position.rewards.map((reward) => ({
-            token: reward.claimable.toString(),
-            amount: reward.claimed.toString(),
-          })),
-          claimed: position.claimedSummerToken.toString(),
-          claimable: position.claimableSummerToken.toString(),
-        },
-        null,
-        2,
-      ),
+      `User position for specific fleet`,
+      '\n' +
+        JSON.stringify(
+          {
+            id: position.id.id,
+            amount: position.amount.toString(),
+            deposits: position.deposits.length,
+            withdrawals: position.withdrawals.length,
+            rewards: position.rewards.map((reward) => ({
+              claimed: reward.claimed.toString(),
+              claimable: reward.claimable.toString(),
+            })),
+            claimed: position.claimedSummerToken.toString(),
+            claimable: position.claimableSummerToken.toString(),
+          },
+          null,
+          2,
+        ),
     )
   })
 
@@ -112,9 +109,10 @@ describe('Armada Protocol - User', () => {
       vaultId,
     })
     console.log(
-      'Fleet: ',
+      'Fleet balance',
+      '\n - Wallet: ',
       fleetAmountBefore.assets.toString(),
-      'Staked: ',
+      '\n - Staked: ',
       stakedAmountBefore.assets.toString(),
     )
   })

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -94,7 +94,7 @@ describe('Armada Protocol - User', () => {
     )
   })
 
-  it(`should get user fleet and staked balance for vault: ${fleetAddress.value}`, async () => {
+  it.only(`should get user fleet and staked balance for vault: ${fleetAddress.value}`, async () => {
     // const _user = User.createFromEthereum(
     //   ChainIds.Base,
     //   '0x4eb7f19d6efcace59eaed70220da5002709f9b71',

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -8,10 +8,11 @@ import {
   Wallet,
 } from '@summerfi/sdk-common'
 
-import { SDKApiUrl, userAddress } from './utils/testConfig'
+import { SDKApiUrl, testWalletAddress } from './utils/testConfig'
 import assert from 'assert'
 
 jest.setTimeout(300000)
+const simulateOnly = true
 
 const chainId = ChainIds.Base
 const ethFleet = Address.createFromEthereum({ value: '0x2bb9ad69feba5547b7cd57aafe8457d40bf834af' })
@@ -21,9 +22,12 @@ const usdcFleet = Address.createFromEthereum({
 const eurcFleet = Address.createFromEthereum({
   value: '0x64db8f51f1bf7064bb5a361a7265f602d348e0f0',
 })
+const selfManagedFleet = Address.createFromEthereum({
+  value: '0x29f13a877F3d1A14AC0B15B07536D4423b35E198',
+})
 const rpcUrl = process.env.E2E_SDK_FORK_URL_BASE
 
-describe('Armada Protocol User', () => {
+describe('Armada Protocol - User', () => {
   const sdk: SDKManager = makeSDK({
     apiDomainUrl: SDKApiUrl,
   })
@@ -32,12 +36,12 @@ describe('Armada Protocol User', () => {
   }
 
   const chainInfo = getChainInfoByChainId(chainId)
-  const fleetAddress = usdcFleet
+  const fleetAddress = selfManagedFleet
 
   const user = User.createFrom({
     chainInfo,
     wallet: Wallet.createFrom({
-      address: userAddress,
+      address: testWalletAddress,
     }),
   })
   const vaultId = ArmadaVaultId.createFrom({
@@ -45,7 +49,7 @@ describe('Armada Protocol User', () => {
     fleetAddress,
   })
 
-  console.log(`Running on ${chainInfo.name} for user ${userAddress.value}`)
+  console.log(`Running on ${chainInfo.name} for user ${testWalletAddress.value}`)
 
   it.skip(`should get all user positions: ${fleetAddress.value}`, async () => {
     const positions = await sdk.armada.users.getUserPositions({
@@ -58,20 +62,24 @@ describe('Armada Protocol User', () => {
   })
 
   it(`should get user position for a specific fleet: ${fleetAddress.value}`, async () => {
+    const _user = User.createFromEthereum(
+      ChainIds.Base,
+      '0x4eb7f19d6efcace59eaed70220da5002709f9b71',
+    )
     const position = await sdk.armada.users.getUserPosition({
-      user,
+      user: _user,
       fleetAddress,
     })
     assert(position != null, 'User position not found')
     console.log(`User position for fleet ${fleetAddress.value}: ${position.amount.toString()}`)
 
     const fleetAmountBefore = await sdk.armada.users.getFleetBalance({
+      user: _user,
       vaultId,
-      user,
     })
     const stakedAmountBefore = await sdk.armada.users.getStakedBalance({
+      user: _user,
       vaultId,
-      user,
     })
     console.log(
       'Fleet: ',

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -72,6 +72,35 @@ describe('Armada Protocol - User', () => {
     })
     assert(position != null, 'User position not found')
     console.log(`User position for fleet ${fleetAddress.value}: ${position.amount.toString()}`)
+    console.log(
+      JSON.stringify(
+        {
+          id: position.id.id,
+          amount: position.amount.toString(),
+          deposits: position.deposits.map((deposit) => ({
+            amount: deposit.amount.toString(),
+          })),
+          withdrawals: position.withdrawals.map((withdrawal) => ({
+            amount: withdrawal.amount.toString(),
+          })),
+          rewards: position.rewards.map((reward) => ({
+            token: reward.claimable.toString(),
+            amount: reward.claimed.toString(),
+          })),
+          claimed: position.claimedSummerToken.toString(),
+          claimable: position.claimableSummerToken.toString(),
+        },
+        null,
+        2,
+      ),
+    )
+  })
+
+  it(`should get user fleet and staked balance for vault: ${fleetAddress.value}`, async () => {
+    const _user = User.createFromEthereum(
+      ChainIds.Base,
+      '0x4eb7f19d6efcace59eaed70220da5002709f9b71',
+    )
 
     const fleetAmountBefore = await sdk.armada.users.getFleetBalance({
       user: _user,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
@@ -37,7 +37,7 @@ describe('Armada Protocol - Vault', () => {
   }
 
   const chainInfo = getChainInfoByChainId(chainId)
-  const fleetAddress = selfManagedFleet
+  const fleetAddress = usdcFleet
 
   const user = User.createFrom({
     chainInfo,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
@@ -23,6 +23,9 @@ const usdcFleet = Address.createFromEthereum({
 const eurcFleet = Address.createFromEthereum({
   value: '0x64db8f51f1bf7064bb5a361a7265f602d348e0f0',
 })
+const selfManagedFleet = Address.createFromEthereum({
+  value: '0x29f13a877F3d1A14AC0B15B07536D4423b35E198',
+})
 const rpcUrl = process.env.E2E_SDK_FORK_URL_BASE
 
 describe('Armada Protocol - Vault', () => {
@@ -34,7 +37,7 @@ describe('Armada Protocol - Vault', () => {
   }
 
   const chainInfo = getChainInfoByChainId(chainId)
-  const fleetAddress = usdcFleet
+  const fleetAddress = selfManagedFleet
 
   const user = User.createFrom({
     chainInfo,
@@ -56,7 +59,7 @@ describe('Armada Protocol - Vault', () => {
 
   it(`should get user position for a specific fleet: ${fleetAddress.value}`, async () => {
     const position = await sdk.armada.users.getUserPosition({
-      user,
+      user: User.createFromEthereum(ChainIds.Base, '0x4eb7f19d6efcace59eaed70220da5002709f9b71'),
       fleetAddress,
     })
     assert(position != null, 'User position not found')
@@ -99,7 +102,7 @@ describe('Armada Protocol - Vault', () => {
   it('should get a specific vault info', async () => {
     const vaultId = ArmadaVaultId.createFrom({
       chainInfo,
-      fleetAddress: ethFleet,
+      fleetAddress,
     })
     const vaultInfo = await sdk.armada.users.getVaultInfo({
       vaultId,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
@@ -47,25 +47,6 @@ describe('Armada Protocol - Vault', () => {
   })
   console.log(`Running on ${chainInfo.name} for user ${testWalletAddress.value}`)
 
-  it(`should get all user positions: ${fleetAddress.value}`, async () => {
-    const positions = await sdk.armada.users.getUserPositions({
-      user,
-    })
-    console.log('User positions:')
-    positions.forEach((position, index) => {
-      console.log(`Position ${index} amount: ${position.amount.toString()}`)
-    })
-  })
-
-  it(`should get user position for a specific fleet: ${fleetAddress.value}`, async () => {
-    const position = await sdk.armada.users.getUserPosition({
-      user: User.createFromEthereum(ChainIds.Base, '0x4eb7f19d6efcace59eaed70220da5002709f9b71'),
-      fleetAddress,
-    })
-    assert(position != null, 'User position not found')
-    console.log(`User position for fleet ${fleetAddress.value}: ${position.amount.toString()}`)
-  })
-
   it('should get all vaults with info', async () => {
     const vaults = await sdk.armada.users.getVaultInfoList({
       chainId,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.withdraw.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.withdraw.test.ts
@@ -8,6 +8,7 @@ import {
   TokenAmount,
   User,
   Wallet,
+  type ChainId,
 } from '@summerfi/sdk-common'
 
 import { sendAndLogTransactions } from '@summerfi/testing-utils'
@@ -16,6 +17,7 @@ import { DEFAULT_SLIPPAGE_PERCENTAGE } from './utils/constants'
 import assert from 'assert'
 
 jest.setTimeout(300000)
+const simulateOnly = false
 
 const ethFleet = Address.createFromEthereum({ value: '0x2bb9ad69feba5547b7cd57aafe8457d40bf834af' })
 const usdcFleet = Address.createFromEthereum({
@@ -24,7 +26,7 @@ const usdcFleet = Address.createFromEthereum({
 const eurcFleet = Address.createFromEthereum({
   value: '0x64db8f51f1bf7064bb5a361a7265f602d348e0f0',
 })
-const permissionedFleetAddressUsdc = Address.createFromEthereum({
+const selfManagedFleet = Address.createFromEthereum({
   value: '0x29f13a877F3d1A14AC0B15B07536D4423b35E198',
 })
 
@@ -33,28 +35,29 @@ describe('Armada Protocol Withdraw', () => {
     const rpcUrl = process.env.E2E_SDK_FORK_URL_BASE
     const chainId = ChainIds.Base
     const fleetAddress = usdcFleet
-    const amountValue = '1'
     const userAddress = testWalletAddress
+    const amountValue = '0.9999'
+    const swapToSymbol = undefined
 
     await runTests({
-      swapToSymbol: undefined,
+      rpcUrl,
       chainId,
       fleetAddress,
-      rpcUrl,
-      amountValue,
       userAddress,
+      amountValue,
+      swapToSymbol,
     })
   })
 
   async function runTests({
-    swapToSymbol: swapSymbol,
     chainId,
+    swapToSymbol: swapSymbol,
     fleetAddress,
     rpcUrl,
     amountValue,
     userAddress,
   }: {
-    chainId: number
+    chainId: ChainId
     swapToSymbol: string | undefined
     fleetAddress: Address
     rpcUrl: string | undefined
@@ -71,23 +74,22 @@ describe('Armada Protocol Withdraw', () => {
     const chainInfo = getChainInfoByChainId(chainId)
 
     const user = User.createFrom({
+      chainInfo,
       wallet: Wallet.createFrom({
         address: userAddress,
       }),
-      chainInfo,
     })
     const vaultId = ArmadaVaultId.createFrom({
       chainInfo,
       fleetAddress,
     })
 
-    const chain = await sdk.chains.getChain({ chainInfo })
     const vaultInfo = await sdk.armada.users.getVaultInfo({
       vaultId,
     })
     const token = vaultInfo.depositCap.token
     const swapToken = swapSymbol
-      ? await chain.tokens.getTokenBySymbol({ symbol: swapSymbol })
+      ? await sdk.tokens.getTokenBySymbol({ chainId, symbol: swapSymbol })
       : undefined
 
     console.log(
@@ -136,30 +138,33 @@ describe('Armada Protocol Withdraw', () => {
       transactions: transactions,
       rpcUrl: rpcUrl,
       privateKey: signerPrivateKey,
+      simulateOnly,
     })
     statuses.forEach((status) => {
       expect(status).toBe('success')
     })
 
-    const fleetAmountAfter = await sdk.armada.users.getFleetBalance({
-      vaultId,
-      user,
-    })
-    const stakedAmountAfter = await sdk.armada.users.getStakedBalance({
-      vaultId,
-      user,
-    })
-    console.log(
-      'after',
-      fleetAmountAfter.assets.toSolidityValue(),
-      '/',
-      stakedAmountAfter.assets.toSolidityValue(),
-    )
-    console.log(
-      'difference',
-      fleetAmountAfter.assets.subtract(fleetAmountBefore.assets).toString(),
-      '/',
-      stakedAmountAfter.assets.subtract(stakedAmountBefore.assets).toString(),
-    )
+    if (!simulateOnly) {
+      const fleetAmountAfter = await sdk.armada.users.getFleetBalance({
+        vaultId,
+        user,
+      })
+      const stakedAmountAfter = await sdk.armada.users.getStakedBalance({
+        vaultId,
+        user,
+      })
+      console.log(
+        'after',
+        fleetAmountAfter.assets.toSolidityValue(),
+        '/',
+        stakedAmountAfter.assets.toSolidityValue(),
+      )
+      console.log(
+        'difference',
+        fleetAmountAfter.assets.subtract(fleetAmountBefore.assets).toString(),
+        '/',
+        stakedAmountAfter.assets.subtract(stakedAmountBefore.assets).toString(),
+      )
+    }
   }
 })

--- a/sdk/sdk-e2e/e2e/armadaProtocol.withdraw.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.withdraw.test.ts
@@ -36,7 +36,7 @@ describe('Armada Protocol Withdraw', () => {
     const chainId = ChainIds.Base
     const fleetAddress = usdcFleet
     const userAddress = testWalletAddress
-    const amountValue = '0.9999'
+    const amountValue = '1.9999'
     const swapToSymbol = undefined
 
     await runTests({

--- a/sdk/sdk-e2e/package.json
+++ b/sdk/sdk-e2e/package.json
@@ -11,6 +11,7 @@
     "e2e:user": "jest --roots e2e -- ./e2e/armadaProtocol.user.test.ts",
     "e2e:deposit": "jest --roots e2e -- ./e2e/armadaProtocol.deposit.test.ts",
     "e2e:withdraw": "jest --roots e2e -- ./e2e/armadaProtocol.withdraw.test.ts",
+    "e2e:switch": "jest --roots e2e -- ./e2e/armadaProtocol.switch.test.ts",
     "e2e:claim": "jest --roots e2e -- ./e2e/armadaProtocol.claim.test.ts",
     "e2e:rewards": "jest --roots e2e -- ./e2e/armadaProtocol.rewards.test.ts",
     "e2e:access": "jest --roots e2e -- ./e2e/armadaProtocol.accessControl.test.ts",

--- a/sdk/sdk-e2e/package.json
+++ b/sdk/sdk-e2e/package.json
@@ -8,6 +8,7 @@
     "lint:fix": "eslint . --fix",
     "e2e": "jest --roots e2e",
     "e2e:vault": "jest --roots e2e -- ./e2e/armadaProtocol.vault.test.ts",
+    "e2e:user": "jest --roots e2e -- ./e2e/armadaProtocol.user.test.ts",
     "e2e:deposit": "jest --roots e2e -- ./e2e/armadaProtocol.deposit.test.ts",
     "e2e:withdraw": "jest --roots e2e -- ./e2e/armadaProtocol.withdraw.test.ts",
     "e2e:claim": "jest --roots e2e -- ./e2e/armadaProtocol.claim.test.ts",


### PR DESCRIPTION
Disable staking on deposits for the front end apps and optimize withdrawals/switching logic.

This pull request introduces several improvements and fixes to the Armada Protocol SDK, focusing on the withdrawal and switch logic in `ArmadaManagerVaults`, as well as enhancements and cleanup in the end-to-end (E2E) test suites. The main changes include stricter validation of withdrawal amounts, a new helper for calculating withdrawal shares, improved approval logic, and updates to the E2E tests for better consistency and coverage.

**ArmadaManagerVaults withdrawal and switch logic:**

- Added validation to prevent zero or negative withdrawal and switch amounts, throwing an error if such values are detected. [[1]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R140-R142) [[2]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R803-R806)
- Introduced a new private helper method `_calculateWithdrawSharesData` to encapsulate the logic for determining whether to withdraw all shares, calculating approval amounts, and setting the correct withdrawal asset amounts. This ensures consistency and reduces code duplication. [[1]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R264-R270) [[2]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R848-R878) [[3]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R1435-R1482)
- Updated approval and withdrawal transaction logic to use the calculated values from `_calculateWithdrawSharesData`, ensuring correct amounts are approved and withdrawn in all scenarios. [[1]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46L271-R300) [[2]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R848-R878) [[3]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46L885-R906)
- Improved the threshold logic for determining "withdraw all" behavior, and clarified comments for maintainability.

**E2E test suite enhancements and cleanup:**

- Added `simulateOnly` flags to deposit and switch tests to allow toggling between simulation and live execution, preventing unnecessary post-transaction checks during simulation runs. [[1]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R21) [[2]](diffhunk://#diff-908a43b1fc1119fa04a3c4e33544a9b476e178d588a5c3d5b9ee65efba74734dR19) [[3]](diffhunk://#diff-908a43b1fc1119fa04a3c4e33544a9b476e178d588a5c3d5b9ee65efba74734dR131-R140) [[4]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R153-R159)
- Updated test addresses and refactored test setup for clarity, including introducing `selfManagedFleetBase` and cleaning up unused or redundant variables. [[1]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R32-R71) [[2]](diffhunk://#diff-6ac35eedc2218f1193b25556fa7f4b23f337c3a7186a7ef44cf793185ca1e6f4R25-R32) [[3]](diffhunk://#diff-fbafcedb905ef82511fe1fcf94a4f7d2f5d58c6b07a310a45865d2f2d7e89a84R26-R28)
- Improved test output formatting and added more detailed logging for user and vault position queries, making it easier to debug and verify test results.
- Removed redundant or skipped tests from the vault E2E suite to focus on relevant scenarios.
- Ensured consistent usage of `testWalletAddress` and improved type usage for `chainId` in tests. [[1]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R12) [[2]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R32-R71) [[3]](diffhunk://#diff-6ac35eedc2218f1193b25556fa7f4b23f337c3a7186a7ef44cf793185ca1e6f4L11-R15)

These changes improve the safety, correctness, and maintainability of both the core SDK logic and the automated test coverage.

**References:**  
[[1]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R140-R142) [[2]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R264-R270) [[3]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46L271-R300) [[4]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R803-R806) [[5]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R848-R878) [[6]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46L885-R906) [[7]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46R1435-R1482) [[8]](diffhunk://#diff-9d2c46b0eef14e10f221e3d080b7533549a83819ade670dd21368316187a1d46L1426) [[9]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R12) [[10]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R21) [[11]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R32-R71) [[12]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8L105-R104) [[13]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R153-R159) [[14]](diffhunk://#diff-95f6bc68a81f269b139c2d6ea1ebbc23893b6520c46efda89571346905520eb8R181) [[15]](diffhunk://#diff-908a43b1fc1119fa04a3c4e33544a9b476e178d588a5c3d5b9ee65efba74734dR19) [[16]](diffhunk://#diff-908a43b1fc1119fa04a3c4e33544a9b476e178d588a5c3d5b9ee65efba74734dR37-L49) [[17]](diffhunk://#diff-908a43b1fc1119fa04a3c4e33544a9b476e178d588a5c3d5b9ee65efba74734dR131-R140) [[18]](diffhunk://#diff-6ac35eedc2218f1193b25556fa7f4b23f337c3a7186a7ef44cf793185ca1e6f4L11-R15) [[19]](diffhunk://#diff-6ac35eedc2218f1193b25556fa7f4b23f337c3a7186a7ef44cf793185ca1e6f4R25-R32) [[20]](diffhunk://#diff-6ac35eedc2218f1193b25556fa7f4b23f337c3a7186a7ef44cf793185ca1e6f4L35-R116) [[21]](diffhunk://#diff-fbafcedb905ef82511fe1fcf94a4f7d2f5d58c6b07a310a45865d2f2d7e89a84R26-R28) [[22]](diffhunk://#diff-fbafcedb905ef82511fe1fcf94a4f7d2f5d58c6b07a310a45865d2f2d7e89a84L47-L65)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Safer withdrawal/switch flows: prevent zero/negative withdrawals, more reliable full vs partial handling.
  - Clearer transaction errors: revert messages now include the transaction hash.

- Tests
  - Improved e2e coverage: reactivated user tests, added user fleet/staked-balance checks, and a focused fleet/staked test.
  - Simulation mode: optional simulateOnly to skip post-checks.
  - Token lookups and chain typing standardized (chain-aware token resolution, typed chain IDs).

- Chores
  - Added npm scripts for running user- and switch-focused e2e tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->