### PR TITLE
Panel fee revenue edit handling init

### DIFF
--- a/apps/earn-protocol-institutions/components/layout/TopBlocks/TopBlocks.module.css
+++ b/apps/earn-protocol-institutions/components/layout/TopBlocks/TopBlocks.module.css
@@ -3,4 +3,9 @@
   gap: 16px;
   margin-bottom: 20px;
   width: 100%;
+  flex-wrap: wrap;
+
+  .tobBlockItem {
+    flex: 1;
+  }
 }

--- a/apps/earn-protocol-institutions/components/layout/TopBlocks/TopBlocks.module.css.d.ts
+++ b/apps/earn-protocol-institutions/components/layout/TopBlocks/TopBlocks.module.css.d.ts
@@ -1,4 +1,5 @@
 declare const styles: {
+  readonly "tobBlockItem": string;
   readonly "topBlocksWrapper": string;
 };
 export = styles;

--- a/apps/earn-protocol-institutions/components/layout/TopBlocks/TopBlocks.tsx
+++ b/apps/earn-protocol-institutions/components/layout/TopBlocks/TopBlocks.tsx
@@ -14,7 +14,11 @@ export const TopBlocks = ({ blocks }: TopBlocksProps) => {
   return (
     <div className={topBlocksStyles.topBlocksWrapper}>
       {blocks.map((block) => (
-        <Card key={block.title} variant={block.colorful ? 'cardGradientFull' : 'cardSecondary'}>
+        <Card
+          key={block.title}
+          variant={block.colorful ? 'cardGradientFull' : 'cardSecondary'}
+          className={topBlocksStyles.tobBlockItem}
+        >
           <DataBlock
             title={block.title}
             titleSize="medium"

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.module.css
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelAssetRelocation/PanelAssetRelocation.module.css
@@ -29,17 +29,6 @@
         font-size: 12px;
         text-align: right;
       }
-
-      /* Target number inputs with the inputWrapper class */
-      .inputWrapper[type='number']::-webkit-outer-spin-button,
-      .inputWrapper[type='number']::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-        margin: 0;
-      }
-
-      .inputWrapper[type='number'] {
-        -moz-appearance: textfield;
-      }
     }
 
     .summary {

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css
@@ -16,5 +16,43 @@
         transition: opacity 0.2s ease-in-out;
       }
     }
+
+    .tableWrapper {
+      overflow-x: auto;
+
+      .table {
+        min-width: 600px;
+      }
+    }
+
+    .tableCellNodeUpdating {
+      margin-top: -4px;
+      margin-bottom: -4px;
+    }
+
+    .inputContainer {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+
+      .inputWrapper,
+      .inputWrapperPercentage,
+      .inputImpliedCap {
+        max-width: 178px;
+        height: 28px;
+        padding: var(--spacing-space-2x-small) var(--spacing-space-x-small);
+        border-radius: var(--radius-small);
+        font-size: 12px;
+        text-align: right;
+      }
+
+      .inputWrapperPercentage {
+        max-width: 60px;
+      }
+
+      .inputImpliedCap {
+        max-width: 118px;
+      }
+    }
   }
 }

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css.d.ts
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css.d.ts
@@ -1,7 +1,14 @@
 declare const styles: {
+  readonly "inputContainer": string;
+  readonly "inputImpliedCap": string;
+  readonly "inputWrapper": string;
+  readonly "inputWrapperPercentage": string;
   readonly "onEdit": string;
   readonly "panelFeeRevenueAdminCard": string;
   readonly "panelFeeRevenueAdminWrapper": string;
+  readonly "table": string;
+  readonly "tableCellNodeUpdating": string;
+  readonly "tableWrapper": string;
 };
 export = styles;
 

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.tsx
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.tsx
@@ -1,15 +1,19 @@
-import { type FC } from 'react'
+'use client'
+import { type FC, useCallback, useMemo } from 'react'
 import { Card, Table, Text } from '@summerfi/app-earn-ui'
-import { type SDKVaultishType } from '@summerfi/app-types'
+import { type SDKVaultishType, UiSimpleFlowSteps } from '@summerfi/app-types'
 
+import { EditSummary } from '@/components/molecules/EditSummary/EditSummary'
+import { usePanelFeeRevenueAdmin } from '@/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider'
 import { type InstitutionVaultFeeRevenueData } from '@/types/institution-data'
 
+import { getFeeRevenueAdminChanges } from './helpers/get-fee-revenue-admin-changes'
+import { useFeeRevenueData } from './hooks/use-fee-revenue-data'
+import { useThirdPartyCostsData } from './hooks/use-third-party-costs-data'
 import { feeRevenueColumns } from './tables/fee-revenue/columns'
-import { feeRevenueMapper } from './tables/fee-revenue/mapper'
 import { feeRevenueHistoryColumns } from './tables/history/columns'
 import { feeRevenueHistoryMapper } from './tables/history/mapper'
 import { thirdPartyCostsColumns } from './tables/third-party-costs/columns'
-import { thirdPartyCostsMapper } from './tables/third-party-costs/mapper'
 
 import classNames from './PanelFeeRevenueAdmin.module.css'
 
@@ -22,17 +26,43 @@ export const PanelFeeRevenueAdmin: FC<PanelFeeRevenueAdminProps> = ({
   vaultData: _vaultData,
   feeRevenueData,
 }) => {
-  const thirdPartyCostsRows = thirdPartyCostsMapper({
-    costs: feeRevenueData.thirdPartyCosts,
+  const { state, dispatch } = usePanelFeeRevenueAdmin()
+  const { rows: thirdPartyCostsRows, onCancel: thirdPartyCostsOnCancel } = useThirdPartyCostsData({
+    dispatch,
+    rawData: feeRevenueData.thirdPartyCosts,
+  })
+
+  const { rows: feeRevenueRows, onCancel: feeRevenueOnCancel } = useFeeRevenueData({
+    dispatch,
+    rawData: feeRevenueData.feeRevenue,
   })
 
   const feeRevenueHistoryRows = feeRevenueHistoryMapper({
     feeRevenueHistory: feeRevenueData.feeRevenueHistory,
   })
 
-  const feeRevenueRows = feeRevenueMapper({
-    feeRevenue: feeRevenueData.feeRevenue,
-  })
+  const change = useMemo(
+    () =>
+      getFeeRevenueAdminChanges({
+        state,
+        feeRevenueData: feeRevenueData.feeRevenue,
+        thirdPartyCostsData: feeRevenueData.thirdPartyCosts,
+      }),
+    [state, feeRevenueData.feeRevenue, feeRevenueData.thirdPartyCosts],
+  )
+
+  const onCancel = useCallback(() => {
+    dispatch({ type: 'reset' })
+    thirdPartyCostsOnCancel()
+    feeRevenueOnCancel()
+  }, [dispatch, thirdPartyCostsOnCancel, feeRevenueOnCancel])
+
+  const onConfirm = useCallback(() => {
+    dispatch({ type: 'update-step', payload: UiSimpleFlowSteps.PENDING })
+    // TODO: Implement confirm handler
+    // eslint-disable-next-line no-console
+    console.log('confirm')
+  }, [dispatch])
 
   return (
     <Card variant="cardSecondary" className={classNames.panelFeeRevenueAdminWrapper}>
@@ -43,20 +73,36 @@ export const PanelFeeRevenueAdmin: FC<PanelFeeRevenueAdminProps> = ({
         <Text as="p" variant="p3semi">
           Fee Revenue
         </Text>
-        <Table rows={feeRevenueRows} columns={feeRevenueColumns} />
+        <Table
+          rows={feeRevenueRows}
+          columns={feeRevenueColumns}
+          wrapperClassName={classNames.tableWrapper}
+          tableClassName={classNames.table}
+        />
       </Card>
       <Card variant="cardPrimary" className={classNames.panelFeeRevenueAdminCard}>
         <Text as="p" variant="p3semi">
           3rd Party Costs
         </Text>
-        <Table rows={thirdPartyCostsRows} columns={thirdPartyCostsColumns} />
+        <Table
+          rows={thirdPartyCostsRows}
+          columns={thirdPartyCostsColumns}
+          wrapperClassName={classNames.tableWrapper}
+          tableClassName={classNames.table}
+        />
       </Card>
       <Card className={classNames.panelFeeRevenueAdminCard} style={{ background: 'unset' }}>
         <Text as="p" variant="p1semi">
           History
         </Text>
-        <Table rows={feeRevenueHistoryRows} columns={feeRevenueHistoryColumns} />
+        <Table
+          rows={feeRevenueHistoryRows}
+          columns={feeRevenueHistoryColumns}
+          wrapperClassName={classNames.tableWrapper}
+          tableClassName={classNames.table}
+        />
       </Card>
+      <EditSummary title="Summary" change={change} onCancel={onCancel} onConfirm={onConfirm} />
     </Card>
   )
 }

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/helpers/get-fee-revenue-admin-changes.ts
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/helpers/get-fee-revenue-admin-changes.ts
@@ -1,0 +1,80 @@
+import { formatDecimalAsPercent } from '@summerfi/app-utils'
+
+import { type PanelFeeRevenueAdminState } from '@/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider'
+import {
+  type InstitutionVaultFeeRevenueItem,
+  type InstitutionVaultThirdPartyCost,
+} from '@/types/institution-data'
+
+/**
+ * Helper function to get the changes in the fee revenue admin
+ * @param state - State of the fee revenue admin
+ * @param feeRevenueData - Raw data for the fee revenue
+ * @param thirdPartyCostsData - Raw data for the third party costs
+ * @returns {Array} Array of changes in the fee revenue admin
+ */
+export const getFeeRevenueAdminChanges = ({
+  state,
+  feeRevenueData,
+  thirdPartyCostsData,
+}: {
+  state: PanelFeeRevenueAdminState
+  feeRevenueData: InstitutionVaultFeeRevenueItem[]
+  thirdPartyCostsData: InstitutionVaultThirdPartyCost[]
+}) => {
+  const feeRevenueChange = state.feeRevenueItems.map((item) => {
+    const from = feeRevenueData.find((i) => i.name === item.name)?.aumFee ?? 'n/a'
+
+    return {
+      title: item.name,
+      from: formatDecimalAsPercent(from),
+      to: formatDecimalAsPercent(item.aumFee),
+    }
+  })
+
+  const thirdPartyCostsAggregatedChange = state.thirdPartyCostsItems.reduce<{
+    [key: string]: {
+      type: string
+      changes: { title: string; from: string; to: string }[]
+    }
+  }>((acc, item) => {
+    const originalItem = thirdPartyCostsData.find((i) => i.type === item.type)
+
+    if (!acc[item.type]) {
+      acc[item.type] = {
+        type: item.type,
+        changes: [],
+      }
+    }
+
+    // check each field for changes
+    if (originalItem) {
+      if (originalItem.fee !== item.fee) {
+        acc[item.type].changes.push({
+          title: 'Fee',
+          from: formatDecimalAsPercent(originalItem.fee),
+          to: formatDecimalAsPercent(item.fee),
+        })
+      }
+
+      if (originalItem.address !== item.address) {
+        acc[item.type].changes.push({
+          title: 'Address',
+          from: originalItem.address,
+          to: item.address,
+        })
+      }
+    }
+
+    return acc
+  }, {})
+
+  const thirdPartyCostsChange = Object.entries(thirdPartyCostsAggregatedChange)
+    .filter(([_, data]) => data.changes.length > 0)
+    .map(([_, data]) => ({
+      title: data.type,
+      items: data.changes,
+    }))
+
+  return [...feeRevenueChange, ...thirdPartyCostsChange]
+}

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/hooks/use-fee-revenue-data.ts
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/hooks/use-fee-revenue-data.ts
@@ -1,0 +1,78 @@
+'use client'
+import { type Dispatch, useCallback, useState } from 'react'
+
+import { feeRevenueMapper } from '@/features/panels/vaults/components/PanelFeeRevenueAdmin/tables/fee-revenue/mapper'
+import { type PanelFeeRevenueAdminAction } from '@/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider'
+import { type InstitutionVaultFeeRevenueItem } from '@/types/institution-data'
+
+/**
+ * Hook to manage fee revenue data
+ * @param dispatch - Dispatch function to update the state
+ * @param rawData - Raw data for the fee revenue
+ * @returns {Object} Fee revenue data management utilities:
+ *   - rows: Array of fee revenue
+ *   - onCancel: Function to cancel the editing of the fee revenue
+ */
+export const useFeeRevenueData = ({
+  dispatch,
+  rawData,
+}: {
+  dispatch: Dispatch<PanelFeeRevenueAdminAction>
+  rawData: InstitutionVaultFeeRevenueItem[]
+}) => {
+  const [updatingFeeRevenueItem, setUpdatingFeeRevenueItem] =
+    useState<InstitutionVaultFeeRevenueItem | null>(null)
+
+  const [updatingFeeRevenueItemValue, setUpdatingFeeRevenueItemValue] = useState<string>('')
+
+  const onEdit = useCallback((item: InstitutionVaultFeeRevenueItem) => {
+    setUpdatingFeeRevenueItem(item)
+  }, [])
+
+  const onRowEditCancel = useCallback(() => {
+    setUpdatingFeeRevenueItem(null)
+    setUpdatingFeeRevenueItemValue('')
+  }, [])
+
+  const onSave = useCallback(
+    (item: InstitutionVaultFeeRevenueItem) => {
+      setUpdatingFeeRevenueItem(null)
+      if (
+        updatingFeeRevenueItemValue.length > 0 &&
+        updatingFeeRevenueItemValue !== item.aumFee.toString() &&
+        Number.isFinite(Number(updatingFeeRevenueItemValue))
+      ) {
+        dispatch({
+          type: 'edit-fee-revenue-item',
+          payload: { ...item, aumFee: Number(updatingFeeRevenueItemValue) },
+        })
+      }
+      setUpdatingFeeRevenueItemValue('')
+    },
+    [dispatch, updatingFeeRevenueItemValue],
+  )
+
+  const onChange = useCallback((value: string) => {
+    setUpdatingFeeRevenueItemValue(value)
+  }, [])
+
+  const feeRevenueRows = feeRevenueMapper({
+    rawData,
+    onEdit,
+    onSave,
+    onRowEditCancel,
+    updatingFeeRevenueItem,
+    updatingFeeRevenueItemValue,
+    onChange,
+  })
+
+  const onCancel = useCallback(() => {
+    setUpdatingFeeRevenueItem(null)
+    setUpdatingFeeRevenueItemValue('')
+  }, [])
+
+  return {
+    rows: feeRevenueRows,
+    onCancel,
+  }
+}

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/hooks/use-third-party-costs-data.ts
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/hooks/use-third-party-costs-data.ts
@@ -1,0 +1,95 @@
+'use client'
+import { type Dispatch, useCallback, useState } from 'react'
+
+import { thirdPartyCostsMapper } from '@/features/panels/vaults/components/PanelFeeRevenueAdmin/tables/third-party-costs/mapper'
+import { type PanelFeeRevenueAdminAction } from '@/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider'
+import { type InstitutionVaultThirdPartyCost } from '@/types/institution-data'
+
+/**
+ * Hook to manage thrid party costs data
+ * @param dispatch - Dispatch function to update the state
+ * @param rawData - Raw data for the thrid party costs
+ * @returns {Object} thrid party costs data management utilities:
+ *   - rows: Array of thrid party costs
+ *   - onCancel: Function to cancel the editing of the thrid party costs
+ */
+export const useThirdPartyCostsData = ({
+  dispatch,
+  rawData,
+}: {
+  dispatch: Dispatch<PanelFeeRevenueAdminAction>
+  rawData: InstitutionVaultThirdPartyCost[]
+}) => {
+  const [updatingThirdPartyCostsItem, setUpdatingThirdPartyCostsItem] =
+    useState<InstitutionVaultThirdPartyCost | null>(null)
+
+  const [updatingThirdPartyCostsFee, setUpdatingThirdPartyCostsFee] = useState<string>('')
+  const [updatingThirdPartyCostsAddress, setUpdatingThirdPartyCostsAddress] = useState<string>('')
+
+  const onEdit = (item: InstitutionVaultThirdPartyCost) => {
+    setUpdatingThirdPartyCostsItem(item)
+  }
+
+  const onRowEditCancel = () => {
+    setUpdatingThirdPartyCostsItem(null)
+    setUpdatingThirdPartyCostsFee('')
+    setUpdatingThirdPartyCostsAddress('')
+  }
+
+  const onSave = useCallback(
+    (item: InstitutionVaultThirdPartyCost) => {
+      setUpdatingThirdPartyCostsItem(null)
+      if (
+        (updatingThirdPartyCostsFee.length > 0 &&
+          updatingThirdPartyCostsFee !== item.fee.toString() &&
+          Number.isFinite(Number(updatingThirdPartyCostsFee))) ||
+        (updatingThirdPartyCostsAddress.length > 0 &&
+          updatingThirdPartyCostsAddress !== item.address.toString() &&
+          Number.isFinite(Number(updatingThirdPartyCostsAddress)))
+      ) {
+        dispatch({
+          type: 'edit-third-party-costs-item',
+          payload: {
+            ...item,
+            fee: updatingThirdPartyCostsFee ? Number(updatingThirdPartyCostsFee) : item.fee,
+            address: updatingThirdPartyCostsAddress ? updatingThirdPartyCostsAddress : item.address,
+          },
+        })
+      }
+      setUpdatingThirdPartyCostsAddress('')
+      setUpdatingThirdPartyCostsFee('')
+    },
+    [dispatch, updatingThirdPartyCostsFee, updatingThirdPartyCostsAddress],
+  )
+
+  const onChangeCosts = useCallback((value: string) => {
+    setUpdatingThirdPartyCostsFee(value)
+  }, [])
+
+  const onChangeAddress = useCallback((value: string) => {
+    setUpdatingThirdPartyCostsAddress(value)
+  }, [])
+
+  const onCancel = useCallback(() => {
+    setUpdatingThirdPartyCostsItem(null)
+    setUpdatingThirdPartyCostsFee('')
+    setUpdatingThirdPartyCostsAddress('')
+  }, [])
+
+  const thirdPartyCostsRows = thirdPartyCostsMapper({
+    rawData,
+    onEdit,
+    onSave,
+    onRowEditCancel,
+    updatingThirdPartyCostsItem,
+    updatingThirdPartyCostsFee,
+    updatingThirdPartyCostsAddress,
+    onChangeCosts,
+    onChangeAddress,
+  })
+
+  return {
+    rows: thirdPartyCostsRows,
+    onCancel,
+  }
+}

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/tables/fee-revenue/mapper.tsx
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/tables/fee-revenue/mapper.tsx
@@ -1,27 +1,82 @@
-import { Button, Icon, TableCellText } from '@summerfi/app-earn-ui'
+import { Button, Icon, Input, TableCellNodes, TableCellText } from '@summerfi/app-earn-ui'
 import { formatDecimalAsPercent } from '@summerfi/app-utils'
 
 import { type InstitutionVaultFeeRevenueItem } from '@/types/institution-data'
 
-import classNames from '@/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css'
+import styles from '@/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css'
 
 export const feeRevenueMapper = ({
-  feeRevenue,
+  rawData,
+  onEdit,
+  onSave,
+  onRowEditCancel,
+  updatingFeeRevenueItem,
+  updatingFeeRevenueItemValue,
+  onChange,
 }: {
-  feeRevenue: InstitutionVaultFeeRevenueItem[]
+  rawData: InstitutionVaultFeeRevenueItem[]
+  onEdit: (item: InstitutionVaultFeeRevenueItem) => void
+  onSave: (item: InstitutionVaultFeeRevenueItem) => void
+  onRowEditCancel: () => void
+  updatingFeeRevenueItem: InstitutionVaultFeeRevenueItem | null
+  updatingFeeRevenueItemValue: string
+  onChange: (value: string) => void
 }) => {
-  return feeRevenue.map((item) => {
+  return rawData.map((item) => {
+    const isUpdating = updatingFeeRevenueItem?.name === item.name
+
+    const resolvedOnClick = () => {
+      if (isUpdating) {
+        onSave(item)
+      } else {
+        onEdit(item)
+      }
+    }
+
     return {
       content: {
         name: <TableCellText>{item.name}</TableCellText>,
-        'aum-fee': <TableCellText>{formatDecimalAsPercent(item.aumFee)}</TableCellText>,
+        'aum-fee': (
+          <TableCellNodes className={isUpdating ? styles.tableCellNodeUpdating : ''}>
+            {isUpdating ? (
+              <Input
+                variant="withBorder"
+                wrapperClassName={styles.inputContainer}
+                inputWrapperClassName={styles.inputWrapper}
+                value={updatingFeeRevenueItemValue || item.aumFee}
+                onChange={(e) => onChange(e.target.value)}
+              />
+            ) : (
+              formatDecimalAsPercent(item.aumFee)
+            )}
+          </TableCellNodes>
+        ),
         action: (
-          <TableCellText style={{ marginLeft: '40px' }}>
+          <TableCellText
+            style={{
+              marginLeft: isUpdating ? '67px' : '40px',
+              gap: 'var(--spacing-space-small)',
+            }}
+          >
+            {isUpdating && (
+              <Button
+                variant="unstyled"
+                style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+                onClick={onRowEditCancel}
+              >
+                <Icon iconName="trash" size={20} className={styles.onEdit} />
+              </Button>
+            )}
             <Button
               variant="unstyled"
               style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+              onClick={resolvedOnClick}
             >
-              <Icon iconName="edit" size={16} className={classNames.onEdit} />
+              <Icon
+                iconName={isUpdating ? 'checkmark' : 'edit'}
+                size={16}
+                className={styles.onEdit}
+              />
             </Button>
           </TableCellText>
         ),

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/tables/third-party-costs/mapper.tsx
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelFeeRevenueAdmin/tables/third-party-costs/mapper.tsx
@@ -1,24 +1,98 @@
-import { Button, Icon, TableCellText } from '@summerfi/app-earn-ui'
+import { Button, Icon, Input, TableCellNodes, TableCellText } from '@summerfi/app-earn-ui'
 import { formatAddress, formatDecimalAsPercent } from '@summerfi/app-utils'
 
 import { type InstitutionVaultThirdPartyCost } from '@/types/institution-data'
 
-import classNames from '@/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css'
+import styles from '@/features/panels/vaults/components/PanelFeeRevenueAdmin/PanelFeeRevenueAdmin.module.css'
 
-export const thirdPartyCostsMapper = ({ costs }: { costs: InstitutionVaultThirdPartyCost[] }) => {
-  return costs.map((cost) => {
+export const thirdPartyCostsMapper = ({
+  rawData,
+  onEdit,
+  onSave,
+  onRowEditCancel,
+  updatingThirdPartyCostsItem,
+  updatingThirdPartyCostsFee,
+  updatingThirdPartyCostsAddress,
+  onChangeCosts,
+  onChangeAddress,
+}: {
+  rawData: InstitutionVaultThirdPartyCost[]
+  onEdit: (item: InstitutionVaultThirdPartyCost) => void
+  onSave: (item: InstitutionVaultThirdPartyCost) => void
+  onRowEditCancel: () => void
+  updatingThirdPartyCostsItem: InstitutionVaultThirdPartyCost | null
+  updatingThirdPartyCostsFee: string
+  updatingThirdPartyCostsAddress: string
+  onChangeCosts: (value: string) => void
+  onChangeAddress: (value: string) => void
+}) => {
+  return rawData.map((cost) => {
+    const isUpdating = updatingThirdPartyCostsItem?.type === cost.type
+
+    const resolvedOnClick = () => {
+      if (isUpdating) {
+        onSave(cost)
+      } else {
+        onEdit(cost)
+      }
+    }
+
     return {
       content: {
         type: <TableCellText>{cost.type}</TableCellText>,
-        fee: <TableCellText>{formatDecimalAsPercent(cost.fee)}</TableCellText>,
-        address: <TableCellText>{formatAddress(cost.address)}</TableCellText>,
+        fee: (
+          <TableCellNodes className={isUpdating ? styles.tableCellNodeUpdating : ''}>
+            {isUpdating ? (
+              <Input
+                variant="withBorder"
+                wrapperClassName={styles.inputContainer}
+                inputWrapperClassName={styles.inputWrapperPercentage}
+                value={updatingThirdPartyCostsFee || cost.fee}
+                onChange={(e) => onChangeCosts(e.target.value)}
+              />
+            ) : (
+              formatDecimalAsPercent(cost.fee, { precision: 1 })
+            )}
+          </TableCellNodes>
+        ),
+        address: (
+          <TableCellNodes className={isUpdating ? styles.tableCellNodeUpdating : ''}>
+            {isUpdating ? (
+              <Input
+                variant="withBorder"
+                wrapperClassName={styles.inputContainer}
+                inputWrapperClassName={styles.inputWrapper}
+                value={updatingThirdPartyCostsAddress || cost.address}
+                onChange={(e) => onChangeAddress(e.target.value)}
+              />
+            ) : (
+              formatAddress(cost.address, { first: 10, last: 10 })
+            )}
+          </TableCellNodes>
+        ),
         action: (
-          <TableCellText style={{ marginLeft: '40px' }}>
+          <TableCellText
+            style={{ marginLeft: isUpdating ? '13px' : '40px', gap: 'var(--spacing-space-small)' }}
+          >
+            {isUpdating && (
+              <Button
+                variant="unstyled"
+                style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+                onClick={onRowEditCancel}
+              >
+                <Icon iconName="trash" size={20} className={styles.onEdit} />
+              </Button>
+            )}
             <Button
               variant="unstyled"
               style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+              onClick={resolvedOnClick}
             >
-              <Icon iconName="edit" size={16} className={classNames.onEdit} />
+              <Icon
+                iconName={isUpdating ? 'checkmark' : 'edit'}
+                size={16}
+                className={styles.onEdit}
+              />
             </Button>
           </TableCellText>
         ),

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelRiskParameters/PanelRiskParameters.module.css
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelRiskParameters/PanelRiskParameters.module.css
@@ -48,16 +48,5 @@
     .inputImpliedCap {
       max-width: 118px;
     }
-
-    /* Target number inputs with the inputWrapper class */
-    .inputWrapper[type='number']::-webkit-outer-spin-button,
-    .inputWrapper[type='number']::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-
-    .inputWrapper[type='number'] {
-      -moz-appearance: textfield;
-    }
   }
 }

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelRiskParameters/vault-risk-parameters-table/mapper.tsx
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelRiskParameters/vault-risk-parameters-table/mapper.tsx
@@ -54,7 +54,7 @@ export const vaultRiskParametersMapper = ({
         action: (
           <TableCellText
             style={{
-              marginLeft: isUpdating ? '35px' : '40px',
+              marginLeft: isUpdating ? '36px' : '40px',
               gap: 'var(--spacing-space-small)',
             }}
           >

--- a/apps/earn-protocol-institutions/features/panels/vaults/components/PanelRoleAdmin/PanelRoleAdmin.module.css
+++ b/apps/earn-protocol-institutions/features/panels/vaults/components/PanelRoleAdmin/PanelRoleAdmin.module.css
@@ -38,16 +38,5 @@
       font-size: 12px;
       text-align: right;
     }
-
-    /* Target number inputs with the inputWrapper class */
-    .inputWrapper[type='number']::-webkit-outer-spin-button,
-    .inputWrapper[type='number']::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-
-    .inputWrapper[type='number'] {
-      -moz-appearance: textfield;
-    }
   }
 }

--- a/apps/earn-protocol-institutions/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider.tsx
+++ b/apps/earn-protocol-institutions/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider.tsx
@@ -1,0 +1,87 @@
+'use client'
+import { createContext, type Dispatch, useContext, useReducer } from 'react'
+import { UiSimpleFlowSteps, type UiTransactionStatuses } from '@summerfi/app-types'
+
+import {
+  type InstitutionVaultFeeRevenueItem,
+  type InstitutionVaultThirdPartyCost,
+} from '@/types/institution-data'
+
+export type PanelFeeRevenueAdminState = {
+  step: UiSimpleFlowSteps
+  txStatus: UiTransactionStatuses | undefined
+  thirdPartyCostsItems: InstitutionVaultThirdPartyCost[]
+  feeRevenueItems: InstitutionVaultFeeRevenueItem[]
+}
+
+export type PanelFeeRevenueAdminAction =
+  | { type: 'edit-third-party-costs-item'; payload: InstitutionVaultThirdPartyCost }
+  | { type: 'edit-fee-revenue-item'; payload: InstitutionVaultFeeRevenueItem }
+  | { type: 'update-step'; payload: UiSimpleFlowSteps }
+  | { type: 'update-tx-status'; payload: UiTransactionStatuses | undefined }
+  | { type: 'partial-reset'; payload?: Partial<PanelFeeRevenueAdminState> }
+  | { type: 'reset' }
+
+const initialState: PanelFeeRevenueAdminState = {
+  step: UiSimpleFlowSteps.INIT,
+  txStatus: undefined,
+  thirdPartyCostsItems: [],
+  feeRevenueItems: [],
+}
+
+const reducer = (
+  state: PanelFeeRevenueAdminState,
+  action: PanelFeeRevenueAdminAction,
+): PanelFeeRevenueAdminState => {
+  switch (action.type) {
+    case 'edit-third-party-costs-item':
+      return {
+        ...state,
+        thirdPartyCostsItems: [
+          ...state.thirdPartyCostsItems.filter((item) => item.type !== action.payload.type),
+          action.payload,
+        ],
+      }
+    case 'edit-fee-revenue-item':
+      return {
+        ...state,
+        feeRevenueItems: [
+          ...state.feeRevenueItems.filter((item) => item.name !== action.payload.name),
+          action.payload,
+        ],
+      }
+    case 'update-step':
+      return { ...state, step: action.payload }
+    case 'update-tx-status':
+      return { ...state, txStatus: action.payload }
+    case 'partial-reset':
+      return { ...state, ...action.payload }
+    case 'reset':
+      return initialState
+    default:
+      return state
+  }
+}
+
+const PanelFeeRevenueAdminContext = createContext<{
+  state: PanelFeeRevenueAdminState
+  dispatch: Dispatch<PanelFeeRevenueAdminAction>
+} | null>(null)
+
+export function PanelFeeRevenueAdminProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  return (
+    <PanelFeeRevenueAdminContext.Provider value={{ state, dispatch }}>
+      {children}
+    </PanelFeeRevenueAdminContext.Provider>
+  )
+}
+
+export function usePanelFeeRevenueAdmin() {
+  const ctx = useContext(PanelFeeRevenueAdminContext)
+
+  if (!ctx) throw new Error('usePanelFeeRevenueAdmin must be inside PanelFeeRevenueAdminProvider')
+
+  return ctx
+}

--- a/apps/earn-protocol-institutions/providers/PanelsProvider/PanelsProvider.tsx
+++ b/apps/earn-protocol-institutions/providers/PanelsProvider/PanelsProvider.tsx
@@ -3,8 +3,14 @@ import { type FC, type PropsWithChildren } from 'react'
 import { PanelRiskParametersProvider } from '@/providers/PanekRiskParametersProvider/PanelRiskParametersProvider'
 import { PanelAdminProvider } from '@/providers/PanelAdminProvider/PanelAdminProvider'
 import { PanelClientProvider } from '@/providers/PanelClientProvider/PanelClientProvider'
+import { PanelFeeRevenueAdminProvider } from '@/providers/PanelFeeRevenueAdminProvider/PanelFeeRevenueAdminProvider'
 
-const providers = [PanelAdminProvider, PanelClientProvider, PanelRiskParametersProvider]
+const providers = [
+  PanelAdminProvider,
+  PanelClientProvider,
+  PanelRiskParametersProvider,
+  PanelFeeRevenueAdminProvider,
+]
 
 export const PanelsProvider: FC<PropsWithChildren> = ({ children }) => {
   return providers.reduceRight((acc, Provider) => {


### PR DESCRIPTION
## Description
Introduce fee revenue admin editing with change summaries, refactor tables with hooks and providers, and improve layout responsiveness.

## Changes
- Top blocks: enable wrapping and per-item flex via `tobBlockItem`.
- Fee Revenue Admin:
  - Convert to client component; integrate `usePanelFeeRevenueAdmin`.
  - Add hooks: `useFeeRevenueData`, `useThirdPartyCostsData` for inline edit/save/cancel.
  - Add change aggregation: `getFeeRevenueAdminChanges` + `EditSummary` integration.
  - Table UX: scrollable wrapper, min-width table, inline input styles.
- Edit Summary: supports grouped list changes (fee revenue and third-party costs).
- Panel Asset Relocation: remove redundant number input spin CSS.
- Add/align CSS modules and .d.ts typings.

## Benefits
- Inline edits with clear review via a summary before confirm.
- Cleaner state management with hooks and provider.
- Better table usability on smaller screens.
- Consistent, reusable change display components.

## Testing
- Edit fee revenue items; verify rows update and summary reflects changes.
- Edit third-party costs (fee/address); confirm summary grouping by type.
- Cancel/confirm flows update provider state correctly.
- Check table scroll behavior and input styles at various widths.

## Next steps
- Wire confirm action to backend mutation.
- Add validation for fee/address fields.
- Add loading/error states for save operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Inline editing with save/cancel for Fee Revenue and Third-Party Costs tables.
  - Added review summary with confirm/cancel actions and guided step flow.
  - Improved table responsiveness (horizontal scrolling, minimum widths) and consistent input sizing/alignment.

- Style
  - Top blocks now wrap and distribute space evenly for better responsiveness.
  - Re-enabled native number input spinners across relevant panels.
  - Minor spacing tweak in the risk parameters table for improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->