### PR TITLE
Refactor SiloRewardFetcher to use 'rewards' instead of 'programs' in SiloVaultReward interface and update related logic. Clean up TypeScript types in database-types.ts for consistency and readability.

### DIFF
--- a/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/SiloRewardFetcher.ts
+++ b/background-jobs/update-summer-earn-rewards-apr/src/reward-fetchers/SiloRewardFetcher.ts
@@ -11,7 +11,7 @@ interface SiloProgram {
 
 interface SiloVaultReward {
   vaultAddress: string
-  programs?: SiloProgram[]
+  rewards?: SiloProgram[]
 
   chainKey?: string
   protocolKey?: string
@@ -84,12 +84,12 @@ export class SiloRewardFetcher implements IRewardFetcher {
         (acc, product) => {
           const vaultData = productToSiloResponse[product.id]
 
-          if (!vaultData || !vaultData.programs || !Array.isArray(vaultData.programs)) {
+          if (!vaultData || !vaultData.rewards || !Array.isArray(vaultData.rewards)) {
             acc[product.id] = []
             return acc
           }
 
-          acc[product.id] = vaultData.programs
+          acc[product.id] = vaultData.rewards
             .filter((program) => program.rewardTokenSymbol && program.apr)
             .map((program, index) => {
               // Convert APR from 18 decimals and multiply by 100 for percentage

--- a/packages/summer-institutions-db/src/database-types.ts
+++ b/packages/summer-institutions-db/src/database-types.ts
@@ -1,38 +1,39 @@
-import type { ColumnType } from "kysely";
+import type { ColumnType } from 'kysely'
 
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>
 
-export type Timestamp = ColumnType<Date, Date | string, Date | string>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
-export type UserRole = "RoleAdmin" | "SuperAdmin" | "Viewer";
+export type UserRole = 'RoleAdmin' | 'SuperAdmin' | 'Viewer'
 
 export interface GlobalAdmins {
-  createdAt: Generated<Timestamp>;
-  id: Generated<number>;
-  userSub: string;
+  createdAt: Generated<Timestamp>
+  id: Generated<number>
+  userSub: string
 }
 
 export interface Institutions {
-  createdAt: Generated<Timestamp>;
-  displayName: string;
-  id: Generated<number>;
-  logoFile: Buffer | null;
-  logoUrl: Generated<string>;
-  name: string;
+  createdAt: Generated<Timestamp>
+  displayName: string
+  id: Generated<number>
+  logoFile: Buffer | null
+  logoUrl: Generated<string>
+  name: string
 }
 
 export interface InstitutionUsers {
-  createdAt: Generated<Timestamp>;
-  id: Generated<number>;
-  institutionId: number;
-  role: UserRole | null;
-  userSub: string;
+  createdAt: Generated<Timestamp>
+  id: Generated<number>
+  institutionId: number
+  role: UserRole | null
+  userSub: string
 }
 
 export interface Database {
-  globalAdmins: GlobalAdmins;
-  institutions: Institutions;
-  institutionUsers: InstitutionUsers;
+  globalAdmins: GlobalAdmins
+  institutions: Institutions
+  institutionUsers: InstitutionUsers
 }


### PR DESCRIPTION
refactor: update Silo reward fetcher property naming and format database types

- Rename `programs` to `rewards` in SiloVaultReward interface for better semantic clarity
- Update all references from `vaultData.programs` to `vaultData.rewards` in SiloRewardFetcher
- Format database-types.ts with consistent single quotes and semicolons
- Improve code readability and maintain consistent naming conventions

This change aligns the property naming with the actual data structure being used
for reward information in the Silo protocol integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved consistency in rewards data, enabling clearer calculations and display of reward rates.
- Refactor
  - Standardized naming for rewards across the system and updated internal validation and mapping to align with the new structure.
- Style
  - Formatting and style clean-up in database type definitions for improved readability.
- Notes
  - No expected changes to user workflows; improvements are primarily behind the scenes with minor clarity gains in rewards presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->