### PR TITLE
Add VaultApys type and integrate into ArmadaVaultInfo

### DIFF
--- a/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerVaults.ts
+++ b/sdk/armada-protocol-common/src/common/interfaces/IArmadaManagerVaults.ts
@@ -12,6 +12,7 @@ import {
   type IArmadaVaultInfo,
   type ChainId,
 } from '@summerfi/sdk-common'
+import type { VaultApys } from '../types/VaultApys'
 
 export interface IArmadaManagerVaults {
   /** USER TRANSACTIONS */
@@ -129,9 +130,7 @@ export interface IArmadaManagerVaults {
 
   getVaultsApys(params: { chainId: ChainId; vaultIds: IArmadaVaultId[] }): Promise<{
     byFleetAddress: {
-      [fleetAddress: string]: {
-        apy: IPercentage | null
-      }
+      [fleetAddress: string]: VaultApys
     }
   }>
 

--- a/sdk/armada-protocol-common/src/index.ts
+++ b/sdk/armada-protocol-common/src/index.ts
@@ -77,3 +77,4 @@ export type {
   MerklApiRewardBreakdown,
   MerklApiToken,
 } from './common/types/MerklTypes'
+export type { VaultApys } from './common/types/VaultApys'

--- a/sdk/sdk-common/src/common/implementation/ArmadaVaultInfo.ts
+++ b/sdk/sdk-common/src/common/implementation/ArmadaVaultInfo.ts
@@ -7,6 +7,7 @@ import type { IPercentage } from '../interfaces/IPercentage'
 import type { IPrice } from '../interfaces/IPrice'
 import type { IToken } from '../interfaces/IToken'
 import type { ITokenAmount } from '../interfaces/ITokenAmount'
+import type { VaultApys } from '../types/VaultApys'
 import { PoolInfo } from './PoolInfo'
 
 /**
@@ -32,6 +33,7 @@ export class ArmadaVaultInfo extends PoolInfo implements IArmadaVaultInfo {
   readonly totalShares: ITokenAmount
   readonly sharePrice: IPrice
   readonly apy: IPercentage | null
+  readonly apys: VaultApys
   readonly rewardsApys: Array<{
     token: IToken
     apy: IPercentage | null
@@ -60,6 +62,7 @@ export class ArmadaVaultInfo extends PoolInfo implements IArmadaVaultInfo {
     this.totalShares = params.totalShares
     this.sharePrice = params.sharePrice
     this.apy = params.apy
+    this.apys = params.apys
     this.rewardsApys = params.rewardsApys
     this.merklRewards = params.merklRewards
   }

--- a/sdk/sdk-common/src/common/interfaces/IArmadaVaultInfo.ts
+++ b/sdk/sdk-common/src/common/interfaces/IArmadaVaultInfo.ts
@@ -6,6 +6,7 @@ import { PoolType } from '../enums/PoolType'
 import { isPercentage, type IPercentage } from './IPercentage'
 import { isToken, type IToken } from './IToken'
 import { isPrice, type IPrice } from './IPrice'
+import type { VaultApys } from '../types/VaultApys'
 
 /**
  * Unique signature to provide branded types to the interface
@@ -35,6 +36,8 @@ export interface IArmadaVaultInfo extends IPoolInfo, IArmadaVaultInfoData {
   readonly sharePrice: IPrice
   /** Vault apy */
   readonly apy: IPercentage | null
+  /** Vault apys for different time periods */
+  readonly apys: VaultApys
   /** Vault SUMR rewards apy */
   readonly rewardsApys: Array<{
     token: IToken
@@ -65,6 +68,12 @@ export const ArmadaVaultInfoDataSchema = z.object({
   totalShares: z.custom<ITokenAmount>((val) => isTokenAmount(val)),
   sharePrice: z.custom<IPrice>((val) => isPrice(val)),
   apy: z.custom<IPercentage | null>((val) => isPercentage(val) || val === null),
+  apys: z.object({
+    live: z.custom<IPercentage | null>((val) => isPercentage(val) || val === null),
+    sma24h: z.custom<IPercentage | null>((val) => isPercentage(val) || val === null),
+    sma7day: z.custom<IPercentage | null>((val) => isPercentage(val) || val === null),
+    sma30day: z.custom<IPercentage | null>((val) => isPercentage(val) || val === null),
+  }),
   rewardsApys: z.array(
     z.object({
       token: z.custom<IToken>((val) => isToken(val)),

--- a/sdk/sdk-common/src/common/types/VaultApys.ts
+++ b/sdk/sdk-common/src/common/types/VaultApys.ts
@@ -1,0 +1,8 @@
+import type { IPercentage } from '../interfaces/IPercentage'
+
+export type VaultApys = {
+  live: IPercentage | null
+  sma24h: IPercentage | null
+  sma7day: IPercentage | null
+  sma30day: IPercentage | null
+}

--- a/sdk/sdk-common/src/index.ts
+++ b/sdk/sdk-common/src/index.ts
@@ -429,3 +429,4 @@ export { FETCH_CONFIG, createTimeoutSignal, fetchWithTimeout } from './configs/f
 
 export type { ExtendedTransactionInfo } from './orders/common/types/DEPRECATED'
 export { NATIVE_CURRENCY_ADDRESS_LOWERCASE } from './common/utils/nativeCurrencyAddress'
+export type { VaultApys } from './common/types/VaultApys'

--- a/sdk/sdk-common/tests/ArmadaVaultInfo.spec.ts
+++ b/sdk/sdk-common/tests/ArmadaVaultInfo.spec.ts
@@ -61,6 +61,12 @@ describe('SDK Common | Armada | ArmadaVaultInfo', () => {
         apy: Percentage.createFrom({
           value: 0.05,
         }),
+        apys: {
+          live: Percentage.createFrom({ value: 0.05 }),
+          sma24h: Percentage.createFrom({ value: 0.049 }),
+          sma7day: Percentage.createFrom({ value: 0.048 }),
+          sma30day: Percentage.createFrom({ value: 0.047 }),
+        },
         rewardsApys: [],
         merklRewards: [],
       })
@@ -70,6 +76,11 @@ describe('SDK Common | Armada | ArmadaVaultInfo', () => {
       expect(poolInfo.depositCap).toEqual(depositCap)
       expect(poolInfo.totalDeposits).toEqual(totalDeposits)
       expect(poolInfo.totalShares).toEqual(totalShares)
+      expect(poolInfo.apys).toBeDefined()
+      expect(poolInfo.apys.live).toBeDefined()
+      expect(poolInfo.apys.sma24h).toBeDefined()
+      expect(poolInfo.apys.sma7day).toBeDefined()
+      expect(poolInfo.apys.sma30day).toBeDefined()
     })
   })
 })

--- a/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
+++ b/sdk/sdk-e2e/e2e/armadaProtocol.vault.test.ts
@@ -42,4 +42,50 @@ describe('Armada Protocol - Vault', () => {
     assert(vaultInfo != null, 'Vault not found')
     console.log('Specific vault info:\n', stringifyArmadaVaultInfo(vaultInfo))
   })
+
+  it('should have apys property with all time period values', async () => {
+    const vaultId = ArmadaVaultId.createFrom({
+      chainInfo,
+      fleetAddress,
+    })
+    const vaultInfo = await sdk.armada.users.getVaultInfo({
+      vaultId,
+    })
+    assert(vaultInfo != null, 'Vault not found')
+    assert(vaultInfo.apys != null, 'apys property should exist')
+    assert('live' in vaultInfo.apys, 'apys should have live property')
+    assert('sma24h' in vaultInfo.apys, 'apys should have sma24h property')
+    assert('sma7day' in vaultInfo.apys, 'apys should have sma7day property')
+    assert('sma30day' in vaultInfo.apys, 'apys should have sma30day property')
+    console.log('APYs:', {
+      live: vaultInfo.apys.live?.toString(),
+      sma24h: vaultInfo.apys.sma24h?.toString(),
+      sma7day: vaultInfo.apys.sma7day?.toString(),
+      sma30day: vaultInfo.apys.sma30day?.toString(),
+    })
+  })
+
+  it('should verify all vaults have apys property', async () => {
+    const vaults = await sdk.armada.users.getVaultInfoList({
+      chainId,
+    })
+    assert(vaults.list.length > 0, 'Should have at least one vault')
+    vaults.list.forEach((vault) => {
+      assert(vault.apys != null, `Vault ${vault.id.toString()} should have apys property`)
+      assert('live' in vault.apys, `Vault ${vault.id.toString()} apys should have live property`)
+      assert(
+        'sma24h' in vault.apys,
+        `Vault ${vault.id.toString()} apys should have sma24h property`,
+      )
+      assert(
+        'sma7day' in vault.apys,
+        `Vault ${vault.id.toString()} apys should have sma7day property`,
+      )
+      assert(
+        'sma30day' in vault.apys,
+        `Vault ${vault.id.toString()} apys should have sma30day property`,
+      )
+    })
+    console.log('All vaults have valid apys property')
+  })
 })

--- a/sdk/sdk-e2e/e2e/utils/stringifiers.ts
+++ b/sdk/sdk-e2e/e2e/utils/stringifiers.ts
@@ -13,6 +13,12 @@ export function stringifyArmadaVaultInfo(vaultInfo: IArmadaVaultInfo): string {
       totalShares: vaultInfo.totalShares.toString(),
       sharePrice: vaultInfo.sharePrice.toString(),
       apy: vaultInfo.apy?.toString(),
+      apys: {
+        live: vaultInfo.apys.live?.toString(),
+        sma24h: vaultInfo.apys.sma24h?.toString(),
+        sma7day: vaultInfo.apys.sma7day?.toString(),
+        sma30day: vaultInfo.apys.sma30day?.toString(),
+      },
       rewardsApys: vaultInfo.rewardsApys.map((reward) => ({
         token: reward.token.toString(),
         apy: reward.apy?.toString(),


### PR DESCRIPTION
Introduce the VaultApys type to enhance the ArmadaVaultInfo interface, allowing for better representation of APY data across different time periods. Update related interfaces and implementations accordingly.