### PR TITLE
docs: update README to reflect current monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@
 
 ### Apps
 
-- `summerfi-api`: Summerfi API
+- `earn-protocol`: Summer.fi Earn Protocol (main app)
+- `earn-protocol-institutions`: Institutional portal
+- `earn-protocol-landing-page`: Static landing page
+- `summerfi-api`: Summerfi API (Lambda functions via SST)
 
 ### Packages
 
 - `sdk`: Summerfi SDK
+- `app-earn-ui`: Shared UI components for earn apps
+- `app-types`: Shared TypeScript types
+- `app-utils`: Shared utilities
+- `app-risk`: Risk assessment module
+- `app-tos`: Terms of Service module
 - `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and
   `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
@@ -58,3 +66,4 @@ Learn more about the power of Turborepo:
 - [Filtering](https://turbo.build/repo/docs/core-concepts/monorepos/filtering)
 - [Configuration Options](https://turbo.build/repo/docs/reference/configuration)
 - [CLI Usage](https://turbo.build/repo/docs/reference/command-line-reference)
+


### PR DESCRIPTION
The README currently only lists `summerfi-api` under Apps, but the monorepo has grown to include multiple apps and packages. This PR updates the structure section to accurately reflect the current state.

## Changes
- Added `earn-protocol`, `earn-protocol-institutions`, and `earn-protocol-landing-page` to Apps section
- Added `app-earn-ui`, `app-types`, `app-utils`, `app-risk`, and `app-tos` to Packages section

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to include a comprehensive listing of all applications and supporting packages in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->