### PR TITLE
Disable vault switch on Hyperliquid and Arbitrum

### DIFF
--- a/packages/app-earn-ui/src/components/organisms/ControlsSwitch/ControlsSwitch.tsx
+++ b/packages/app-earn-ui/src/components/organisms/ControlsSwitch/ControlsSwitch.tsx
@@ -9,7 +9,11 @@ import {
   type TokenSymbolsList,
   type VaultApyData,
 } from '@summerfi/app-types'
-import { formatCryptoBalance, formatDecimalAsPercent } from '@summerfi/app-utils'
+import {
+  formatCryptoBalance,
+  formatDecimalAsPercent,
+  humanReadableChainToLabelMap,
+} from '@summerfi/app-utils'
 import clsx from 'clsx'
 
 import { Card } from '@/components/atoms/Card/Card'
@@ -181,7 +185,9 @@ export const ControlsSwitch = ({
     return potentialVaults.filter((vault) => vault.inputToken.symbol === filterByToken)
   }, [filterByToken, potentialVaults])
 
-  if (chainId === NetworkIds.HYPERLIQUID) {
+  if ([NetworkIds.HYPERLIQUID, NetworkIds.ARBITRUMMAINNET].includes(chainId)) {
+    const networkName = humanReadableChainToLabelMap[chainId]
+
     return (
       <div>
         <div className={controlsSwitchStyles.positionAndVaultsListWrapper}>
@@ -193,7 +199,7 @@ export const ControlsSwitch = ({
               margin: '30px 30px 0',
             }}
           >
-            Vault switching is not available on Hyperliquid
+            Vault switching is not available on {networkName}
             <br />
             at the moment.
           </Text>


### PR DESCRIPTION
## Description
Disable vault switching functionality for Hyperliquid and Arbitrum networks.

## Changes
- Updated the controls switch to disable vault switching on specified networks.
- Added a human-readable label for the network in the message displayed to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault switching is now disabled for additional networks.
  * Network names now display dynamically instead of hardcoded text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->