### PR TITLE
Better mixpanel events filtering

### DIFF
--- a/apps/earn-protocol/app/api/t/route.ts
+++ b/apps/earn-protocol/app/api/t/route.ts
@@ -3,6 +3,136 @@ import { EarnProtocolEventNames } from '@summerfi/app-types'
 import { snakeCase } from 'lodash-es'
 import { type NextRequest, NextResponse } from 'next/server'
 
+const NAME_VALIDATOR = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u
+// eslint-disable-next-line no-useless-escape
+const SAFE_STRING_RE = /^[A-Za-z0-9\-\._\$]+$/u
+const IS_NUMERIC = /^\d+(\.\d+)?$/u
+const MAX_NAME_LENGTH = 100
+const SANITIZED_TOKEN = '[sanitized]'
+
+const isValidName = (value: unknown) => {
+  if (typeof value !== 'string') return false
+  const v = value.trim()
+
+  if (v.length === 0 || v.length > MAX_NAME_LENGTH) return false
+
+  return NAME_VALIDATOR.test(v)
+}
+
+const sanitizeNamesInObject = (input: unknown): unknown => {
+  if (Array.isArray(input)) return input.map(sanitizeNamesInObject)
+  if (input && typeof input === 'object') {
+    const obj = input as { [key: string]: unknown }
+    const out: { [key: string]: unknown } = {}
+
+    for (const [k, v] of Object.entries(obj)) {
+      if (k.toLowerCase().includes('name')) {
+        out[k] = isValidName(v) ? v : SANITIZED_TOKEN
+      } else {
+        out[k] = sanitizeNamesInObject(v)
+      }
+    }
+
+    return out
+  }
+
+  return input
+}
+
+const containsSanitized = (input: unknown): boolean => {
+  if (input === SANITIZED_TOKEN) return true
+  if (Array.isArray(input)) return input.some(containsSanitized)
+  if (input && typeof input === 'object') {
+    return Object.values(input as { [key: string]: unknown }).some(containsSanitized)
+  }
+
+  return false
+}
+
+const isValidUrl = (value: unknown) => {
+  if (typeof value !== 'string') return false
+  const v = value.trim()
+
+  if (v.length === 0 || v.length > 2000) return false
+  try {
+    const parsed = new URL(v)
+
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+const isSafeString = (value: unknown) => {
+  if (value === null) return true
+  if (typeof value !== 'string') return false
+  const v = value.trim()
+
+  if (v.length === 0 || v.length > 200) return false
+
+  return SAFE_STRING_RE.test(v)
+}
+
+const isNumericOrNumericString = (value: unknown) => {
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (typeof value === 'string') return IS_NUMERIC.test(value.trim())
+
+  return false
+}
+
+const isValidScreenDimension = (value: unknown) => {
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0 && value < 20000
+  if (typeof value === 'string') {
+    const n = Number(value)
+
+    return Number.isFinite(n) && n > 0 && n < 20000 && /^\d+$/u.test(value.trim())
+  }
+
+  return false
+}
+
+const validateSpecialKeys = (obj: { [key: string]: unknown }) => {
+  // $current_url handled separately
+  const check = (key: string, validator: (v: unknown) => boolean) => {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      return validator(obj[key])
+    }
+
+    return true
+  }
+
+  // $browser: safe string or null
+  if (!check('$browser', isSafeString)) return false
+
+  // $browser_version: number or numeric string or null
+  if (!check('$browser_version', (v) => v === null || isNumericOrNumericString(v))) return false
+
+  // $initial_referrer & $initial_referring_domain: safe strings (allow "$direct")
+  if (
+    !check(
+      '$initial_referrer',
+      (v) => v === null || (typeof v === 'string' && (v === '$direct' || isSafeString(v))),
+    )
+  )
+    return false
+  if (
+    !check(
+      '$initial_referring_domain',
+      (v) => v === null || (typeof v === 'string' && (v === '$direct' || isSafeString(v))),
+    )
+  )
+    return false
+
+  // $mobile: boolean or null
+  if (!check('$mobile', (v) => v === null || typeof v === 'boolean')) return false
+
+  // screen height/width: numbers
+  if (!check('$screen_height', (v) => v === null || isValidScreenDimension(v))) return false
+  if (!check('$screen_width', (v) => v === null || isValidScreenDimension(v))) return false
+
+  return true
+}
+
 export const revalidate = 0
 
 const skipArtificialTrackingOS = [
@@ -26,13 +156,52 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ status: 400 })
     }
 
+    const wholeEventBody = {
+      ...eventBody,
+      ...Object.keys(rest).reduce(
+        (a, v) => ({
+          ...a,
+          [`$${snakeCase(v)}`]: rest[v],
+        }),
+        {},
+      ),
+    }
+
+    // --- sanitizer & blocking logic (uses top-level utilities) ---
+    const sanitizedEventBody = sanitizeNamesInObject(wholeEventBody) as { [key: string]: unknown }
+
+    // Validate $current_url when present and reject if invalid
+    const currentUrlValue = sanitizedEventBody.$current_url
+
+    if (currentUrlValue !== undefined && !isValidUrl(currentUrlValue)) {
+      return NextResponse.json({ status: 400 })
+    }
+
+    // validate other special keys
+    if (!validateSpecialKeys(sanitizedEventBody)) {
+      return NextResponse.json({ status: 400 })
+    }
+
+    if (containsSanitized(sanitizedEventBody)) {
+      // Drop events that contain sanitized name fields
+      return NextResponse.json({ status: 400 })
+    }
+    // --- end sanitizer & blocking logic ---
+
+    // cleaning up: ensure page exists and looks like a path (use sanitized body)
+    if (
+      !sanitizedEventBody.page ||
+      typeof sanitizedEventBody.page !== 'string' ||
+      !sanitizedEventBody.page.startsWith('/')
+    ) {
+      return NextResponse.json({ status: 400 })
+    }
     trackEventHandler(
       `${eventName}`,
       {
         // eslint-disable-next-line camelcase
         distinct_id: distinctId,
-        ...eventBody,
-        ...Object.keys(rest).reduce((a, v) => ({ ...a, [`$${snakeCase(v)}`]: rest[v] }), {}),
+        wholeEventBody: sanitizedEventBody,
       },
       mixpanel,
     )

--- a/apps/earn-protocol/app/api/t/route.ts
+++ b/apps/earn-protocol/app/api/t/route.ts
@@ -105,20 +105,29 @@ const validateSpecialKeys = (obj: { [key: string]: unknown }) => {
   if (!check('$browser', isSafeString)) return false
 
   // $browser_version: number or numeric string or null
-  if (!check('$browser_version', (v) => v === null || isNumericOrNumericString(v))) return false
+  if (
+    !check(
+      '$browser_version',
+      (v) =>
+        v === null ||
+        isNumericOrNumericString(v) ||
+        (typeof v === 'string' && /^\d+(\.\d+){0,5}$/u.test(v.trim())),
+    )
+  )
+    return false
 
   // $initial_referrer & $initial_referring_domain: safe strings (allow "$direct")
   if (
     !check(
       '$initial_referrer',
-      (v) => v === null || (typeof v === 'string' && (v === '$direct' || isSafeString(v))),
+      (v) => v === null || (typeof v === 'string' && (v === '$direct' || isValidUrl(v))),
     )
   )
     return false
   if (
     !check(
       '$initial_referring_domain',
-      (v) => v === null || (typeof v === 'string' && (v === '$direct' || isSafeString(v))),
+      (v) => v === null || (typeof v === 'string' && (v === '$direct' || isValidUrl(v))),
     )
   )
     return false

--- a/apps/earn-protocol/features/sumr-claim/components/SumrClaimSearch/SumrClaimSearch.tsx
+++ b/apps/earn-protocol/features/sumr-claim/components/SumrClaimSearch/SumrClaimSearch.tsx
@@ -36,7 +36,7 @@ export const SumrClaimSearch = () => {
   const handleButtonClick = () => {
     if (isAddress(resolvedAddress ?? '')) {
       EarnProtocolEvents.buttonClicked({
-        buttonName: 'sumr-claim-search',
+        buttonName: 'ep-sumr-claim-search',
         page: pathname,
       })
 
@@ -45,7 +45,7 @@ export const SumrClaimSearch = () => {
 
     if (!user) {
       EarnProtocolEvents.buttonClicked({
-        buttonName: 'sumr-claim-search',
+        buttonName: 'ep-sumr-claim-search',
         page: pathname,
       })
       openAuthModal()
@@ -55,7 +55,7 @@ export const SumrClaimSearch = () => {
 
     if (resolvedAddress) {
       EarnProtocolEvents.buttonClicked({
-        buttonName: 'sumr-claim-search',
+        buttonName: 'ep-sumr-claim-search',
         page: pathname,
         walletAddress: resolvedAddress,
       })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Strengthened request validation for the tracking endpoint; unsafe, malformed, or disallowed payloads are now rejected with 400 responses. Success (200) and error (500) behaviors remain unchanged.

- Refactor
  - Centralized sanitization and validation of event payloads so only cleaned, validated data is processed downstream.

- Chores
  - Standardized analytics button name to “ep-sumr-claim-search” across Sumr Claim search interactions for consistent tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->