### PR TITLE
Enhance Merkl rewards breakdown parsing

### DIFF
--- a/packages/eslint-config/function.cjs
+++ b/packages/eslint-config/function.cjs
@@ -40,6 +40,7 @@ module.exports = {
     '.*.js',
     'node_modules/',
     'dist/',
+    'declarations/',
   ],
   overrides: [
     {

--- a/packages/eslint-config/library.cjs
+++ b/packages/eslint-config/library.cjs
@@ -46,6 +46,7 @@ module.exports = {
     '.*.js',
     'node_modules/',
     'dist/',
+    'declarations/',
   ],
   overrides: [
     {

--- a/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
+++ b/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
@@ -148,17 +148,13 @@ export interface MerklReward {
   /** The merkle proofs for claiming */
   proofs: string[]
   /** Breakdown of the reward into components */
-  breakdowns: Record<
-    ChainId,
-    Record<
-      AddressValue,
-      {
-        total: string
-        claimable: string
-        claimed: string
-      }
-    >
-  >
+  breakdowns: Record<ChainId, Record<AddressValue, MerklRewardBreakdown>>
   /** List of unknown campaign breakdowns */
   unknownCampaigns: MerklApiRewardBreakdown[]
+}
+
+export interface MerklRewardBreakdown {
+  amount: string
+  claimed: string
+  pending: string
 }

--- a/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
+++ b/sdk/armada-protocol-common/src/common/types/MerklTypes.ts
@@ -159,4 +159,6 @@ export interface MerklReward {
       }
     >
   >
+  /** List of unknown campaign breakdowns */
+  unknownCampaigns: MerklApiRewardBreakdown[]
 }

--- a/sdk/armada-protocol-common/src/index.ts
+++ b/sdk/armada-protocol-common/src/index.ts
@@ -64,6 +64,7 @@ export {
 export type { IArmadaManagerMerklRewards } from './common/interfaces/IArmadaManagerMerklRewards'
 export type {
   MerklReward,
+  MerklRewardBreakdown,
   MerklApiOpportunitiesResponse,
   MerklApiOpportunity,
   MerklApiOpportunityRewardsRecord,

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
@@ -122,6 +122,7 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
           ) {
             continue
           }
+          const parsedBreakdowns = this._parseBreakdowns(reward.breakdowns)
           rewards.push({
             token: reward.token,
             root: reward.root,
@@ -130,8 +131,8 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
             claimed: reward.claimed,
             pending: reward.pending,
             proofs: reward.proofs,
-            breakdowns: this._parseBreakdowns(reward.breakdowns).resultByChain,
-            unknownCampaigns: this._parseBreakdowns(reward.breakdowns).unknownCampaigns,
+            breakdowns: parsedBreakdowns.resultByChain,
+            unknownCampaigns: parsedBreakdowns.unknownCampaigns,
           })
         }
 

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
@@ -188,10 +188,7 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
     resultByChain: Record<ChainId, Record<AddressValue, MerklRewardBreakdown>>
     unknownCampaigns: MerklApiRewardBreakdown[]
   } {
-    const resultByChain: Record<
-      ChainId,
-      Record<AddressValue, Pick<MerklRewardBreakdown, 'amount' | 'claimed' | 'pending'>>
-    > = Object.values(this._supportedChainIds).reduce(
+    const resultByChain = Object.values(this._supportedChainIds).reduce(
       (acc, chainId) => {
         acc[chainId as ChainId] = {}
         return acc

--- a/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/ArmadaManagerMerklRewards.ts
@@ -289,10 +289,7 @@ export class ArmadaManagerMerklRewards implements IArmadaManagerMerklRewards {
       }
       users.push(address as `0x${string}`)
       tokens.push(reward.token.address as `0x${string}`)
-      // perform any arithmetic or normalization with BigNumber, then convert to bigint
-      const amountBn = new BigNumber(reward.amount)
-      // ensure integer representation when pushing into calldata (uint256[])
-      amounts.push(BigInt(amountBn.toFixed(0)))
+      amounts.push(BigInt(reward.amount))
       proofs.push(reward.proofs as `0x${string}`[])
       processed++
     }

--- a/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
+++ b/sdk/armada-protocol-service/src/common/implementation/extensions/mapGraphDataToArmadaPosition.ts
@@ -59,7 +59,10 @@ export const mapGraphDataToArmadaPosition =
         }
 
         return {
-          claimableSummerToken: acc.claimableSummerToken + BigInt(positionRewards.claimable || '0'),
+          claimableSummerToken:
+            acc.claimableSummerToken +
+            BigInt(positionRewards.amount || '0') -
+            BigInt(positionRewards.claimed || '0'),
           claimedSummerToken: acc.claimedSummerToken + BigInt(positionRewards.claimed || '0'),
         }
       },

--- a/sdk/armada-protocol-service/src/common/implementation/http/merkl/opportunities.http
+++ b/sdk/armada-protocol-service/src/common/implementation/http/merkl/opportunities.http
@@ -1,6 +1,6 @@
 ### by Protocol Name
 @name = SUMMER
-https://api.merkl.xyz/v4/opportunities?name={{name}}
+https://api.merkl.xyz/v4/opportunities?name={{name}}&status=PAST
 
 ### by Tag
 @tags = POOL

--- a/sdk/sdk-client/src/reexports.ts
+++ b/sdk/sdk-client/src/reexports.ts
@@ -34,4 +34,19 @@ export {
   type ISparkProtocol,
 } from '@summerfi/protocol-plugins'
 export { GeneralRoles } from '@summerfi/armada-protocol-common'
+export type {
+  MerklReward,
+  MerklRewardBreakdown,
+  MerklApiOpportunitiesResponse,
+  MerklApiOpportunity,
+  MerklApiOpportunityRewardsRecord,
+  MerklApiOpportunityRewardsRecordBreakdown,
+  MerklApiOpportunityRewardsRecordBreakdownToken,
+  MerklApiUsersResponse,
+  MerklApiUser,
+  MerklApiChain,
+  MerklApiReward,
+  MerklApiRewardBreakdown,
+  MerklApiToken,
+} from '@summerfi/armada-protocol-common'
 export * from '@summerfi/sdk-common'

--- a/sdk/sdk-e2e/e2e/armadaProtocol.rewards.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.rewards.test.ts
@@ -8,16 +8,13 @@ import { BigNumber } from 'bignumber.js'
 
 const onlySimulation = true // Set to false to actually send transactions
 
-const displayReward = (reward: {
-  amount: string
-  claimed: string
-  token: { decimals: number }
-}): string => {
-  return BigNumber(reward.amount)
-    .minus(reward.claimed)
-    .div(10 ** Number(reward.token.decimals))
-    .toString()
-}
+const addresses = [
+  '0x805769AA22219E3a29b301Ab5897B903A9ad2C4A',
+  // '0x38233654FB0843c8024527682352A5d41E7f7324',
+  // '0xDDc68f9dE415ba2fE2FD84bc62Be2d2CFF1098dA',
+  // '0x746bb7beFD31D9052BB8EbA7D5dD74C9aCf54C6d',
+  // '0xE9c245293DAC615c11A5bF26FCec91C3617645E4',
+] as AddressValue[]
 
 describe('Armada Protocol Rewards', () => {
   const rpcUrl = process.env.E2E_SDK_FORK_URL_BASE
@@ -34,17 +31,10 @@ describe('Armada Protocol Rewards', () => {
 
   let sendTxTool: SendTransactionTool
 
-  const addresses = [
-    // '0x38233654FB0843c8024527682352A5d41E7f7324',
-    '0xDDc68f9dE415ba2fE2FD84bc62Be2d2CFF1098dA',
-    // '0x746bb7beFD31D9052BB8EbA7D5dD74C9aCf54C6d',
-    // '0xE9c245293DAC615c11A5bF26FCec91C3617645E4',
-  ] as AddressValue[]
-
   for (const userAddress of addresses) {
     describe(`Running for user ${userAddress}`, () => {
       describe(`getUserMerklRewards`, () => {
-        it(`should fetch Merkl rewards for the user`, async () => {
+        it.skip(`should fetch Merkl rewards for the user`, async () => {
           const rewards = await sdk.armada.users.getUserMerklRewards({
             address: userAddress,
           })
@@ -67,7 +57,7 @@ describe('Armada Protocol Rewards', () => {
           })
         })
 
-        it(`should fetch Merkl rewards for specific chain IDs`, async () => {
+        it.skip(`should fetch Merkl rewards for specific chain IDs`, async () => {
           const requestedChainIds = [ChainIds.Base]
 
           const rewards = await sdk.armada.users.getUserMerklRewards({
@@ -102,7 +92,7 @@ describe('Armada Protocol Rewards', () => {
         })
       })
 
-      describe.skip(`getUserMerklClaimTx`, () => {
+      describe(`getUserMerklClaimTx`, () => {
         it(`should generate claim transaction for user with rewards`, async () => {
           // First get rewards to find chains with rewards
           const rewards = await sdk.armada.users.getUserMerklRewards({
@@ -482,3 +472,14 @@ describe('Armada Protocol Rewards', () => {
     })
   }
 })
+
+function displayReward(reward: {
+  amount: string
+  claimed: string
+  token: { decimals: number }
+}): string {
+  return BigNumber(reward.amount)
+    .minus(reward.claimed)
+    .div(10 ** Number(reward.token.decimals))
+    .toString()
+}


### PR DESCRIPTION
Improve the parsing of Merkl rewards to handle unknown campaigns and enhance data management. This change allows for better tracking of breakdowns associated with campaigns that do not have a corresponding vault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Merkl rewards now include per-chain breakdowns and an unknownCampaigns field.

- **Public API**
  - Exported a MerklRewardBreakdown type; Merkl-related types re-exported for SDK use.

- **Bug Fixes**
  - Claimable token calculation adjusted so claimable vs claimed split reflects amount minus claimed; displayed amounts formatted by token decimals.

- **Chores**
  - ESLint configs updated to ignore files in declarations/.

- **Tests**
  - E2E reward tests reorganized: top-level addresses, restored helper, some tests skipped/enabled.

- **Other**
  - Merkl "by Protocol Name" API call now filters for PAST status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->