### PR TITLE
Update Merkl API configurations and refactor types for clarity

### DIFF
--- a/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
+++ b/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
@@ -1,21 +1,33 @@
 /**
- * Represents a single opportunity response
+ * Response type from Merkl API for users rewards
  */
 
-export type MerklOpportunityResponse = {
-  status: 'LIVE' | 'PAST'
-  rewardsRecord: MerklRewardsRecord
+export type MerklApiUsersResponse = MerklApiUser[]
+
+export type MerklApiUser = {
+  chain: MerklApiChain
+  rewards: MerklApiReward[]
 }
 
 /**
- * Array of opportunities responses
+ * Response type from Merkl API for opportunities
  */
-export type MerklOpportunitiesResponse = Array<MerklOpportunityResponse>
+export type MerklApiOpportunitiesResponse = MerklApiOpportunity[]
+
+export type MerklApiOpportunity = {
+  chainId: number
+  type: string
+  identifier: string
+  status: 'LIVE' | 'PAST'
+  dailyRewards: number
+  chain: MerklApiChain
+  rewardsRecord: MerklApiOpportunityRewardsRecord
+}
 
 /**
  * Complete rewards record structure
  */
-export interface MerklRewardsRecord {
+export interface MerklApiOpportunityRewardsRecord {
   /** Unique identifier for the rewards record */
   id: string
   /** Total rewards value */
@@ -23,15 +35,15 @@ export interface MerklRewardsRecord {
   /** Timestamp when the record was created */
   timestamp: string
   /** Array of individual reward breakdowns */
-  breakdowns: MerklRewardsBreakdown[]
+  breakdowns: MerklApiOpportunityRewardsRecordBreakdown[]
 }
 
 /**
  * Individual reward breakdown entry
  */
-export interface MerklRewardsBreakdown {
+export interface MerklApiOpportunityRewardsRecordBreakdown {
   /** Token information for this reward */
-  token: MerklRewardsToken
+  token: MerklApiOpportunityRewardsRecordBreakdownToken
   /** Amount of tokens as string (to handle large numbers) */
   amount: string
   /** USD value of the reward amount */
@@ -51,7 +63,7 @@ export interface MerklRewardsBreakdown {
 /**
  * Token information for rewards
  */
-export interface MerklRewardsToken {
+export interface MerklApiOpportunityRewardsRecordBreakdownToken {
   /** Unique identifier for the token */
   id: string
   /** Human-readable name of the token */
@@ -80,18 +92,47 @@ export interface MerklRewardsToken {
   price: number | null
 }
 
+export interface MerklApiChain {
+  id: number
+  name: string
+  icon: string
+  liveCampaigns: number
+}
+
+export interface MerklApiReward {
+  root: string
+  recipient: string
+  amount: string
+  claimed: string
+  pending: string
+  proofs: string[]
+  token: MerklApiToken
+  breakdowns: MerklApiRewardBreakdown[]
+}
+
+export type MerklApiToken = {
+  address: string
+  chainId: number
+  symbol: string
+  decimals: number
+  price: number
+}
+
+export interface MerklApiRewardBreakdown {
+  reason: string
+  amount: string
+  claimed: string
+  pending: string
+  campaignId: string
+  subCampaignId?: string
+}
+
 /**
  * Represents a Merkl reward for a user
  */
 export interface MerklReward {
   /** The token address for the reward */
-  token: {
-    chainId: number
-    address: string
-    symbol: string
-    decimals: number
-    price: number
-  }
+  token: MerklApiToken
   /** The merkle root for the reward */
   root: string
   /** The recipient address */
@@ -104,4 +145,6 @@ export interface MerklReward {
   pending: string
   /** The merkle proofs for claiming */
   proofs: string[]
+  /** Breakdown of the reward into components */
+  breakdowns: MerklApiRewardBreakdown[]
 }

--- a/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
+++ b/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
@@ -2,6 +2,8 @@
  * Response type from Merkl API for users rewards
  */
 
+import type { ChainId, AddressValue } from '@summerfi/sdk-common'
+
 export type MerklApiUsersResponse = MerklApiUser[]
 
 export type MerklApiUser = {
@@ -146,5 +148,15 @@ export interface MerklReward {
   /** The merkle proofs for claiming */
   proofs: string[]
   /** Breakdown of the reward into components */
-  breakdowns: MerklApiRewardBreakdown[]
+  breakdowns: Record<
+    ChainId,
+    Record<
+      AddressValue,
+      {
+        total: string
+        claimable: string
+        claimed: string
+      }
+    >
+  >
 }

--- a/sdk/armada-protocol-common/src/index.ts
+++ b/sdk/armada-protocol-common/src/index.ts
@@ -64,9 +64,15 @@ export {
 export type { IArmadaManagerMerklRewards } from './common/interfaces/IArmadaManagerMerklRewards'
 export type {
   MerklReward,
-  MerklRewardsBreakdown,
-  MerklRewardsRecord,
-  MerklOpportunitiesResponse,
-  MerklOpportunityResponse,
-  MerklRewardsToken,
+  MerklApiOpportunitiesResponse,
+  MerklApiOpportunity,
+  MerklApiOpportunityRewardsRecord,
+  MerklApiOpportunityRewardsRecordBreakdown,
+  MerklApiOpportunityRewardsRecordBreakdownToken,
+  MerklApiUsersResponse,
+  MerklApiUser,
+  MerklApiChain,
+  MerklApiReward,
+  MerklApiRewardBreakdown,
+  MerklApiToken,
 } from './common/types/MerklTypes'

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManager.ts
@@ -94,6 +94,12 @@ export class ArmadaManager implements IArmadaManager {
     this._hubChainInfo = getChainInfoByChainId(Number(_hubChainId))
     this._rewardsRedeemerAddress = getDeployedRewardsRedeemerAddress()
 
+    this.merklRewards = new ArmadaManagerMerklRewards({
+      supportedChains: this._supportedChains,
+      blockchainClientProvider: this._blockchainClientProvider,
+      deploymentProvider: this._deploymentProvider,
+      tokensManager: this._tokensManager,
+    })
     this.utils = new ArmadaManagerUtils({
       configProvider: this._configProvider,
       allowanceManager: this._allowanceManager,
@@ -104,12 +110,7 @@ export class ArmadaManager implements IArmadaManager {
       subgraphManager: this._subgraphManager,
       swapManager: this._swapManager,
       deploymentProvider: this._deploymentProvider,
-    })
-    this.merklRewards = new ArmadaManagerMerklRewards({
-      supportedChains: this._supportedChains,
-      blockchainClientProvider: this._blockchainClientProvider,
-      deploymentProvider: this._deploymentProvider,
-      tokensManager: this._tokensManager,
+      getUserMerklRewards: this.merklRewards.getUserMerklRewards.bind(this.merklRewards),
     })
     this.claims = new ArmadaManagerClaims({
       ...params,

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
@@ -2,6 +2,7 @@ import {
   isTestDeployment,
   type IArmadaManagerMerklRewards,
   type IArmadaManagerUtils,
+  type MerklApiUsersResponse,
   type MerklReward,
 } from '@summerfi/armada-protocol-common'
 import {
@@ -24,38 +25,6 @@ import { getMerklDistributorContractAddress } from './configs/merkl-distributor-
 import { AdmiralsQuartersAbi } from '@summerfi/armada-protocol-abis'
 import type { IDeploymentProvider } from '../..'
 import type { ITokensManager } from '@summerfi/tokens-common'
-
-/**
- * Response type from Merkl API for user rewards
- */
-
-interface MerklApiChain {
-  id: number
-  name: string
-  icon: string
-  liveCampaigns: number
-}
-
-interface MerklApiReward {
-  token: {
-    chainId: number
-    address: string
-    symbol: string
-    decimals: number
-    price: number
-  }
-  root: string
-  recipient: string
-  amount: string
-  claimed: string
-  pending: string
-  proofs: string[]
-}
-
-type MerklApiResponse = {
-  chain: MerklApiChain
-  rewards: MerklApiReward[]
-}[]
 
 /**
  * @name ArmadaManagerMerklRewards
@@ -119,7 +88,7 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
         throw new Error(`Merkl API request failed: ${response.status} ${response.statusText}`)
       }
 
-      const data = (await response.json()) as MerklApiResponse
+      const data = (await response.json()) as MerklApiUsersResponse
 
       if (!data || !Array.isArray(data)) {
         LoggingService.debug('Invalid response from Merkl API', { data })
@@ -156,6 +125,7 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
             claimed: reward.claimed,
             pending: reward.pending,
             proofs: reward.proofs,
+            breakdowns: reward.breakdowns,
           })
         }
 

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
@@ -188,17 +188,21 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
       const vault = getVaultByMerklCampaignId(breakdown.campaignId)
       if (!vault) continue
       const { chainId, fleetAddress } = vault
-      const perChain =
-        resultByChain[chainId] ||
-        ({} as Record<AddressValue, { total: string; claimable: string; claimed: string }>)
-      const prev = perChain[fleetAddress]
+      // Normalize fleet address to ensure consistent key usage
+      const normalizedFleetAddress = fleetAddress.toLowerCase() as AddressValue
+      // Ensure perChain map exists for this chainId
+      const perChain = (resultByChain[chainId] ||= {} as Record<
+        AddressValue,
+        { total: string; claimable: string; claimed: string }
+      >)
+      const prev = perChain[normalizedFleetAddress]
       const total = prev
         ? new BigNumber(prev.total).plus(breakdown.amount)
         : new BigNumber(breakdown.amount)
       const claimed = prev
         ? new BigNumber(prev.claimed).plus(breakdown.claimed)
         : new BigNumber(breakdown.claimed)
-      perChain[fleetAddress] = {
+      perChain[normalizedFleetAddress] = {
         total: total.toString(),
         claimable: total.minus(claimed).toString(),
         claimed: claimed.toString(),

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerUtils.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerUtils.ts
@@ -4,6 +4,7 @@ import {
   getDeployedRewardsRedeemerAddress,
   isTestDeployment,
   type IArmadaManagerUtils,
+  type IArmadaManagerMerklRewards,
 } from '@summerfi/armada-protocol-common'
 import { IConfigurationProvider } from '@summerfi/configuration-provider-common'
 import { IContractsProvider } from '@summerfi/contracts-provider-common'
@@ -57,6 +58,9 @@ export class ArmadaManagerUtils implements IArmadaManagerUtils {
   private _oracleManager: IOracleManager
   private _tokensManager: ITokensManager
   private _deploymentProvider: IDeploymentProvider
+  private _getUserMerklRewards: (
+    params: Parameters<IArmadaManagerMerklRewards['getUserMerklRewards']>[0],
+  ) => ReturnType<IArmadaManagerMerklRewards['getUserMerklRewards']>
 
   /** CONSTRUCTOR */
   constructor(params: {
@@ -69,6 +73,9 @@ export class ArmadaManagerUtils implements IArmadaManagerUtils {
     oracleManager: IOracleManager
     tokensManager: ITokensManager
     deploymentProvider: IDeploymentProvider
+    getUserMerklRewards: (
+      params: Parameters<IArmadaManagerMerklRewards['getUserMerklRewards']>[0],
+    ) => ReturnType<IArmadaManagerMerklRewards['getUserMerklRewards']>
   }) {
     this._configProvider = params.configProvider
     this._allowanceManager = params.allowanceManager
@@ -79,6 +86,7 @@ export class ArmadaManagerUtils implements IArmadaManagerUtils {
     this._oracleManager = params.oracleManager
     this._tokensManager = params.tokensManager
     this._deploymentProvider = params.deploymentProvider
+    this._getUserMerklRewards = params.getUserMerklRewards
 
     this._supportedChains = this._configProvider
       .getConfigurationItem({
@@ -154,6 +162,7 @@ export class ArmadaManagerUtils implements IArmadaManagerUtils {
       query: await this._subgraphManager.getUserPositions({ user }),
       summerToken,
       getTokenBySymbol,
+      getUserMerklRewards: this._getUserMerklRewards,
     })
   }
 
@@ -173,6 +182,7 @@ export class ArmadaManagerUtils implements IArmadaManagerUtils {
       query: await this._subgraphManager.getUserPosition({ user, fleetAddress }),
       summerToken,
       getTokenBySymbol,
+      getUserMerklRewards: this._getUserMerklRewards,
     })
   }
 
@@ -188,6 +198,7 @@ export class ArmadaManagerUtils implements IArmadaManagerUtils {
       query: await this._subgraphManager.getPosition({ positionId: params.positionId }),
       summerToken,
       getTokenBySymbol,
+      getUserMerklRewards: this._getUserMerklRewards,
     })
   }
 

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerVaults.ts
@@ -5,7 +5,7 @@ import {
   createWithdrawTransaction,
   type IArmadaManagerUtils,
   createVaultSwitchTransaction,
-  type MerklOpportunitiesResponse,
+  type MerklApiOpportunitiesResponse,
 } from '@summerfi/armada-protocol-common'
 import type { IBlockchainClientProvider } from '@summerfi/blockchain-client-common'
 import { AdmiralsQuartersAbi } from '@summerfi/armada-protocol-abis'
@@ -1832,7 +1832,7 @@ export class ArmadaManagerVaults implements IArmadaManagerVaults {
     const rewardsManagerAddresses = vaultsData.map((vault) => vault.vault?.rewardsManager.id)
     // find opportunities by querying merkl api using rewards manager address as id
     const url = `https://api.merkl.xyz/v4/opportunities?identifier={{identifier}}&chainId=${chainId}`
-    const opportunitiesPerVault: MerklOpportunitiesResponse[] = await Promise.all(
+    const opportunitiesPerVault: MerklApiOpportunitiesResponse[] = await Promise.all(
       rewardsManagerAddresses.map((address) =>
         address
           ? fetch(url.replace('{{identifier}}', address)).then((res) => {

--- a/sdk/armada-protocol-service/src/common/implementation/configs/vaultByMerklCampaignId.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/configs/vaultByMerklCampaignId.ts
@@ -1,4 +1,4 @@
-import type { ChainId, AddressValue } from '@summerfi/sdk-common/index'
+import type { ChainId, AddressValue } from '@summerfi/sdk-common'
 // parsed with
 // Object.fromEntries(d.map(c => ([c.campaignId, {chainId: c.computeChainId,fleetAddress: c.params.vaultAddress?.toLowerCase() || c.params.targetToken?.toLowerCase()}])))
 const vaultsByCampaignId: Record<string, { chainId: ChainId; fleetAddress: AddressValue }> = {

--- a/sdk/armada-protocol-service/src/common/implementation/configs/vaultByMerklCampaignId.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/configs/vaultByMerklCampaignId.ts
@@ -1,0 +1,93 @@
+import type { ChainId, AddressValue } from '@summerfi/sdk-common/index'
+// parsed with
+// Object.fromEntries(d.map(c => ([c.campaignId, {chainId: c.computeChainId,fleetAddress: c.params.vaultAddress?.toLowerCase() || c.params.targetToken?.toLowerCase()}])))
+const vaultsByCampaignId: Record<string, { chainId: ChainId; fleetAddress: AddressValue }> = {
+  '4750370497051111624': {
+    chainId: 42161,
+    fleetAddress: '0xb1a851b8c70a4749408754d398702153a61dfc78',
+  },
+  '0x4242d091559422e460fa5ecc9e69bd0a9118ab22901756981cfc63cc3ef483a7': {
+    chainId: 8453,
+    fleetAddress: '0x98c49e13bf99d7cad8069faa2a370933ec9ecf17',
+  },
+  '4665638834234154336': {
+    chainId: 8453,
+    fleetAddress: '0xb1a851b8c70a4749408754d398702153a61dfc78',
+  },
+  '4597408534685042831': {
+    chainId: 1,
+    fleetAddress: '0xdf8dfc3c051c88e62bb5d81819f312f15d5414a1',
+  },
+  '0x726b675e5381e42f321c499b8e5bfd3c7a04edb89bdaafc027228829228a8444': {
+    chainId: 8453,
+    fleetAddress: '0x64db8f51f1bf7064bb5a361a7265f602d348e0f0',
+  },
+  '0xf3f4b21c4a3397148f77355047011bcf3ae97e85a4de02a00d141f72a60acf6a': {
+    chainId: 8453,
+    fleetAddress: '0x2bb9ad69feba5547b7cd57aafe8457d40bf834af',
+  },
+  '428494664685285825': {
+    chainId: 1,
+    fleetAddress: '0x7a49e6c6c64b32b7e89bd9c0de121165977c422d',
+  },
+  '1936160081885606219': {
+    chainId: 8453,
+    fleetAddress: '0x7a49e6c6c64b32b7e89bd9c0de121165977c422d',
+  },
+  '0xc8a50ce913838a3d7651c11777fe6bcfa01d12f28a80c5ace1c956321554708a': {
+    chainId: 42161,
+    fleetAddress: '0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58',
+  },
+  '0xdde5191a70cdf006d1b37ec526bc4d20c4d806612c42ea0060d9e1dc188585c6': {
+    chainId: 1,
+    fleetAddress: '0x2e6abcbcced9af05bc3b8a4908e0c98c29a88e10',
+  },
+  '0x738289d6e153b8ac3ae284c2f17eb5c8c7c8386c968b5cb6a52e9768ac19113e': {
+    chainId: 1,
+    fleetAddress: '0x98c49e13bf99d7cad8069faa2a370933ec9ecf17',
+  },
+  '10565144708732355975': {
+    chainId: 8453,
+    fleetAddress: '0xdf8dfc3c051c88e62bb5d81819f312f15d5414a1',
+  },
+  '8730067419425724421': {
+    chainId: 42161,
+    fleetAddress: '0x8dca3e548c8b80c93ee8404cfc3ca46010c81679',
+  },
+  '0x9bd792a717a5eb880d4cdee0fe570cfc45662f9a3c873c3fe7568b690b98b106': {
+    chainId: 42161,
+    fleetAddress: '0x98c49e13bf99d7cad8069faa2a370933ec9ecf17',
+  },
+  '1056369275858719998': {
+    chainId: 146,
+    fleetAddress: '0x322bba211f7160bf1f220da08abbea76d7f4b578',
+  },
+  '0x2c6ad88e62bab15f13ea90a58b42094db8cdc2a4cd55b87f7531c2ecab189dec': {
+    chainId: 146,
+    fleetAddress: '0x507a2d9e87dbd3076e65992049c41270b47964f8',
+  },
+  '9182768833879779011': {
+    chainId: 1,
+    fleetAddress: '0xc1768910a0e22a282f1d36725ab2eb29de5334f4',
+  },
+  '0xd79c56220b553ab269a80462ca168432aba8ecd5b802439b6543dbb1d2ce51cf': {
+    chainId: 1,
+    fleetAddress: '0x17ee2d03e88b55e762c66c76ec99c3a28a54ad8d',
+  },
+  '0x7c84024a87871193adb9cb494c0d55980411c47eb6ecedf262f99c671b496d6d': {
+    chainId: 1,
+    fleetAddress: '0xe9cda459bed6dcfb8ac61cd8ce08e2d52370cb06',
+  },
+  '0x7b3fea42e10871a09b29a3c8b3fed2404a88c2e785c17a178cd2427aa1af59c6': {
+    chainId: 1,
+    fleetAddress: '0x67e536797570b3d8919df052484273815a0ab506',
+  },
+}
+
+export function getVaultByMerklCampaignId(
+  campaignId: string,
+): { chainId: ChainId; fleetAddress: AddressValue } | undefined {
+  const vault = vaultsByCampaignId[campaignId]
+
+  return vault
+}

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -62,12 +62,9 @@ export const mapGraphDataToArmadaPosition =
           return acc
         }
         // Use BigNumber to safely parse decimal strings before converting to BigInt
-        const claimableBN = new BigNumber(positionRewards.claimable || '0')
-        const claimedBN = new BigNumber(positionRewards.claimed || '0')
         return {
-          claimableSummerToken:
-            acc.claimableSummerToken + BigInt(claimableBN.integerValue().toString()),
-          claimedSummerToken: acc.claimedSummerToken + BigInt(claimedBN.integerValue().toString()),
+          claimableSummerToken: acc.claimableSummerToken + BigInt(positionRewards.claimable || '0'),
+          claimedSummerToken: acc.claimedSummerToken + BigInt(positionRewards.claimed || '0'),
         }
       },
       { claimableSummerToken: 0n, claimedSummerToken: 0n },

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -51,13 +51,14 @@ export const mapGraphDataToArmadaPosition =
 
     const merklSummerRewardsForPosition = merklSummerRewards.perChain[chainInfo.chainId]?.reduce(
       (acc, reward) => {
-        const positionRewards = reward.breakdowns[chainInfo.chainId][position.id as AddressValue]
+        const vaultKey = position.vault.id.toLowerCase() as AddressValue
+        const positionRewards = reward.breakdowns[chainInfo.chainId][vaultKey]
         if (positionRewards == null) {
           return acc
         }
         return {
-          claimableSummerToken: acc.claimableSummerToken + BigInt(positionRewards.claimable || 0n),
-          claimedSummerToken: acc.claimedSummerToken + BigInt(positionRewards.claimed || 0n),
+          claimableSummerToken: acc.claimableSummerToken + BigInt(positionRewards.claimable),
+          claimedSummerToken: acc.claimedSummerToken + BigInt(positionRewards.claimed),
         }
       },
       { claimableSummerToken: 0n, claimedSummerToken: 0n },

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -68,15 +68,15 @@ export const mapGraphDataToArmadaPosition =
       },
       { claimableSummerToken: 0n, claimedSummerToken: 0n },
     )
-    const claimedSummerToken = TokenAmount.createFrom({
-      amount: BigNumber(position.claimedSummerTokenNormalized || '0')
+    const claimedSummerToken = TokenAmount.createFromBaseUnit({
+      amount: BigNumber(position.claimedSummerToken || '0')
         .plus(merklSummerRewardsForPosition?.claimedSummerToken.toString() || '0')
         .toString(),
       token: summerToken,
     })
 
-    const claimableSummerToken = TokenAmount.createFrom({
-      amount: BigNumber(position.claimableSummerTokenNormalized || '0')
+    const claimableSummerToken = TokenAmount.createFromBaseUnit({
+      amount: BigNumber(position.claimableSummerToken || '0')
         .plus(merklSummerRewardsForPosition?.claimableSummerToken.toString() || '0')
         .toString(),
       token: summerToken,

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -61,7 +61,6 @@ export const mapGraphDataToArmadaPosition =
         if (positionRewards == null) {
           return acc
         }
-        // Use BigNumber to safely parse decimal strings before converting to BigInt
         return {
           claimableSummerToken: acc.claimableSummerToken + BigInt(positionRewards.claimable || '0'),
           claimedSummerToken: acc.claimedSummerToken + BigInt(positionRewards.claimed || '0'),

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionQuery.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionQuery.ts
@@ -31,7 +31,7 @@ export const parseGetUserPositionQuery = async ({
     rewardsTokensAddresses: [summerToken.address.value],
   })
 
-  const armadaPositions = query.positions.map(
+  const armadaPositions = (query.positions ?? []).map(
     mapGraphDataToArmadaPosition({
       user,
       chainInfo,

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionQuery.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionQuery.ts
@@ -19,6 +19,10 @@ export const parseGetUserPositionQuery = ({
   getTokenBySymbol: (params: { chainInfo: IChainInfo; symbol: string }) => IToken
 }): IArmadaPosition | undefined => {
   const chainInfo = user.chainInfo
+  // TODO: pass a callback to fetch merkl rewards (rewards manager => getUserMerklRewards)
+  // in the response parse campaigns breakdowns data
+  // then map each campaign data to their respective vault
+
   const armadaPositions = query.positions.map(
     mapGraphDataToArmadaPosition({ user, chainInfo, summerToken, getTokenBySymbol }),
   )

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionQuery.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionQuery.ts
@@ -4,7 +4,7 @@ import {
   type IToken,
   type IUser,
 } from '@summerfi/sdk-common'
-import type { GetUserPositionQuery } from '@summerfi/subgraph-manager-common'
+import type { GetUserPositionQuery, GetPositionQuery } from '@summerfi/subgraph-manager-common'
 import { mapGraphDataToArmadaPosition } from './mapGraphDataToArmadaPosition'
 import type { IArmadaManagerMerklRewards } from '@summerfi/armada-protocol-common'
 
@@ -16,7 +16,7 @@ export const parseGetUserPositionQuery = async ({
   getUserMerklRewards,
 }: {
   user: IUser
-  query: GetUserPositionQuery
+  query: GetUserPositionQuery | GetPositionQuery
   summerToken: IToken
   getTokenBySymbol: (params: { chainInfo: IChainInfo; symbol: string }) => IToken
   getUserMerklRewards: (

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionsQuery.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/parseGetUserPositionsQuery.ts
@@ -6,20 +6,38 @@ import {
 } from '@summerfi/sdk-common'
 import type { GetUserPositionsQuery } from '@summerfi/subgraph-manager-common'
 import { mapGraphDataToArmadaPosition } from './mapGraphDataToArmadaPosition'
+import type { IArmadaManagerMerklRewards } from '@summerfi/armada-protocol-common'
 
-export const parseGetUserPositionsQuery = ({
+export const parseGetUserPositionsQuery = async ({
   user,
   query,
   summerToken,
   getTokenBySymbol,
+  getUserMerklRewards,
 }: {
   user: IUser
   query: GetUserPositionsQuery
   summerToken: IToken
   getTokenBySymbol: (params: { chainInfo: IChainInfo; symbol: string }) => IToken
-}): IArmadaPosition[] => {
+  getUserMerklRewards: (
+    params: Parameters<IArmadaManagerMerklRewards['getUserMerklRewards']>[0],
+  ) => ReturnType<IArmadaManagerMerklRewards['getUserMerklRewards']>
+}): Promise<IArmadaPosition[]> => {
   const chainInfo = user.chainInfo
+
+  const merklSummerRewards = await getUserMerklRewards({
+    address: user.wallet.address.value,
+    chainIds: [user.chainInfo.chainId],
+    rewardsTokensAddresses: [summerToken.address.value],
+  })
+
   return query.positions.map(
-    mapGraphDataToArmadaPosition({ user, chainInfo, summerToken, getTokenBySymbol }),
+    mapGraphDataToArmadaPosition({
+      user,
+      chainInfo,
+      summerToken,
+      getTokenBySymbol,
+      merklSummerRewards,
+    }),
   )
 }

--- a/sdk/armada-protocol-service/src/common/implementation/http/merkl/opportunities.http
+++ b/sdk/armada-protocol-service/src/common/implementation/http/merkl/opportunities.http
@@ -12,4 +12,4 @@ https://api.merkl.xyz/v4/opportunities/{{opportunityId}}
 
 ### by Identifier (rewards manager)
 @identifier = 0xB1A851b8c70A4749408754d398702153A61DFc78
-https://api.merkl.xyz/v4/opportunities?identifier={{identifier}}
+https://api.merkl.xyz/v4/opportunities?identifier={{identifier}}&chainId=8453

--- a/sdk/armada-protocol-service/src/common/implementation/http/merkl/users.http
+++ b/sdk/armada-protocol-service/src/common/implementation/http/merkl/users.http
@@ -1,5 +1,6 @@
 # @address = 0x38233654FB0843c8024527682352A5d41E7f7324
-@address = 0xE9c245293DAC615c11A5bF26FCec91C3617645E4
+# @address = 0xE9c245293DAC615c11A5bF26FCec91C3617645E4
+@address = 0xDDc68f9dE415ba2fE2FD84bc62Be2d2CFF1098dA
 @chain_id = 1,8453,42161,146
 
 https://api.merkl.xyz/v4/users/{{address}}/rewards

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -32,7 +32,8 @@ describe('Armada Protocol - User', () => {
   const fleetAddress = ethFleet
 
   const sdk: SDKManager = makeSDK({
-    apiDomainUrl: SDKApiUrl,
+    // apiDomainUrl: SDKApiUrl,
+    apiDomainUrl: 'https://summer.fi',
   })
   if (!rpcUrl) {
     throw new Error('Missing rpc url')
@@ -95,19 +96,25 @@ describe('Armada Protocol - User', () => {
     )
   })
 
-  it.only(`should get user merkl rewards`, async () => {
+  it.skip(`should get user merkl rewards`, async () => {
     const rewards = await sdk.armada.users.getUserMerklRewards({
       address: user.wallet.address.value,
     })
     console.log('User Merkle rewards:', JSON.stringify(rewards, null, 2))
   })
 
-  it.skip(`should get user fleet and staked balance for vault: ${fleetAddress.value}`, async () => {
-    // const _user = User.createFromEthereum(
-    //   ChainIds.Base,
-    //   '0x4eb7f19d6efcace59eaed70220da5002709f9b71',
-    // )
-    const _user = user
+  it.only(`should get user fleet and staked balance for vault: ${fleetAddress.value}`, async () => {
+    // const _user = user
+    const _user = User.createFromEthereum(
+      ChainIds.ArbitrumOne,
+      '0xDDc68f9dE415ba2fE2FD84bc62Be2d2CFF1098dA',
+    )
+    const vaultId = ArmadaVaultId.createFrom({
+      chainInfo: getChainInfoByChainId(ChainIds.ArbitrumOne),
+      fleetAddress: Address.createFromEthereum({
+        value: '0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58',
+      }),
+    })
 
     const fleetAmountBefore = await sdk.armada.users.getFleetBalance({
       user: _user,

--- a/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.user.test.ts
@@ -32,8 +32,7 @@ describe('Armada Protocol - User', () => {
   const fleetAddress = ethFleet
 
   const sdk: SDKManager = makeSDK({
-    // apiDomainUrl: SDKApiUrl,
-    apiDomainUrl: 'https://summer.fi',
+    apiDomainUrl: SDKApiUrl,
   })
   if (!rpcUrl) {
     throw new Error('Missing rpc url')

--- a/sdk/subgraph-manager-common/src/generated/client.ts
+++ b/sdk/subgraph-manager-common/src/generated/client.ts
@@ -11501,7 +11501,7 @@ export type GetUserPositionsQueryVariables = Exact<{
 }>;
 
 
-export type GetUserPositionsQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, claimedSummerTokenNormalized: string, claimableSummerTokenNormalized: string, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, rebalanceCount: bigint, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string }, rewards: Array<{ __typename?: 'PositionRewards', claimedNormalized: string, claimableNormalized: string, rewardToken: { __typename?: 'Token', symbol: string, lastPriceUSD?: string | null } }> }> };
+export type GetUserPositionsQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, claimedSummerToken: bigint, claimableSummerToken: bigint, claimedSummerTokenNormalized: string, claimableSummerTokenNormalized: string, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, rebalanceCount: bigint, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string }, rewards: Array<{ __typename?: 'PositionRewards', claimedNormalized: string, claimableNormalized: string, rewardToken: { __typename?: 'Token', symbol: string, lastPriceUSD?: string | null } }> }> };
 
 export type GetUserPositionQueryVariables = Exact<{
   accountAddress: Scalars['String']['input'];
@@ -11509,14 +11509,14 @@ export type GetUserPositionQueryVariables = Exact<{
 }>;
 
 
-export type GetUserPositionQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, claimedSummerTokenNormalized: string, claimableSummerTokenNormalized: string, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string }, rewards: Array<{ __typename?: 'PositionRewards', claimedNormalized: string, claimableNormalized: string, rewardToken: { __typename?: 'Token', symbol: string, lastPriceUSD?: string | null } }> }> };
+export type GetUserPositionQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, claimedSummerToken: bigint, claimableSummerToken: bigint, claimedSummerTokenNormalized: string, claimableSummerTokenNormalized: string, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string }, rewards: Array<{ __typename?: 'PositionRewards', claimedNormalized: string, claimableNormalized: string, rewardToken: { __typename?: 'Token', symbol: string, lastPriceUSD?: string | null } }> }> };
 
 export type GetPositionQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetPositionQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, claimedSummerTokenNormalized: string, claimableSummerTokenNormalized: string, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string }, rewards: Array<{ __typename?: 'PositionRewards', claimedNormalized: string, claimableNormalized: string, rewardToken: { __typename?: 'Token', symbol: string, lastPriceUSD?: string | null } }> }> };
+export type GetPositionQuery = { __typename?: 'Query', positions: Array<{ __typename?: 'Position', id: string, inputTokenBalance: bigint, outputTokenBalance: bigint, stakedInputTokenBalance: bigint, stakedOutputTokenBalance: bigint, createdTimestamp: bigint, claimedSummerToken: bigint, claimableSummerToken: bigint, claimedSummerTokenNormalized: string, claimableSummerTokenNormalized: string, deposits: Array<{ __typename?: 'Deposit', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, withdrawals: Array<{ __typename?: 'Withdraw', amount: bigint, amountUSD: string, inputTokenBalance: bigint, timestamp: bigint }>, vault: { __typename?: 'Vault', id: string, inputTokenBalance: bigint, inputTokenPriceUSD?: string | null, outputTokenPriceUSD?: string | null, inputToken: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number }, outputToken?: { __typename?: 'Token', id: string, symbol: string, name: string, decimals: number } | null, protocol: { __typename?: 'YieldAggregator', id: string } }, account: { __typename?: 'Account', id: string }, rewards: Array<{ __typename?: 'PositionRewards', claimedNormalized: string, claimableNormalized: string, rewardToken: { __typename?: 'Token', symbol: string, lastPriceUSD?: string | null } }> }> };
 
 export type GetRebalancesQueryVariables = Exact<{
   timestamp?: InputMaybe<Scalars['BigInt']['input']>;
@@ -11731,6 +11731,8 @@ export const GetUserPositionsDocument = gql`
     account {
       id
     }
+    claimedSummerToken
+    claimableSummerToken
     claimedSummerTokenNormalized
     claimableSummerTokenNormalized
     rewards {
@@ -11789,6 +11791,8 @@ export const GetUserPositionDocument = gql`
     account {
       id
     }
+    claimedSummerToken
+    claimableSummerToken
     claimedSummerTokenNormalized
     claimableSummerTokenNormalized
     rewards {
@@ -11847,6 +11851,8 @@ export const GetPositionDocument = gql`
     account {
       id
     }
+    claimedSummerToken
+    claimableSummerToken
     claimedSummerTokenNormalized
     claimableSummerTokenNormalized
     rewards {

--- a/sdk/subgraph-manager-common/src/queries/positions.graphql
+++ b/sdk/subgraph-manager-common/src/queries/positions.graphql
@@ -43,6 +43,8 @@ query GetUserPositions($accountAddress: String!) {
     account {
       id
     }
+    claimedSummerToken
+    claimableSummerToken
     claimedSummerTokenNormalized
     claimableSummerTokenNormalized
     rewards {
@@ -100,6 +102,8 @@ query GetUserPosition($accountAddress: String!, $vaultId: String!) {
     account {
       id
     }
+    claimedSummerToken
+    claimableSummerToken
     claimedSummerTokenNormalized
     claimableSummerTokenNormalized
     rewards {
@@ -157,6 +161,8 @@ query GetPosition($id: ID!) {
     account {
       id
     }
+    claimedSummerToken
+    claimableSummerToken
     claimedSummerTokenNormalized
     claimableSummerTokenNormalized
     rewards {


### PR DESCRIPTION
Enhance the Merkl API integration by adding a `chainId` parameter to HTTP requests and improving type definitions for user rewards and opportunities. This refactor aims to provide better clarity and consistency in the API response handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-vault Merkl reward breakdowns added; Merkl rewards now flow into user positions, improving claimed/claimable totals.

- Refactor
  - Public Merkl types reorganized to a new API-centric schema (breaking change for integrators).

- Chores
  - Merkl HTTP calls refined (identifier endpoint chain-scoped; user rewards queries add chainId & claimable-only); example address updated; campaign→vault lookup registry added.
  - E2E: Merkl rewards test disabled and user/vault test adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->