### PR TITLE
feat: get blockchain management/performance fees with the old method as a fallback

### DIFF
--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/LandingPageHero.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/LandingPageHero.tsx
@@ -57,7 +57,7 @@ export const LandingPageHero = ({
       (vaultsList
         ? vaultsList.map((vault) => {
             const vaultInfo = findVaultInfo(vaultsInfo, vault)
-            const managementFee = getManagementFee(vault.inputToken.symbol)
+            const managementFee = vault.managementFee ?? getManagementFee(vault.inputToken.symbol)
 
             if (!vaultInfo) return 0
             if (!vaultsApyByNetworkMap) return 0

--- a/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/OurProducts.tsx
+++ b/apps/earn-protocol-landing-page/components/layout/LandingPageContent/components/OurProducts.tsx
@@ -66,7 +66,7 @@ export const OurProducts = ({
       (vaultsList
         ? vaultsList.map((vault) => {
             const vaultInfo = findVaultInfo(vaultsInfo, vault)
-            const managementFee = getManagementFee(vault.inputToken.symbol)
+            const managementFee = vault.managementFee ?? getManagementFee(vault.inputToken.symbol)
 
             if (!vaultInfo) return 0
             if (!vaultsApyByNetworkMap) return 0

--- a/apps/earn-protocol/app/api/landing-page-data/route.ts
+++ b/apps/earn-protocol/app/api/landing-page-data/route.ts
@@ -22,6 +22,7 @@ import { getDaoManagedVaultsIDsList } from '@/app/server-handlers/cached/get-vau
 import { getCachedVaultsApy } from '@/app/server-handlers/cached/get-vaults-apy'
 import { getCachedVaultsInfo } from '@/app/server-handlers/cached/get-vaults-info'
 import { getCachedVaultsList } from '@/app/server-handlers/cached/get-vaults-list'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import { getCachedRewardTokenPrice } from '@/app/server-handlers/reward-token-price'
 import { getPaginatedLatestActivity } from '@/app/server-handlers/tables-data/latest-activity/api'
 import { getPaginatedRebalanceActivity } from '@/app/server-handlers/tables-data/rebalance-activity/api'
@@ -136,11 +137,13 @@ export async function GET() {
 
   const daoManagedVaultsList = await getDaoManagedVaultsIDsList(vaults)
 
-  const vaultsWithConfig = decorateVaultsWithConfig({
-    systemConfig,
-    vaults,
-    daoManagedVaultsList,
-  })
+  const vaultsWithConfig = await decorateVaultsWithFees(
+    decorateVaultsWithConfig({
+      systemConfig,
+      vaults,
+      daoManagedVaultsList,
+    }),
+  )
 
   const vaultsApyByNetworkMap = await getCachedVaultsApy({
     fleets: vaultsWithConfig.map(({ id, protocol: { network } }) => ({

--- a/apps/earn-protocol/app/server-handlers/cached/get-fleet-fees/index.ts
+++ b/apps/earn-protocol/app/server-handlers/cached/get-fleet-fees/index.ts
@@ -1,0 +1,42 @@
+import { unstable_cache as unstableCache } from 'next/cache'
+
+import { type FleetCommanderFees, getFleetCommanderFees } from '@/app/server-handlers/fleet-fees'
+import { CACHE_TAGS, CACHE_TIMES } from '@/constants/revalidation'
+import { getFleetFeesTag } from '@/helpers/get-cache-handler-name'
+
+/**
+ * Per-vault cached read of the on-chain fleet fee rates (management + performance).
+ *
+ * Cached for 3h per (fleetAddress, chainId) so the value is fetched once and reused across every
+ * place that displays the management fee. Falls back to `null` fees on error so callers can
+ * gracefully degrade.
+ */
+export const getCachedFleetCommanderFees = async ({
+  fleetAddress,
+  chainId,
+}: {
+  fleetAddress: string
+  chainId: number
+}): Promise<FleetCommanderFees> => {
+  try {
+    return await unstableCache<
+      ({
+        fleetAddress,
+        chainId,
+      }: {
+        fleetAddress: string
+        chainId: number
+      }) => Promise<FleetCommanderFees>
+    >(getFleetCommanderFees, ['fleetFees'], {
+      revalidate: CACHE_TIMES.FLEET_FEES,
+      // Per-vault tag for surgical busting (vault open/manage refresh) + a shared tag so the
+      // vaults-list refresh can revalidate every vault's fees at once.
+      tags: [getFleetFeesTag(fleetAddress, chainId), CACHE_TAGS.FLEET_FEES],
+    })({ fleetAddress, chainId })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error fetching ${fleetAddress}-${chainId} fleet fees:`, error)
+
+    return { managementFee: null, performanceFee: null }
+  }
+}

--- a/apps/earn-protocol/app/server-handlers/fleet-fees/decorate-vaults-with-fees.ts
+++ b/apps/earn-protocol/app/server-handlers/fleet-fees/decorate-vaults-with-fees.ts
@@ -1,0 +1,31 @@
+import { type SDKVaultishType } from '@summerfi/app-types'
+import { subgraphNetworkToId, supportedSDKNetwork } from '@summerfi/app-utils'
+
+import { getCachedFleetCommanderFees } from '@/app/server-handlers/cached/get-fleet-fees'
+
+/**
+ * Attaches the on-chain fleet fee rates (`managementFee` from `tipRate`, `performanceFee` from
+ * `performanceFeeRate`) to each vault so every downstream UI can read them off the vault object
+ * instead of guessing from the input token symbol.
+ *
+ * Each vault's fees are fetched through the per-vault 3h cache, so calling this across a full list
+ * is cheap once warm. `managementFee` is normalised to `undefined` when unreadable so consumers can
+ * fall back to the legacy token-symbol heuristic.
+ */
+export const decorateVaultsWithFees = <T extends SDKVaultishType>(vaults: T[]): Promise<T[]> =>
+  Promise.all(
+    vaults.map(async (vault) => {
+      const chainId = subgraphNetworkToId(supportedSDKNetwork(vault.protocol.network))
+
+      const { managementFee, performanceFee } = await getCachedFleetCommanderFees({
+        fleetAddress: vault.id,
+        chainId,
+      })
+
+      return {
+        ...vault,
+        managementFee: managementFee ?? undefined,
+        performanceFee,
+      }
+    }),
+  )

--- a/apps/earn-protocol/app/server-handlers/fleet-fees/index.ts
+++ b/apps/earn-protocol/app/server-handlers/fleet-fees/index.ts
@@ -4,8 +4,8 @@ import { type Abi } from 'viem'
 
 import { getSSRPublicClient } from '@/helpers/get-ssr-public-client'
 
-// Both `tipRate` and `performanceFeeRate` are stored on-chain as a `Percentage` uint256 scaled by
-// 1e18 (the SDK writes/reads them with `shiftedBy(±18)`), so a raw value of 1e16 == 0.01 == 1%.
+// Both `tipRate` and `performanceFeeRate` are stored on-chain as uint256 scaled by
+// 1e18 (the SDK writes/reads them with `shiftedBy(±18)`), so a raw value of 1e16 == 1.0 == 1%.
 const FEE_RATE_DECIMALS = 18
 
 // `tipRate` lives in the checked-in FleetCommander ABI, but `performanceFeeRate` (RWA-only) does
@@ -22,9 +22,9 @@ const performanceFeeRateAbi = [
 ] as const satisfies Abi
 
 export type FleetCommanderFees = {
-  // annualised management fee (tipRate) as a decimal fraction (e.g. 0.01 = 1%); null if unreadable
+  // annualised management fee (tipRate) as a percentage number (e.g. 1.00 = 1%); null if unreadable
   managementFee: number | null
-  // RWA-only performance fee (performanceFeeRate) as a decimal fraction; null for non-RWA fleets
+  // RWA-only performance fee (performanceFeeRate) as a percentage number; null for non-RWA fleets
   performanceFee: number | null
 }
 

--- a/apps/earn-protocol/app/server-handlers/fleet-fees/index.ts
+++ b/apps/earn-protocol/app/server-handlers/fleet-fees/index.ts
@@ -1,0 +1,95 @@
+import { FleetCommanderAbi } from '@summerfi/armada-protocol-abis'
+import BigNumber from 'bignumber.js'
+import { type Abi } from 'viem'
+
+import { getSSRPublicClient } from '@/helpers/get-ssr-public-client'
+
+// Both `tipRate` and `performanceFeeRate` are stored on-chain as a `Percentage` uint256 scaled by
+// 1e18 (the SDK writes/reads them with `shiftedBy(±18)`), so a raw value of 1e16 == 0.01 == 1%.
+const FEE_RATE_DECIMALS = 18
+
+// `tipRate` lives in the checked-in FleetCommander ABI, but `performanceFeeRate` (RWA-only) does
+// not, so we read it through a minimal fragment. Non-RWA fleets don't implement it and revert,
+// which we treat as "no performance fee".
+const performanceFeeRateAbi = [
+  {
+    type: 'function',
+    name: 'performanceFeeRate',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256', internalType: 'Percentage' }],
+    stateMutability: 'view',
+  },
+] as const satisfies Abi
+
+export type FleetCommanderFees = {
+  // annualised management fee (tipRate) as a decimal fraction (e.g. 0.01 = 1%); null if unreadable
+  managementFee: number | null
+  // RWA-only performance fee (performanceFeeRate) as a decimal fraction; null for non-RWA fleets
+  performanceFee: number | null
+}
+
+const readFeeRate = async (read: () => Promise<bigint | unknown>): Promise<number | null> => {
+  try {
+    const raw = await read()
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (raw === undefined || raw === null) {
+      return null
+    }
+
+    return new BigNumber(String(raw))
+      .shiftedBy(-FEE_RATE_DECIMALS)
+      .shiftedBy(
+        // the value is in percent, need decimals
+        -2,
+      )
+      .toNumber()
+  } catch {
+    // A revert (e.g. performanceFeeRate on a non-RWA fleet) or transient RPC error -> treat as absent.
+    return null
+  }
+}
+
+/**
+ * Reads the on-chain fee rates for a single fleet (vault) contract.
+ *
+ * - `managementFee` comes from `tipRate()` and exists on every fleet.
+ * - `performanceFee` comes from `performanceFeeRate()` and only exists on RWA fleets; other fleets
+ *   revert and yield `null`.
+ *
+ * Both are returned as decimal fractions ready for `formatDecimalAsPercent`.
+ */
+export const getFleetCommanderFees = async ({
+  fleetAddress,
+  chainId,
+}: {
+  fleetAddress: string
+  chainId: number
+}): Promise<FleetCommanderFees> => {
+  const publicClient = await getSSRPublicClient(chainId)
+
+  if (!publicClient) {
+    throw new Error(`No public client available for chainId ${chainId}`)
+  }
+
+  const address = fleetAddress as `0x${string}`
+
+  const [managementFee, performanceFee] = await Promise.all([
+    readFeeRate(() =>
+      publicClient.readContract({
+        abi: FleetCommanderAbi,
+        address,
+        functionName: 'tipRate',
+      }),
+    ),
+    readFeeRate(() =>
+      publicClient.readContract({
+        abi: performanceFeeRateAbi,
+        address,
+        functionName: 'performanceFeeRate',
+      }),
+    ),
+  ])
+
+  return { managementFee, performanceFee }
+}

--- a/apps/earn-protocol/app/server-handlers/portfolio/resolve-portfolio-context.ts
+++ b/apps/earn-protocol/app/server-handlers/portfolio/resolve-portfolio-context.ts
@@ -14,6 +14,7 @@ import { getCachedUserPositions } from '@/app/server-handlers/cached/get-user-po
 import { getDaoManagedVaultsIDsList } from '@/app/server-handlers/cached/get-vault-dao-managed'
 import { getCachedVaultsInfo } from '@/app/server-handlers/cached/get-vaults-info'
 import { getCachedVaultsList } from '@/app/server-handlers/cached/get-vaults-list'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import { mergePositionWithVault } from '@/features/portfolio/helpers/merge-position-with-vault'
 import { decorateVaultsWithConfig } from '@/helpers/vault-custom-value-helpers'
 
@@ -56,21 +57,26 @@ export const resolvePortfolioContext = async ({ walletAddress }: { walletAddress
 
   // Standard vaults decorated for the view (positions carousel + DCA lookups). RWA vaults are
   // permissioned, so they intentionally stay out of the "you might like" surfaces.
-  const vaultsWithConfig = decorateVaultsWithConfig({
-    vaults: vaultsList.vaults,
-    systemConfig,
-    userPositions: userPositionsJsonSafe,
-    daoManagedVaultsList,
-  })
-
-  // Combined list (standard + RWA), used only to resolve each position to its vault and to drive
-  // the per-vault history/APY calls. RWA positions carry their own (RWA) vault into the view.
-  const allVaultsWithConfig = decorateVaultsWithConfig({
-    vaults: [...vaultsList.vaults, ...rwaVaultsList.vaults],
-    systemConfig,
-    userPositions: [...userPositionsJsonSafe, ...rwaUserPositionsJsonSafe],
-    daoManagedVaultsList,
-  })
+  const [vaultsWithConfig, allVaultsWithConfig] = await Promise.all([
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: vaultsList.vaults,
+        systemConfig,
+        userPositions: userPositionsJsonSafe,
+        daoManagedVaultsList,
+      }),
+    ),
+    // Combined list (standard + RWA), used only to resolve each position to its vault and to drive
+    // the per-vault history/APY calls. RWA positions carry their own (RWA) vault into the view.
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: [...vaultsList.vaults, ...rwaVaultsList.vaults],
+        systemConfig,
+        userPositions: [...userPositionsJsonSafe, ...rwaUserPositionsJsonSafe],
+        daoManagedVaultsList,
+      }),
+    ),
+  ])
 
   // Source of truth for which fleets are RWA: the RWA vaults list (their ids are the fleet
   // addresses). decorateWithFleetConfig keys the fleet config by vault id and can miss the RWA flag

--- a/apps/earn-protocol/app/server-handlers/vault-details/resolve-vault-details-context.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-details/resolve-vault-details-context.ts
@@ -10,6 +10,7 @@ import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
 import { getDaoManagedVaultsIDsList } from '@/app/server-handlers/cached/get-vault-dao-managed'
 import { getCachedVaultDetails } from '@/app/server-handlers/cached/get-vault-details'
 import { getCachedVaultsList } from '@/app/server-handlers/cached/get-vaults-list'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import {
   decorateVaultsWithConfig,
   getVaultIdByVaultCustomName,
@@ -70,17 +71,22 @@ export const resolveVaultDetailsContext = async ({
 
   const daoManagedVaultsList = await getDaoManagedVaultsIDsList(vaults)
 
-  const [vaultWithConfig] = decorateVaultsWithConfig({
-    vaults: [vault],
-    systemConfig,
-    daoManagedVaultsList,
-  })
-
-  const allVaultsWithConfig = decorateVaultsWithConfig({
-    vaults,
-    systemConfig,
-    daoManagedVaultsList,
-  })
+  const [[vaultWithConfig], allVaultsWithConfig] = await Promise.all([
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: [vault],
+        systemConfig,
+        daoManagedVaultsList,
+      }),
+    ),
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults,
+        systemConfig,
+        daoManagedVaultsList,
+      }),
+    ),
+  ])
 
   return {
     systemConfig,

--- a/apps/earn-protocol/app/server-handlers/vault-manage/resolve-vault-manage-context.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-manage/resolve-vault-manage-context.ts
@@ -12,6 +12,7 @@ import { getCachedRwaVaultsList } from '@/app/server-handlers/cached/get-rwa-vau
 import { getDaoManagedVaultsIDsList } from '@/app/server-handlers/cached/get-vault-dao-managed'
 import { getCachedVaultDetails } from '@/app/server-handlers/cached/get-vault-details'
 import { getCachedVaultsList } from '@/app/server-handlers/cached/get-vaults-list'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import { getUserPosition } from '@/app/server-handlers/sdk/get-user-position'
 import {
   decorateVaultsWithConfig,
@@ -102,18 +103,23 @@ export const resolveVaultManageContext = async ({
 
   const daoManagedVaultsList = await getDaoManagedVaultsIDsList(allVaults)
 
-  const [vaultWithConfig] = decorateVaultsWithConfig({
-    vaults: [vault],
-    systemConfig,
-    userPositions: position ? [position] : undefined,
-    daoManagedVaultsList,
-  })
-
-  const allVaultsWithConfig = decorateVaultsWithConfig({
-    vaults: allVaults,
-    systemConfig,
-    daoManagedVaultsList,
-  })
+  const [[vaultWithConfig], allVaultsWithConfig] = await Promise.all([
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: [vault],
+        systemConfig,
+        userPositions: position ? [position] : undefined,
+        daoManagedVaultsList,
+      }),
+    ),
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: allVaults,
+        systemConfig,
+        daoManagedVaultsList,
+      }),
+    ),
+  ])
 
   return {
     systemConfig,

--- a/apps/earn-protocol/app/server-handlers/vault-open/resolve-vault-open-context.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-open/resolve-vault-open-context.ts
@@ -12,6 +12,7 @@ import { getCachedRwaVaultsList } from '@/app/server-handlers/cached/get-rwa-vau
 import { getDaoManagedVaultsIDsList } from '@/app/server-handlers/cached/get-vault-dao-managed'
 import { getCachedVaultDetails } from '@/app/server-handlers/cached/get-vault-details'
 import { getCachedVaultsList } from '@/app/server-handlers/cached/get-vaults-list'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import {
   decorateVaultsWithConfig,
   getVaultCuratedBy,
@@ -67,17 +68,22 @@ export const resolveVaultOpenContext = async ({
   const allVaults = [...vaults, ...rwaVaults]
   const daoManagedVaultsList = await getDaoManagedVaultsIDsList(allVaults)
 
-  const [vaultWithConfig] = decorateVaultsWithConfig({
-    vaults: [vault],
-    systemConfig,
-    daoManagedVaultsList,
-  })
-
-  const allVaultsWithConfig = decorateVaultsWithConfig({
-    vaults: allVaults,
-    systemConfig,
-    daoManagedVaultsList,
-  })
+  const [[vaultWithConfig], allVaultsWithConfig] = await Promise.all([
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: [vault],
+        systemConfig,
+        daoManagedVaultsList,
+      }),
+    ),
+    decorateVaultsWithFees(
+      decorateVaultsWithConfig({
+        vaults: allVaults,
+        systemConfig,
+        daoManagedVaultsList,
+      }),
+    ),
+  ])
 
   return {
     systemConfig,

--- a/apps/earn-protocol/app/server-handlers/vaults-list/get-defi-vaults-list-data.ts
+++ b/apps/earn-protocol/app/server-handlers/vaults-list/get-defi-vaults-list-data.ts
@@ -15,6 +15,7 @@ import {
   emptyWalletAssets,
   getCachedWalletAssets,
 } from '@/app/server-handlers/cached/get-wallet-assets'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import { decorateVaultsWithConfig } from '@/helpers/vault-custom-value-helpers'
 
 // Shared by the /api/defi-vaults-list route and the server-side prefetch in the page, so the
@@ -42,11 +43,13 @@ export const getDefiVaultsListData = async (walletAddress?: string) => {
 
   const systemConfig = parseServerResponseToClient(configRaw)
 
-  const vaultsWithConfig = decorateVaultsWithConfig({
-    systemConfig,
-    vaults,
-    daoManagedVaultsList,
-  })
+  const vaultsWithConfig = await decorateVaultsWithFees(
+    decorateVaultsWithConfig({
+      systemConfig,
+      vaults,
+      daoManagedVaultsList,
+    }),
+  )
 
   const filteredWalletAssetsVaults = walletAddress
     ? vaultsWithConfig.filter((vault) => {

--- a/apps/earn-protocol/app/server-handlers/vaults-list/get-rwa-vaults-list-data.ts
+++ b/apps/earn-protocol/app/server-handlers/vaults-list/get-rwa-vaults-list-data.ts
@@ -13,6 +13,7 @@ import {
   emptyWalletAssets,
   getCachedWalletAssets,
 } from '@/app/server-handlers/cached/get-wallet-assets'
+import { decorateVaultsWithFees } from '@/app/server-handlers/fleet-fees/decorate-vaults-with-fees'
 import { getRwaVaultsListRaw } from '@/app/server-handlers/sdk/get-rwa-vaults-list'
 import { decorateVaultsWithConfig } from '@/helpers/vault-custom-value-helpers'
 
@@ -26,7 +27,8 @@ export const getRwaVaultsListData = async (walletAddress?: string) => {
   for (const vault of vaults) {
     const inputVault = vault.roundsVaultPair?.inputVault
 
-    if (inputVault?.minPositionSize != null && inputVault.underlyingToken?.decimals != null) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (inputVault?.minPositionSize != null && inputVault.underlyingToken.decimals != null) {
       liveMinDeposit[vault.id] = new BigNumber(inputVault.minPositionSize.toString())
         .div(ten.pow(inputVault.underlyingToken.decimals))
         .toNumber()
@@ -41,22 +43,24 @@ export const getRwaVaultsListData = async (walletAddress?: string) => {
 
   const systemConfig = parseServerResponseToClient(configRaw)
 
-  const vaultsWithConfig = decorateVaultsWithConfig({
-    systemConfig,
-    vaults,
-    daoManagedVaultsList: [],
-  }).map((vault) => {
-    // special case for RWA vaults - we want to override the minimumDeposit from config with the live one fetched from subgraph
-    const minDeposit = liveMinDeposit[vault.id]
+  const vaultsWithConfig = await decorateVaultsWithFees(
+    decorateVaultsWithConfig({
+      systemConfig,
+      vaults,
+      daoManagedVaultsList: [],
+    }).map((vault) => {
+      // special case for RWA vaults - we want to override the minimumDeposit from config with the live one fetched from subgraph
+      const minDeposit = liveMinDeposit[vault.id]
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (minDeposit == null || vault.customFields == null) return vault
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (minDeposit == null || vault.customFields == null) return vault
 
-    return {
-      ...vault,
-      customFields: { ...vault.customFields, minimumDeposit: minDeposit },
-    }
-  })
+      return {
+        ...vault,
+        customFields: { ...vault.customFields, minimumDeposit: minDeposit },
+      }
+    }),
+  )
 
   const filteredWalletAssetsVaults = walletAddress
     ? vaultsWithConfig.filter((vault) => {

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewDetails.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewDetails.tsx
@@ -68,7 +68,14 @@ export const VaultManageViewDetails: FC<{
   const vaultBenchmarkName = `${vaultBenchmarkAsset} Vault Benchmark`
   const buttonClickEventHandler = useHandleButtonClickEvent()
   const tooltipEventHandler = useHandleTooltipOpenEvent()
-  const managementFee = getManagementFee(vault.inputToken.symbol)
+  // Prefer the on-chain management fee (tipRate) decorated server-side; fall back to the
+  // token-symbol heuristic for any path that didn't fetch fees.
+  const managementFee = vault.managementFee ?? getManagementFee(vault.inputToken.symbol)
+  // RWA fleets also charge a performance fee (performanceFeeRate); non-RWA fleets don't implement it.
+  const performanceFee =
+    typeof vault.performanceFee === 'number' && vault.performanceFee > 0
+      ? vault.performanceFee
+      : null
 
   const humanReadableNetwork = capitalize(
     sdkNetworkToHumanNetwork(supportedSDKNetwork(vault.protocol.network)),
@@ -252,6 +259,9 @@ export const VaultManageViewDetails: FC<{
             }}
           >
             {formatDecimalAsPercent(managementFee)} management fee
+            {performanceFee !== null
+              ? ` + ${formatDecimalAsPercent(performanceFee)} performance fee`
+              : ''}
           </Text>
           <Text
             as="p"
@@ -260,10 +270,14 @@ export const VaultManageViewDetails: FC<{
               color: 'var(--color-text-secondary)',
             }}
           >
-            A {formatDecimalAsPercent(managementFee)} annualised management fee is charged for using
-            this strategy. The fees are continually accounted for and reflected in the market value
-            of your position. This strategy has no other fees, and there are no restrictions or
-            delays when withdrawing.{' '}
+            {performanceFee !== null
+              ? `A ${formatDecimalAsPercent(managementFee)} annualised management fee and a ${formatDecimalAsPercent(performanceFee)} performance fee are charged for using this strategy. `
+              : `A ${formatDecimalAsPercent(managementFee)} annualised management fee is charged for using this strategy. `}
+            The fees are continually accounted for and reflected in the market value of your
+            position.
+            {performanceFee !== null
+              ? ' There are no restrictions or delays when withdrawing.'
+              : ' This strategy has no other fees, and there are no restrictions or delays when withdrawing.'}{' '}
             {vaultApyData.sma30d
               ? ` The 30d APY for this strategy after fees is ${formatDecimalAsPercent(vaultApyData.sma30d - managementFee)}.`
               : ''}

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewDetails.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewDetails.tsx
@@ -71,7 +71,14 @@ export const VaultOpenViewDetails: FC<VaultOpenViewDetailsProps> = ({
     : 'USD'
   const vaultBenchmarkName = `${vaultBenchmarkAsset} Vault Benchmark`
 
-  const managementFee = getManagementFee(vault.inputToken.symbol)
+  // Prefer the on-chain management fee (tipRate) decorated server-side; fall back to the
+  // token-symbol heuristic for any path that didn't fetch fees.
+  const managementFee = vault.managementFee ?? getManagementFee(vault.inputToken.symbol)
+  // RWA fleets also charge a performance fee (performanceFeeRate); non-RWA fleets don't implement it.
+  const performanceFee =
+    typeof vault.performanceFee === 'number' && vault.performanceFee > 0
+      ? vault.performanceFee
+      : null
 
   const humanReadableNetwork = capitalize(
     sdkNetworkToHumanNetwork(supportedSDKNetwork(vault.protocol.network)),
@@ -221,6 +228,9 @@ export const VaultOpenViewDetails: FC<VaultOpenViewDetailsProps> = ({
             }}
           >
             {formatDecimalAsPercent(managementFee)} management fee
+            {performanceFee !== null
+              ? ` + ${formatDecimalAsPercent(performanceFee)} performance fee`
+              : ''}
           </Text>
           <Text
             as="p"
@@ -229,10 +239,14 @@ export const VaultOpenViewDetails: FC<VaultOpenViewDetailsProps> = ({
               color: 'var(--color-text-secondary)',
             }}
           >
-            A {formatDecimalAsPercent(managementFee)} annualised management fee is charged for using
-            this strategy. The fees are continually accounted for and reflected in the market value
-            of your position. This strategy has no other fees, and there are no restrictions or
-            delays when withdrawing.
+            {performanceFee !== null
+              ? `A ${formatDecimalAsPercent(managementFee)} annualised management fee and a ${formatDecimalAsPercent(performanceFee)} performance fee are charged for using this strategy. `
+              : `A ${formatDecimalAsPercent(managementFee)} annualised management fee is charged for using this strategy. `}
+            The fees are continually accounted for and reflected in the market value of your
+            position.
+            {performanceFee !== null
+              ? ' There are no restrictions or delays when withdrawing.'
+              : ' This strategy has no other fees, and there are no restrictions or delays when withdrawing.'}
             {vaultApyData.sma30d
               ? ` The 30d APY for this strategy after fees is ${formatDecimalAsPercent(vaultApyData.sma30d - managementFee)}.`
               : ''}

--- a/apps/earn-protocol/components/layout/VaultsListView/use-dao-managed-banner-data.ts
+++ b/apps/earn-protocol/components/layout/VaultsListView/use-dao-managed-banner-data.ts
@@ -38,7 +38,8 @@ export const useDaoManagedBannerData = ({
       (prev, current) => (getApyWithBonus(current) > getApyWithBonus(prev) ? current : prev),
     )
 
-    const managementFee = getManagementFee(highest7dApyVault.inputToken.symbol)
+    const managementFee =
+      highest7dApyVault.managementFee ?? getManagementFee(highest7dApyVault.inputToken.symbol)
 
     return {
       assets,

--- a/apps/earn-protocol/constants/revalidation.ts
+++ b/apps/earn-protocol/constants/revalidation.ts
@@ -27,6 +27,7 @@ export const CACHE_TAGS = {
   VAULT_DAO_MANAGED: 'vault-dao-managed',
   VAULT_PERFORMANCE: 'vault-performance',
   RWA_VAULTS_INFO: 'rwa-vaults-info',
+  FLEET_FEES: 'fleet-fees',
 }
 
 export const CACHE_TIMES = {
@@ -59,4 +60,5 @@ export const CACHE_TIMES = {
   STAKING_V2_GLOBAL_DATA: 300,
   ONE_DAY: 3600 * 24,
   RWA_VAULTS_INFO: 300,
+  FLEET_FEES: 3600 * 3, // 3 hours - on-chain management/performance fee rates change very rarely
 }

--- a/apps/earn-protocol/helpers/get-cache-handler-name.ts
+++ b/apps/earn-protocol/helpers/get-cache-handler-name.ts
@@ -25,5 +25,8 @@ export const getPositionsActivePeriodsTag = (walletAddress: string): string =>
 export const getSharePriceTag = (fleetAddress: string, chainId: number | string): string =>
   `share-price-${fleetAddress.toLowerCase()}-${chainId}`
 
+export const getFleetFeesTag = (fleetAddress: string, chainId: number | string): string =>
+  `${CACHE_TAGS.FLEET_FEES}-${fleetAddress.toLowerCase()}-${chainId}`
+
 export const getMerkleRewardsTag = (walletAddress: string): string =>
   `claimable-merkle-rewards-${walletAddress.toLowerCase()}`

--- a/apps/earn-protocol/hooks/use-revalidate.ts
+++ b/apps/earn-protocol/hooks/use-revalidate.ts
@@ -1,9 +1,10 @@
 'use client'
+import { humanNetworktoSDKNetwork, subgraphNetworkToId } from '@summerfi/app-utils'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 
 import { CACHE_TAGS } from '@/constants/revalidation'
-import { getUserDataCacheHandler } from '@/helpers/get-cache-handler-name'
+import { getFleetFeesTag, getUserDataCacheHandler } from '@/helpers/get-cache-handler-name'
 
 const fetchRevalidate = async ({
   tags,
@@ -76,7 +77,10 @@ export const useRevalidateVaultsListData = () => {
     })
 
     fetchRevalidate({
-      tags: [CACHE_TAGS.VAULTS_LIST, CACHE_TAGS.INTEREST_RATES].filter(Boolean),
+      // FLEET_FEES busts every vault's cached on-chain management/performance fee in one go.
+      tags: [CACHE_TAGS.VAULTS_LIST, CACHE_TAGS.INTEREST_RATES, CACHE_TAGS.FLEET_FEES].filter(
+        Boolean,
+      ),
     }).then(() => {
       refreshView()
     })
@@ -108,6 +112,10 @@ export const useRevalidatePositionData = () => {
       CACHE_TAGS.INTEREST_RATES,
       chainName && vaultPerformanceAsset
         ? `${CACHE_TAGS.VAULT_PERFORMANCE}-${chainName.toLowerCase()}-${vaultPerformanceAsset.toLowerCase()}`
+        : undefined,
+      // Surgically bust just this vault's cached on-chain fees so the refreshed page re-reads them.
+      chainName && vaultId
+        ? getFleetFeesTag(vaultId, subgraphNetworkToId(humanNetworktoSDKNetwork(chainName)))
         : undefined,
       walletAddress ? getUserDataCacheHandler(walletAddress) : undefined,
     ].filter(Boolean)

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
@@ -256,7 +256,8 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
     ]
   }, [mapVaultToDropdownItem, vaults])
 
-  const managementFee = getManagementFee(vault.inputToken.symbol)
+  // Prefer the on-chain fee decorated server-side; fall back to the token-symbol heuristic.
+  const managementFee = vault.managementFee ?? getManagementFee(vault.inputToken.symbol)
 
   return (
     <>

--- a/packages/app-earn-ui/src/components/molecules/VaultCard/VaultCard.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultCard/VaultCard.tsx
@@ -114,7 +114,10 @@ export const VaultCard: FC<VaultCardProps> = (props) => {
 
   const vaultInceptionDate = dayjs(Number(createdTimestamp) * 1000)
   const isNewVault = dayjs().diff(vaultInceptionDate, 'day') <= 30
-  const managementFee = getManagementFee(inputToken.symbol)
+  // Prefer the on-chain fee decorated server-side; fall back to the token-symbol heuristic for
+  // callers (e.g. the institutions app) that don't fetch fees.
+  // eslint-disable-next-line react/destructuring-assignment
+  const managementFee = props.managementFee ?? getManagementFee(inputToken.symbol)
 
   return (
     <GradientBox

--- a/packages/app-earn-ui/src/components/molecules/VaultCardHomepage/VaultCardHomepage.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultCardHomepage/VaultCardHomepage.tsx
@@ -263,7 +263,8 @@ export const VaultCardHomepage = ({
   const apyUpdatedAt = getVaultApyUpdatedAtLabel({
     apyTimestamp,
   })
-  const managementFee = getManagementFee(inputToken.symbol)
+  // Prefer the on-chain fee decorated server-side; fall back to the token-symbol heuristic.
+  const managementFee = vault.managementFee ?? getManagementFee(inputToken.symbol)
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const grossApy = (Number(apy) ?? 0) + (Number(rawTokenBonus) ?? 0)

--- a/packages/app-types/types/src/earn-protocol/index.ts
+++ b/packages/app-types/types/src/earn-protocol/index.ts
@@ -83,6 +83,13 @@ type VaultCustomFields = {
   // when the APY spans a shorter window (vault younger than 30d), the number of days actually used
   // (so the UI can explain the partial value); null/undefined when a full 30d window is available
   navApy30dPartialDays?: number | null
+  // annualised management fee read on-chain from the fleet contract's `tipRate`, as a decimal
+  // fraction (e.g. 0.01 = 1%); decorated server-side. Undefined on paths that don't fetch fees
+  // (callers fall back to the token-symbol heuristic in that case).
+  managementFee?: number
+  // RWA-only performance fee read on-chain from the fleet contract's `performanceFeeRate`, as a
+  // decimal fraction; null for non-RWA fleets (which don't implement it), undefined when not fetched.
+  performanceFee?: number | null
 }
 
 export type SDKVaultsListType = (GetVaultsQuery['vaults'][number] & VaultCustomFields)[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault management and performance fees are now fetched from the blockchain and displayed accurately across the app.
  * Enhanced fee messaging in vault details to clearly explain fee structures and withdrawal policies.
  * APY calculations now incorporate accurate server-provided fee data for more precise yield reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->