### PR TITLE
Enhance auth API with detailed JSDoc comments and improve variable handling

### DIFF
--- a/apps/earn-protocol-institutions/app/api/auth/refresh/route.ts
+++ b/apps/earn-protocol-institutions/app/api/auth/refresh/route.ts
@@ -11,16 +11,26 @@ import { getEnrichedUser } from '@/app/server-handlers/auth/user'
 import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from '@/constants/cookies'
 import { cognitoClient } from '@/features/auth/constants'
 
-async function serverRefreshToken(
+/**
+ * Refresh a token for a user
+ * @param refreshToken - The refresh token
+ * @param username - The username of the user
+ * @param secretHash - The secret hash
+ * @returns The access token and id token
+ */
+const serverRefreshToken = async (
   refreshToken: string,
   username: string,
   secretHash: string,
-): Promise<{ accessToken: string; idToken?: string }> {
-  if (!process.env.INSTITUTIONS_COGNITO_CLIENT_ID) {
+): Promise<{ accessToken: string; idToken?: string }> => {
+  const clientId = process.env.INSTITUTIONS_COGNITO_CLIENT_ID
+
+  if (!clientId) {
     throw new Error('Missing Cognito Client ID')
   }
+
   const command = new InitiateAuthCommand({
-    ClientId: process.env.INSTITUTIONS_COGNITO_CLIENT_ID,
+    ClientId: clientId,
     AuthFlow: 'REFRESH_TOKEN_AUTH',
     AuthParameters: {
       REFRESH_TOKEN: refreshToken,

--- a/apps/earn-protocol-institutions/hooks/useLogin.ts
+++ b/apps/earn-protocol-institutions/hooks/useLogin.ts
@@ -33,9 +33,9 @@ export const useLogin = () => {
       await signIn(email, password)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Sign in failed')
-    } finally {
       setIsLoading(false)
     }
+    // don't set isLoading to false in finally to avoid button flickering before redirect
   }
 
   const handleSetNewPassword = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Description
Refactor Institutions app authentication flows for clarity, safety, and UX. Adds JSDoc, improves env var handling, secures cookies in production, and prevents login button flicker.

## Changes
- Convert auth handlers to typed arrow functions with JSDoc:
  - `serverRefreshToken`, `serverSetNewPassword`, `serverSignIn`
- Validate and read env vars inside functions (safer runtime checks)
  - `INSTITUTIONS_COGNITO_CLIENT_ID`, `INSTITUTIONS_COGNITO_CLIENT_SECRET`
- Add `generateSecretHash` with input validation and safer env access
- Improve session helpers in `session.ts`:
  - Move `INSTITUTIONS_SESSION_SECRET` validation inside `createSession`/`readSession`
  - Convert to exported const arrow functions and add JSDoc
- Set cookies with `secure: process.env.NODE_ENV === 'production'`
- Safer token payload handling via local variables before validation
- UX: in `useLogin`, avoid `finally` to prevent button flicker before redirect

## Benefits
1. Safer env var usage and clearer error messages
2. More secure cookies in production environments
3. Better developer ergonomics via JSDoc and explicit return types
4. Smoother login UX without premature loading reset

## Testing
- Sign in with valid/invalid credentials; verify errors surface properly
- Trigger password set flow; ensure session and tokens are returned
- Refresh tokens; confirm new access token is set and cookies include `secure` in production
- Session lifecycle:
  - `createSession` creates cookie and encodes claims
  - `readSession` returns valid payload; handles missing/invalid token gracefully
  - `destroySession` clears cookie
- Verify login button doesn’t flicker during redirect

## Next steps
- Add unit tests for auth/server handlers and session helpers
- Centralize cookie option builder to avoid duplication
- Add rate limiting/abuse protection on auth endpoints

## Additional Notes
This refactor is non-breaking; it improves safety, maintainability, and UX without changing API contracts.