### PR TITLE
feat: implement server-side spike removal for native interest rates

### DIFF
--- a/summerfi-api/get-rates-function/src/lib/cleanRateSeries.test.ts
+++ b/summerfi-api/get-rates-function/src/lib/cleanRateSeries.test.ts
@@ -9,15 +9,19 @@ describe('cleanRateSeries', () => {
     const points = Array.from({ length: 25 }, (_, i) => ({ t: t0 + ms(i), r: 10 })) // 10% base rate
     points[12].r = 57762.58 // absurd spike like the one we saw
 
-    const { cleanedPct, replaced } = cleanRateSeries(points, { win: 24, nSigmas: 3.5, maxRunToFix: 2 })
-    
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 24,
+      nSigmas: 3.5,
+      maxRunToFix: 2,
+    })
+
     // The spike should be replaced
     expect(replaced[12]).toBe(true)
-    
+
     // The cleaned value should be reasonable (close to surrounding 10%)
     expect(cleanedPct[12]).toBeGreaterThan(5)
     expect(cleanedPct[12]).toBeLessThan(20)
-    
+
     // Other points should not be replaced
     expect(replaced.filter(Boolean).length).toBe(1)
   })
@@ -29,9 +33,9 @@ describe('cleanRateSeries', () => {
       ...Array.from({ length: 12 }, (_, i) => ({ t: t0 + ms(i), r: 8 })),
       ...Array.from({ length: 12 }, (_, i) => ({ t: t0 + ms(12 + i), r: 20 })),
     ]
-    
+
     const { replaced } = cleanRateSeries(points, { win: 12, nSigmas: 3.5, maxRunToFix: 2 })
-    
+
     // No points should be replaced as this is a sustained change
     expect(replaced.some(Boolean)).toBe(false)
   })
@@ -43,16 +47,16 @@ describe('cleanRateSeries', () => {
       { t: t0 + ms(1), r: -5 },
       { t: t0 + ms(2), r: 15 },
     ]
-    
+
     const { cleanedPct } = cleanRateSeries(points, { win: 3 })
-    
+
     expect(cleanedPct.length).toBe(3)
-    expect(cleanedPct.every(v => Number.isFinite(v))).toBe(true)
+    expect(cleanedPct.every((v) => Number.isFinite(v))).toBe(true)
   })
 
   test('handles empty input', () => {
     const { cleanedPct, replaced } = cleanRateSeries([])
-    
+
     expect(cleanedPct).toEqual([])
     expect(replaced).toEqual([])
   })
@@ -63,9 +67,9 @@ describe('cleanRateSeries', () => {
       { t: t0, r: 10 },
       { t: t0 + ms(1), r: 12 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeries(points)
-    
+
     expect(cleanedPct).toEqual([10, 12])
     expect(replaced).toEqual([false, false])
   })
@@ -73,25 +77,29 @@ describe('cleanRateSeries', () => {
   test('replaces two consecutive spikes but preserves longer runs', () => {
     const t0 = Date.now()
     const points = Array.from({ length: 30 }, (_, i) => ({ t: t0 + ms(i), r: 10 }))
-    
+
     // Two consecutive spikes (should be replaced)
     points[10].r = 1000
     points[11].r = 1500
-    
+
     // Four consecutive high values (should be preserved as potential regime change)
     points[20].r = 100
     points[21].r = 100
     points[22].r = 100
     points[23].r = 100
-    
-    const { cleanedPct, replaced } = cleanRateSeries(points, { win: 24, nSigmas: 3.5, maxRunToFix: 2 })
-    
+
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 24,
+      nSigmas: 3.5,
+      maxRunToFix: 2,
+    })
+
     // Two-point spike should be replaced
     expect(replaced[10]).toBe(true)
     expect(replaced[11]).toBe(true)
     expect(cleanedPct[10]).toBeLessThan(50)
     expect(cleanedPct[11]).toBeLessThan(50)
-    
+
     // Four-point sustained change should be preserved
     expect(replaced[20]).toBe(false)
     expect(replaced[21]).toBe(false)
@@ -113,13 +121,13 @@ describe('cleanRateSeries', () => {
       { t: t0 + ms(6), r: 8.6 },
       { t: t0 + ms(7), r: 8.4 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeries(points, { win: 6, nSigmas: 3.5 })
-    
+
     // Only the spike should be replaced
     expect(replaced[4]).toBe(true)
     expect(replaced.filter(Boolean).length).toBe(1)
-    
+
     // Interpolated value should be close to surrounding values
     expect(cleanedPct[4]).toBeGreaterThan(7)
     expect(cleanedPct[4]).toBeLessThan(10)
@@ -138,21 +146,21 @@ describe('cleanRateSeries', () => {
       { t: t0 + ms(14), r: 3.52 },
       { t: t0 + ms(15), r: 3.52 },
     ]
-    
+
     // Base algorithm cannot detect long runs of extremes
     // because they contaminate the window statistics
-    const { cleanedPct, replaced } = cleanRateSeries(points, { 
-      win: 6, 
-      nSigmas: 1.5, 
-      maxRunToFix: 12 
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 6,
+      nSigmas: 1.5,
+      maxRunToFix: 12,
     })
-    
+
     // This is a known limitation - long runs contaminate the MAD calculation
     const replacedCount = replaced.filter(Boolean).length
-    
+
     // Cannot detect these with base algorithm
     expect(replacedCount).toBe(0)
-    
+
     // This is why we need the hybrid approach!
     // The hybrid approach with hard limits handles this case correctly
   })
@@ -164,25 +172,25 @@ describe('cleanRateSeries', () => {
       { t: t0, r: 3.52 },
       { t: t0 + ms(1), r: 3.52 },
       // 10 consecutive hours of extreme positive spikes
-      ...Array.from({ length: 10 }, (_, i) => ({ 
-        t: t0 + ms(2 + i), 
-        r: 57762.58 
+      ...Array.from({ length: 10 }, (_, i) => ({
+        t: t0 + ms(2 + i),
+        r: 57762.58,
       })),
       { t: t0 + ms(12), r: 3.52 },
       { t: t0 + ms(13), r: 3.52 },
     ]
-    
-    const { cleanedPct, replaced } = cleanRateSeries(points, { 
-      win: 48, 
-      nSigmas: 2.5, 
-      maxRunToFix: 12 
+
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 48,
+      nSigmas: 2.5,
+      maxRunToFix: 12,
     })
-    
+
     // All extreme spikes should be replaced
     for (let i = 2; i < 12; i++) {
       expect(replaced[i]).toBe(true)
     }
-    
+
     // Interpolated values should be reasonable
     for (let i = 2; i < 12; i++) {
       expect(cleanedPct[i]).toBeLessThan(50)
@@ -197,24 +205,24 @@ describe('cleanRateSeries', () => {
       { t: t0, r: 3.52 },
       { t: t0 + ms(1), r: 3.52 },
       { t: t0 + ms(2), r: 3.52 },
-      { t: t0 + ms(3), r: 11.90 }, // Sudden jump
-      { t: t0 + ms(4), r: 11.90 },
-      { t: t0 + ms(5), r: 11.90 },
-      { t: t0 + ms(6), r: 11.90 },
+      { t: t0 + ms(3), r: 11.9 }, // Sudden jump
+      { t: t0 + ms(4), r: 11.9 },
+      { t: t0 + ms(5), r: 11.9 },
+      { t: t0 + ms(6), r: 11.9 },
       { t: t0 + ms(7), r: 3.52 }, // Back to normal
       { t: t0 + ms(8), r: 3.52 },
     ]
-    
-    const { cleanedPct, replaced } = cleanRateSeries(points, { 
-      win: 24, 
+
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 24,
       nSigmas: 3.0,
-      maxRunToFix: 6
+      maxRunToFix: 6,
     })
-    
+
     // With aggressive settings, these moderate jumps might be replaced
     // depending on the statistical threshold
     const replacedCount = replaced.filter(Boolean).length
-    
+
     // If replaced, values should be smoothed
     if (replacedCount > 0) {
       for (let i = 3; i <= 6; i++) {
@@ -230,31 +238,31 @@ describe('cleanRateSeries', () => {
     const t0 = Date.now()
     // Pattern from 2025-08-14: positive 10.90% suddenly becomes -1.28%
     const points = [
-      { t: t0, r: 10.90 },
-      { t: t0 + ms(1), r: 10.90 },
-      { t: t0 + ms(2), r: 10.90 },
+      { t: t0, r: 10.9 },
+      { t: t0 + ms(1), r: 10.9 },
+      { t: t0 + ms(2), r: 10.9 },
       { t: t0 + ms(3), r: -1.28 }, // Sign inversion
       { t: t0 + ms(4), r: -1.28 },
       { t: t0 + ms(5), r: -1.28 },
       { t: t0 + ms(6), r: -1.28 },
       { t: t0 + ms(7), r: -1.28 },
-      { t: t0 + ms(8), r: 10.90 }, // Back to positive
-      { t: t0 + ms(9), r: 10.90 },
+      { t: t0 + ms(8), r: 10.9 }, // Back to positive
+      { t: t0 + ms(9), r: 10.9 },
     ]
-    
-    const { cleanedPct, replaced } = cleanRateSeries(points, { 
+
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
       win: 6,
-      nSigmas: 3.5,  // Default sensitivity
-      maxRunToFix: 6
+      nSigmas: 3.5, // Default sensitivity
+      maxRunToFix: 6,
     })
-    
+
     // Small inversions (-1.28%) are not extreme enough for detection
     // This is a known limitation of the base algorithm
-    const replacedInversions = [3, 4, 5, 6, 7].filter(i => replaced[i]).length
-    
+    const replacedInversions = [3, 4, 5, 6, 7].filter((i) => replaced[i]).length
+
     // These small inversions won't be detected with default settings
     expect(replacedInversions).toBe(0)
-    
+
     // Values remain unchanged
     expect(cleanedPct[3]).toBe(-1.28)
     expect(cleanedPct[4]).toBe(-1.28)
@@ -275,15 +283,15 @@ describe('cleanRateSeries', () => {
       { t: t0 + ms(8), r: 10.99 },
       { t: t0 + ms(9), r: 10.91 },
     ]
-    
-    const { replaced } = cleanRateSeries(points, { 
-      win: 24, 
+
+    const { replaced } = cleanRateSeries(points, {
+      win: 24,
       nSigmas: 3.0,
-      maxRunToFix: 6
+      maxRunToFix: 6,
     })
-    
+
     // No values should be replaced as this is clean gradual change
-    expect(replaced.every(r => r === false)).toBe(true)
+    expect(replaced.every((r) => r === false)).toBe(true)
   })
 
   test('handles mixed extreme spikes pattern (from taste-rates.json)', () => {
@@ -298,18 +306,18 @@ describe('cleanRateSeries', () => {
       { t: t0 + ms(5), r: 3.97 },
       { t: t0 + ms(6), r: 3.97 },
     ]
-    
-    const { cleanedPct, replaced } = cleanRateSeries(points, { 
-      win: 24, 
+
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 24,
       nSigmas: 3.0,
-      maxRunToFix: 6
+      maxRunToFix: 6,
     })
-    
+
     // Extreme spikes should be replaced
     expect(replaced[2]).toBe(true)
     expect(replaced[3]).toBe(true)
     expect(replaced[4]).toBe(true)
-    
+
     // Replaced values should be close to surrounding normal values
     expect(cleanedPct[2]).toBeLessThan(50)
     expect(cleanedPct[3]).toBeLessThan(50)
@@ -319,25 +327,25 @@ describe('cleanRateSeries', () => {
   test('handles constant rate with single outlier (from taste-rates.json)', () => {
     const t0 = Date.now()
     // Pattern where all values are identical except one outlier
-    const points = Array.from({ length: 25 }, (_, i) => ({ 
-      t: t0 + ms(i), 
-      r: 3.96 
+    const points = Array.from({ length: 25 }, (_, i) => ({
+      t: t0 + ms(i),
+      r: 3.96,
     }))
     // Insert outlier
     points[12].r = -27.76
-    
-    const { cleanedPct, replaced } = cleanRateSeries(points, { 
-      win: 24, 
+
+    const { cleanedPct, replaced } = cleanRateSeries(points, {
+      win: 24,
       nSigmas: 3.0,
-      maxRunToFix: 2
+      maxRunToFix: 2,
     })
-    
+
     // The outlier should be replaced
     expect(replaced[12]).toBe(true)
-    
+
     // Replaced value should match the constant rate
     expect(cleanedPct[12]).toBeCloseTo(3.96, 1)
-    
+
     // All other values should remain unchanged
     for (let i = 0; i < 25; i++) {
       if (i !== 12) {
@@ -350,20 +358,20 @@ describe('cleanRateSeries', () => {
   test('handles zero MAD scenario gracefully', () => {
     const t0 = Date.now()
     // All values identical except spikes - causes MAD to be 0
-    const points = Array.from({ length: 30 }, (_, i) => ({ 
-      t: t0 + ms(i), 
-      r: 5.0 
+    const points = Array.from({ length: 30 }, (_, i) => ({
+      t: t0 + ms(i),
+      r: 5.0,
     }))
     // Add spikes
     points[10].r = 1000
     points[11].r = 1000
-    
+
     const { cleanedPct, replaced } = cleanRateSeries(points)
-    
+
     // Should handle zero MAD without crashing and replace spikes
     expect(replaced[10]).toBe(true)
     expect(replaced[11]).toBe(true)
-    
+
     // Replaced values should be close to the constant value
     expect(cleanedPct[10]).toBeCloseTo(5.0, 1)
     expect(cleanedPct[11]).toBeCloseTo(5.0, 1)
@@ -381,18 +389,18 @@ describe('cleanRateSeries', () => {
       { t: t0 + ms(5), r: 5 },
       { t: t0 + ms(6), r: 5 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeries(points, {
       win: 6,
       nSigmas: 3.0,
-      maxRunToFix: 3
+      maxRunToFix: 3,
     })
-    
+
     // Extreme values should be replaced despite being numerous
     expect(replaced[2]).toBe(true)
     expect(replaced[3]).toBe(true)
     expect(replaced[4]).toBe(true)
-    
+
     // Cleaned values should be reasonable
     expect(cleanedPct[2]).toBeLessThan(100)
     expect(cleanedPct[3]).toBeLessThan(100)
@@ -404,28 +412,28 @@ describe('inferWindowSize', () => {
   test('infers window size for 10-minute data', () => {
     const t0 = Date.now()
     const timestamps = Array.from({ length: 100 }, (_, i) => t0 + i * 10 * 60 * 1000)
-    
+
     expect(inferWindowSize(timestamps)).toBe(36) // ~6 hours of 10-min data
   })
 
   test('infers window size for hourly data', () => {
     const t0 = Date.now()
     const timestamps = Array.from({ length: 100 }, (_, i) => t0 + i * 60 * 60 * 1000)
-    
+
     expect(inferWindowSize(timestamps)).toBe(24) // ~1 day of hourly data
   })
 
   test('infers window size for daily data', () => {
     const t0 = Date.now()
     const timestamps = Array.from({ length: 100 }, (_, i) => t0 + i * 24 * 60 * 60 * 1000)
-    
+
     expect(inferWindowSize(timestamps)).toBe(7) // ~1 week of daily data
   })
 
   test('infers window size for weekly data', () => {
     const t0 = Date.now()
     const timestamps = Array.from({ length: 100 }, (_, i) => t0 + i * 7 * 24 * 60 * 60 * 1000)
-    
+
     expect(inferWindowSize(timestamps)).toBe(4) // ~1 month of weekly data
   })
 

--- a/summerfi-api/get-rates-function/src/lib/cleanRateSeriesHybrid.test.ts
+++ b/summerfi-api/get-rates-function/src/lib/cleanRateSeriesHybrid.test.ts
@@ -14,22 +14,22 @@ describe('cleanRateSeriesHybrid', () => {
       { t: t0 + ms(4), r: 10 },
       { t: t0 + ms(5), r: 10 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
     })
-    
+
     // Extreme values should be replaced
     expect(replaced[2]).toBe(true)
     expect(replaced[3]).toBe(true)
-    
+
     // Normal values should not be replaced
     expect(replaced[0]).toBe(false)
     expect(replaced[1]).toBe(false)
     expect(replaced[4]).toBe(false)
     expect(replaced[5]).toBe(false)
-    
+
     // Replaced values should be reasonable
     expect(cleanedPct[2]).toBeLessThan(50)
     expect(cleanedPct[3]).toBeGreaterThan(-20)
@@ -41,28 +41,28 @@ describe('cleanRateSeriesHybrid', () => {
     const points = [
       { t: t0, r: 3.52 },
       { t: t0 + ms(1), r: 3.52 },
-      ...Array.from({ length: 10 }, (_, i) => ({ 
-        t: t0 + ms(2 + i), 
-        r: -9041.28 
+      ...Array.from({ length: 10 }, (_, i) => ({
+        t: t0 + ms(2 + i),
+        r: -9041.28,
       })),
       { t: t0 + ms(12), r: 3.52 },
       { t: t0 + ms(13), r: 3.52 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       contextFactor: 10,
       win: 24,
       nSigmas: 3.0,
-      maxRunToFix: 6
+      maxRunToFix: 6,
     })
-    
+
     // All extreme values should be replaced even in long run
     for (let i = 2; i < 12; i++) {
       expect(replaced[i]).toBe(true)
     }
-    
+
     // Replaced values should be reasonable
     for (let i = 2; i < 12; i++) {
       expect(cleanedPct[i]).toBeGreaterThan(-10)
@@ -73,18 +73,18 @@ describe('cleanRateSeriesHybrid', () => {
   test('detects contextual outliers above 50%', () => {
     const t0 = Date.now()
     // Value that's not extreme but is 10x the surrounding median
-    const points = Array.from({ length: 25 }, (_, i) => ({ 
-      t: t0 + ms(i), 
-      r: 5 
+    const points = Array.from({ length: 25 }, (_, i) => ({
+      t: t0 + ms(i),
+      r: 5,
     }))
     points[12].r = 75 // 15x the median, above 50% threshold
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       contextFactor: 10,
     })
-    
+
     // Should be replaced as contextual outlier
     expect(replaced[12]).toBe(true)
     expect(cleanedPct[12]).toBeCloseTo(5, 1)
@@ -92,19 +92,19 @@ describe('cleanRateSeriesHybrid', () => {
 
   test('preserves values below 50% even if statistical outlier', () => {
     const t0 = Date.now()
-    const points = Array.from({ length: 25 }, (_, i) => ({ 
-      t: t0 + ms(i), 
-      r: 5 
+    const points = Array.from({ length: 25 }, (_, i) => ({
+      t: t0 + ms(i),
+      r: 5,
     }))
     points[12].r = 30 // Statistical outlier but below 50%
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       contextFactor: 10,
       nSigmas: 3.0,
     })
-    
+
     // May or may not be replaced based on statistical detection
     // but not by contextual check (under 50%)
     if (replaced[12]) {
@@ -120,19 +120,19 @@ describe('cleanRateSeriesHybrid', () => {
       { t: t0 + ms(1), r: 5 },
       { t: t0 + ms(2), r: 600 }, // Exceeds hard limit
       { t: t0 + ms(3), r: 150 }, // Statistical outlier
-      { t: t0 + ms(4), r: 80 },  // Contextual outlier (16x median, >50%)
+      { t: t0 + ms(4), r: 80 }, // Contextual outlier (16x median, >50%)
       { t: t0 + ms(5), r: 5 },
       { t: t0 + ms(6), r: 5 },
     ]
-    
+
     const { replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       contextFactor: 10,
       nSigmas: 2.0,
-      win: 6,  // Small window for better detection
+      win: 6, // Small window for better detection
     })
-    
+
     // All three types should be detected
     expect(replaced[2]).toBe(true) // Hard limit
     expect(replaced[3]).toBe(true) // Statistical
@@ -154,48 +154,48 @@ describe('cleanRateSeriesHybrid', () => {
       { t: t0 + ms(8), r: 10.99 },
       { t: t0 + ms(9), r: 10.91 },
     ]
-    
+
     const { replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       contextFactor: 10,
       win: 24,
       nSigmas: 3.0,
-      maxRunToFix: 6
+      maxRunToFix: 6,
     })
-    
+
     // No replacements for clean gradual changes
-    expect(replaced.every(r => r === false)).toBe(true)
+    expect(replaced.every((r) => r === false)).toBe(true)
   })
 
   test('small sign inversions within reasonable limits are preserved', () => {
     const t0 = Date.now()
     // From taste-rates.json: positive to negative flip
     const points = [
-      { t: t0, r: 10.90 },
-      { t: t0 + ms(1), r: 10.90 },
-      { t: t0 + ms(2), r: 10.90 },
+      { t: t0, r: 10.9 },
+      { t: t0 + ms(1), r: 10.9 },
+      { t: t0 + ms(2), r: 10.9 },
       { t: t0 + ms(3), r: -1.28 }, // Sign flip but within -95% to 500% limits
       { t: t0 + ms(4), r: -1.28 },
       { t: t0 + ms(5), r: -1.28 },
-      { t: t0 + ms(6), r: 10.90 },
-      { t: t0 + ms(7), r: 10.90 },
+      { t: t0 + ms(6), r: 10.9 },
+      { t: t0 + ms(7), r: 10.9 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       contextFactor: 10,
       win: 6,
       nSigmas: 3.0,
-      maxRunToFix: 6
+      maxRunToFix: 6,
     })
-    
+
     // -1.28% is within reasonable limits and not statistically extreme enough
     // The hybrid approach correctly preserves these as potentially valid
-    const replacedCount = [3, 4, 5].filter(i => replaced[i]).length
+    const replacedCount = [3, 4, 5].filter((i) => replaced[i]).length
     expect(replacedCount).toBe(0)
-    
+
     // Values should remain unchanged
     expect(cleanedPct[3]).toBe(-1.28)
     expect(cleanedPct[4]).toBe(-1.28)
@@ -204,21 +204,21 @@ describe('cleanRateSeriesHybrid', () => {
 
   test('handles empty and small inputs', () => {
     const t0 = Date.now()
-    
+
     // Empty
     const empty = cleanRateSeriesHybrid([])
     expect(empty.cleanedPct).toEqual([])
     expect(empty.replaced).toEqual([])
-    
+
     // Single point
     const single = cleanRateSeriesHybrid([{ t: t0, r: 10 }])
     expect(single.cleanedPct).toEqual([10])
     expect(single.replaced).toEqual([false])
-    
+
     // Two points
     const two = cleanRateSeriesHybrid([
       { t: t0, r: 10 },
-      { t: t0 + ms(1), r: 12 }
+      { t: t0 + ms(1), r: 12 },
     ])
     expect(two.cleanedPct).toEqual([10, 12])
     expect(two.replaced).toEqual([false, false])
@@ -233,17 +233,17 @@ describe('cleanRateSeriesHybrid', () => {
       { t: t0 + ms(3), r: 10000 }, // Spike to replace
       { t: t0 + ms(4), r: 20 },
     ]
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
     })
-    
+
     // Spikes should be replaced
     expect(replaced[1]).toBe(true)
     expect(replaced[2]).toBe(true)
     expect(replaced[3]).toBe(true)
-    
+
     // Interpolated values should gradually increase from 10 to 20
     expect(cleanedPct[1]).toBeCloseTo(12.5, 1)
     expect(cleanedPct[2]).toBeCloseTo(15, 1)
@@ -259,12 +259,12 @@ describe('cleanRateSeriesHybrid', () => {
       { t: t0 + ms(3), r: 10000 }, // Will be NaN
       { t: t0 + ms(4), r: 5 },
     ]
-    
+
     const { cleanedPct } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
     })
-    
+
     // Should interpolate between 10 and 5
     expect(cleanedPct[0]).toBe(10)
     expect(cleanedPct[1]).toBeGreaterThan(5)
@@ -278,54 +278,54 @@ describe('cleanRateSeriesHybrid', () => {
 
   test('handles boundary cases at start and end', () => {
     const t0 = Date.now()
-    
+
     // Spike at start
     const startSpike = [
       { t: t0, r: 10000 },
       { t: t0 + ms(1), r: 5 },
       { t: t0 + ms(2), r: 5 },
     ]
-    
+
     const startResult = cleanRateSeriesHybrid(startSpike, {
       maxReasonableRate: 500,
     })
-    
+
     expect(startResult.replaced[0]).toBe(true)
     expect(startResult.cleanedPct[0]).toBe(5) // Backward fill
-    
+
     // Spike at end
     const endSpike = [
       { t: t0, r: 5 },
       { t: t0 + ms(1), r: 5 },
       { t: t0 + ms(2), r: 10000 },
     ]
-    
+
     const endResult = cleanRateSeriesHybrid(endSpike, {
       maxReasonableRate: 500,
     })
-    
+
     expect(endResult.replaced[2]).toBe(true)
     expect(endResult.cleanedPct[2]).toBe(5) // Forward fill
   })
 
   test('handles constant values with MAD = 0', () => {
     const t0 = Date.now()
-    const points = Array.from({ length: 25 }, (_, i) => ({ 
-      t: t0 + ms(i), 
-      r: 3.96 
+    const points = Array.from({ length: 25 }, (_, i) => ({
+      t: t0 + ms(i),
+      r: 3.96,
     }))
     points[12].r = -27.76 // Outlier in constant data
-    
+
     const { cleanedPct, replaced } = cleanRateSeriesHybrid(points, {
       maxReasonableRate: 500,
       minReasonableRate: -95,
       win: 24,
       nSigmas: 3.0,
     })
-    
+
     // Outlier should be replaced
     expect(replaced[12]).toBe(true)
-    
+
     // Should be replaced with the constant value
     expect(cleanedPct[12]).toBeCloseTo(3.96, 1)
   })

--- a/summerfi-api/get-rates-function/src/lib/cleanRateSeriesHybrid.ts
+++ b/summerfi-api/get-rates-function/src/lib/cleanRateSeriesHybrid.ts
@@ -17,42 +17,45 @@ export interface HybridCleanOpts extends CleanOpts {
  */
 export function cleanRateSeriesHybrid(
   points: RatePoint[],
-  opts: HybridCleanOpts = {}
+  opts: HybridCleanOpts = {},
 ): { cleanedPct: number[]; replaced: boolean[] } {
   const {
-    maxReasonableRate = 500,  // Max 500% APY seems generous but possible
-    minReasonableRate = -95,  // Min -95% (near total loss but not impossible)
-    contextFactor = 10,       // Values >10x surrounding median are suspicious
+    maxReasonableRate = 500, // Max 500% APY seems generous but possible
+    minReasonableRate = -95, // Min -95% (near total loss but not impossible)
+    contextFactor = 10, // Values >10x surrounding median are suspicious
     win = 24,
-    nSigmas = 3.0,            // Slightly more sensitive than default
-    maxRunToFix = 6,          // Handle up to 6 hour error bursts
+    nSigmas = 3.0, // Slightly more sensitive than default
+    maxRunToFix = 6, // Handle up to 6 hour error bursts
     ...restOpts
   } = opts
 
   if (!points.length) return { cleanedPct: [], replaced: [] }
   if (points.length < 3) {
-    return { 
-      cleanedPct: points.map(p => p.r), 
-      replaced: new Array(points.length).fill(false) 
+    return {
+      cleanedPct: points.map((p) => p.r),
+      replaced: new Array(points.length).fill(false),
     }
   }
 
   // Step 1: Pre-filter absolute impossibilities
-  const preFiltered = points.map(p => ({
+  const preFiltered = points.map((p) => ({
     ...p,
-    r: (p.r > maxReasonableRate || p.r < minReasonableRate) ? NaN : p.r
+    r: p.r > maxReasonableRate || p.r < minReasonableRate ? NaN : p.r,
   }))
 
   // Step 2: Apply statistical cleaning on the pre-filtered data
-  const statisticalResult = cleanRateSeries(preFiltered.map(p => ({
-    ...p,
-    r: isNaN(p.r) ? 0 : p.r  // Temporarily use 0 for NaN to avoid breaking the algorithm
-  })), {
-    win,
-    nSigmas,
-    maxRunToFix,
-    ...restOpts
-  })
+  const statisticalResult = cleanRateSeries(
+    preFiltered.map((p) => ({
+      ...p,
+      r: isNaN(p.r) ? 0 : p.r, // Temporarily use 0 for NaN to avoid breaking the algorithm
+    })),
+    {
+      win,
+      nSigmas,
+      maxRunToFix,
+      ...restOpts,
+    },
+  )
 
   // Step 3: Apply contextual reasonableness check
   const finalReplaced = new Array(points.length).fill(false)
@@ -60,14 +63,14 @@ export function cleanRateSeriesHybrid(
 
   for (let i = 0; i < points.length; i++) {
     const originalRate = points[i].r
-    
+
     // Mark as needing replacement if:
     // 1. It was pre-filtered as impossible
     const isImpossible = originalRate > maxReasonableRate || originalRate < minReasonableRate
-    
+
     // 2. It was statistically identified as outlier
     const isStatisticalOutlier = statisticalResult.replaced[i]
-    
+
     // 3. Contextual check: is it wildly different from surroundings?
     let isContextualOutlier = false
     if (!isImpossible && !isStatisticalOutlier && Math.abs(originalRate) > 50) {
@@ -75,13 +78,13 @@ export function cleanRateSeriesHybrid(
       const windowStart = Math.max(0, i - 12)
       const windowEnd = Math.min(points.length, i + 13)
       const surroundingRates = []
-      
+
       for (let j = windowStart; j < windowEnd; j++) {
         if (j !== i && Math.abs(points[j].r) <= maxReasonableRate) {
           surroundingRates.push(points[j].r)
         }
       }
-      
+
       if (surroundingRates.length >= 6) {
         const median = getMedian(surroundingRates)
         if (median !== 0 && Math.abs(originalRate / median) > contextFactor) {
@@ -89,26 +92,26 @@ export function cleanRateSeriesHybrid(
         }
       }
     }
-    
+
     finalReplaced[i] = isImpossible || isStatisticalOutlier || isContextualOutlier
-    
+
     // Use the statistically cleaned value if available, otherwise will interpolate
     if (finalReplaced[i]) {
-      finalCleaned[i] = NaN  // Mark for interpolation
+      finalCleaned[i] = NaN // Mark for interpolation
     } else {
       finalCleaned[i] = originalRate
     }
   }
 
   // Step 4: Interpolate the NaN values
-  const timestamps = points.map(p => p.t)
+  const timestamps = points.map((p) => p.t)
   const interpolated = linearTimeInterpolation(timestamps, finalCleaned)
 
   return { cleanedPct: interpolated, replaced: finalReplaced }
 }
 
 function getMedian(values: number[]): number {
-  const sorted = values.filter(v => !isNaN(v)).sort((a, b) => a - b)
+  const sorted = values.filter((v) => !isNaN(v)).sort((a, b) => a - b)
   if (!sorted.length) return 0
   const mid = Math.floor(sorted.length / 2)
   return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
@@ -117,38 +120,38 @@ function getMedian(values: number[]): number {
 function linearTimeInterpolation(timestamps: number[], values: number[]): number[] {
   const result = [...values]
   let i = 0
-  
+
   while (i < result.length) {
     if (!isNaN(result[i])) {
       i++
       continue
     }
-    
+
     // Find the span of NaN values
     const startIdx = i - 1
     while (i < result.length && isNaN(result[i])) i++
     const endIdx = i
-    
+
     // Get boundary values for interpolation
     const startVal = startIdx >= 0 ? result[startIdx] : NaN
     const endVal = endIdx < result.length ? result[endIdx] : NaN
-    
+
     // Interpolate
     for (let j = startIdx + 1; j < endIdx; j++) {
       if (!isNaN(startVal) && !isNaN(endVal)) {
         // Linear interpolation based on time
-        const weight = (timestamps[j] - timestamps[startIdx]) / 
-                      (timestamps[endIdx] - timestamps[startIdx])
+        const weight =
+          (timestamps[j] - timestamps[startIdx]) / (timestamps[endIdx] - timestamps[startIdx])
         result[j] = startVal + (endVal - startVal) * weight
       } else if (!isNaN(startVal)) {
-        result[j] = startVal  // Forward fill
+        result[j] = startVal // Forward fill
       } else if (!isNaN(endVal)) {
-        result[j] = endVal    // Backward fill
+        result[j] = endVal // Backward fill
       } else {
-        result[j] = 0         // No good values, use 0
+        result[j] = 0 // No good values, use 0
       }
     }
   }
-  
+
   return result
 }


### PR DESCRIPTION
Adds hybrid spike detection and cleaning algorithm that:
- Detects and replaces extreme outliers (>1000% or <-95%)
- Uses statistical analysis (Hampel filter) for anomaly detection
- Applies contextual checks for values that deviate significantly from surroundings
- Interpolates replaced values using time-weighted linear interpolation

The cleaning is applied only to native rates from subgraphs, not reward rates from database. Handles edge cases like long runs of errors and prevents contamination of statistics.

Tested with production data containing 57,762% and -9,041% spikes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Reduced spurious spikes and implausible values in displayed rates via automatic outlier cleaning.
  - Normalized timestamps for consistent time alignment across rate data.
  - Ensured smoother, more stable rate curves when combining multiple sources.

- Refactor
  - Unified rate-cleaning across all rate aggregation paths for consistent behavior.

- Tests
  - Added comprehensive test coverage for rate-cleaning logic, including window-size inference, edge cases, and hybrid detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->