### PR TITLE
RWA pending position handling

### DIFF
--- a/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
@@ -17,6 +17,7 @@ import { redirect } from 'next/navigation'
 import { isAddress } from 'viem'
 
 import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
+import { getCachedRwaUserVaultExposure } from '@/app/server-handlers/cached/get-rwa-user-vault-exposure'
 import { getCachedRwaVaultDetails } from '@/app/server-handlers/cached/get-rwa-vault-details'
 import { getCachedVaultDetails } from '@/app/server-handlers/cached/get-vault-details'
 import { getUserPosition } from '@/app/server-handlers/sdk/get-user-position'
@@ -70,20 +71,28 @@ const VaultManageWithData = async ({
     !!parsedVaultId && !!getVaultCuratedBy(parsedVaultId, parsedNetworkId, systemConfig)
 
   if (isRwaVault) {
-    const position = parsedVaultId
-      ? await getUserPosition({
-          vaultAddress: parsedVaultId,
-          network: parsedNetwork,
-          walletAddress,
-          isRwaVault,
-        })
-      : undefined
+    const [position, exposure] = parsedVaultId
+      ? await Promise.all([
+          getUserPosition({
+            vaultAddress: parsedVaultId,
+            network: parsedNetwork,
+            walletAddress,
+            isRwaVault,
+          }),
+          getCachedRwaUserVaultExposure({
+            chainId: parsedNetworkId,
+            fleetAddress: parsedVaultId,
+            walletAddress,
+          }),
+        ])
+      : [undefined, null]
     const hasShares = !!position && new BigNumber(position.amount.amount).gt(0)
+    // A pre-claim user with no settled shares but pending/claimable exposure still belongs on the
+    // manage view (it synthesizes a "settling" position from this exposure). Only fall back to the
+    // deposit view when there is genuinely nothing (no shares AND no exposure).
+    const hasExposure = !!exposure && new BigNumber(exposure.total).gt(0)
 
-    if (!hasShares) {
-      // No Fleet shares yet (receipts only) — render the open/deposit view (same sidebar + pending
-      // positions). `resolveVaultManageContext` is RWA-aware so the manage path below also works
-      // once the user does hold shares.
+    if (!hasShares && !hasExposure) {
       await queryClient.prefetchQuery({
         queryKey: getVaultOpenCoreQueryKey(network, vaultId),
         queryFn: () => getVaultOpenCoreData({ network, vaultId }),

--- a/apps/earn-protocol/app/server-handlers/cached/get-rwa-user-vault-exposure/index.ts
+++ b/apps/earn-protocol/app/server-handlers/cached/get-rwa-user-vault-exposure/index.ts
@@ -1,0 +1,25 @@
+import { unstable_cache as unstableCache } from 'next/cache'
+
+import { getRwaUserVaultExposure } from '@/app/server-handlers/sdk/get-rwa-user-vault-exposure'
+import { CACHE_TIMES } from '@/constants/revalidation'
+import { getUserDataCacheHandler } from '@/helpers/get-cache-handler-name'
+
+// Cached per wallet under the user-data tag, so the existing revalidateUser() calls (after a
+// deposit/claim/cancel) bust it. Shared by the manage page's routing gate and the core-data handler
+// so they make a single network call.
+export const getCachedRwaUserVaultExposure = ({
+  chainId,
+  fleetAddress,
+  walletAddress,
+}: {
+  chainId: number
+  fleetAddress: string
+  walletAddress: string
+}) => {
+  const userKey = walletAddress.toLowerCase()
+
+  return unstableCache(getRwaUserVaultExposure, ['rwaUserExposure'], {
+    revalidate: CACHE_TIMES.PORTFOLIO_DATA,
+    tags: [getUserDataCacheHandler(userKey)],
+  })({ chainId, fleetAddress, walletAddress })
+}

--- a/apps/earn-protocol/app/server-handlers/sdk/get-rwa-user-vault-exposure.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-rwa-user-vault-exposure.ts
@@ -1,0 +1,62 @@
+import { type AddressValue, type ChainId } from '@summerfi/sdk-common'
+
+import { backendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+
+/**
+ * Server-side, JSON-safe view of a wallet's total RWA exposure to a fleet, split into the settlement
+ * buckets the rounds-vault model exposes. Amounts are decimal strings (denominated in the fleet
+ * input asset) so the result survives `unstable_cache` (JSON.stringify can't serialise the SDK's
+ * ITokenAmount/IFiatCurrencyAmount instances) and crosses to the client.
+ *
+ * `total = settledPosition + pendingDeposits + claimableDeposits + pendingWithdrawals`.
+ */
+export type RwaUserExposure = {
+  total: string
+  totalUsd: string
+  settledPosition: string
+  pendingDeposits: string
+  claimableDeposits: string
+  pendingWithdrawals: string
+  // Denomination of the amounts above (the fleet input asset, e.g. USDC).
+  tokenSymbol: string
+  tokenDecimals: number
+}
+
+/**
+ * Reads the wallet's RWA vault exposure through {@link backendInstiSDK} (institutional subgraph +
+ * Client-Id/Insti-Version headers). Additive to the page, so it degrades to `null` rather than
+ * throwing — a missing exposure simply means the manage view falls back to the deposit view.
+ */
+export async function getRwaUserVaultExposure({
+  chainId,
+  fleetAddress,
+  walletAddress,
+}: {
+  chainId: number
+  fleetAddress: string
+  walletAddress: string
+}): Promise<RwaUserExposure | null> {
+  try {
+    const exposure = await backendInstiSDK.rwa.getUserVaultExposure({
+      chainId: chainId as ChainId,
+      fleetAddress: fleetAddress.toLowerCase() as AddressValue,
+      userAddress: walletAddress.toLowerCase() as AddressValue,
+    })
+
+    return {
+      total: exposure.total.amount,
+      totalUsd: exposure.totalUsd.amount,
+      settledPosition: exposure.settledPosition.amount,
+      pendingDeposits: exposure.pendingDeposits.amount,
+      claimableDeposits: exposure.claimableDeposits.amount,
+      pendingWithdrawals: exposure.pendingWithdrawals.amount,
+      tokenSymbol: exposure.total.token.symbol,
+      tokenDecimals: exposure.total.token.decimals,
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('getRwaUserVaultExposure failed', error)
+
+    return null
+  }
+}

--- a/apps/earn-protocol/app/server-handlers/vault-manage/build-synthetic-rwa-position.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-manage/build-synthetic-rwa-position.ts
@@ -1,0 +1,60 @@
+import { type IArmadaPosition, type SDKVaultishType, type SDKVaultType } from '@summerfi/app-types'
+import { PositionType } from '@summerfi/sdk-common'
+
+import { type RwaUserExposure } from '@/app/server-handlers/sdk/get-rwa-user-vault-exposure'
+
+/**
+ * Builds a synthetic {@link IArmadaPosition} from a pre-claim RWA user's vault exposure, so the
+ * manage view can render a meaningful "settling" summary instead of bailing (no settled Fleet
+ * position exists yet — the user only holds receipts).
+ *
+ * The manage subtree only ever READS plain fields off the position (it crosses a JSON boundary via
+ * parseServerResponseToClient), so a plain object cast to IArmadaPosition is sufficient — no SDK
+ * class instances/methods are needed. Mapping (everything denominated in the fleet input asset):
+ *  - amount/assets/depositsAmount/netDeposits = exposure.total  → Market Value & Net Contribution
+ *  - shares = 0  (forces the share-price fallback to vault.pricePerShare in the manage view)
+ *  - withdrawalsAmount/earnings = 0  → Earned = 0 (nothing realised pre-settlement)
+ * The per-bucket breakdown (pending vs claimable) lives in the Deposits/Withdrawals table, not here.
+ */
+export const buildSyntheticRwaPosition = ({
+  exposure,
+  vault,
+}: {
+  exposure: RwaUserExposure
+  vault: SDKVaultType | SDKVaultishType
+}): IArmadaPosition => {
+  const token = vault.inputToken
+  const { total, totalUsd } = exposure
+  const priceUsd = String(vault.inputTokenPriceUSD ?? '0')
+
+  const ta = (amount: string) => ({ token, amount })
+  const fiat = (amount: string) => ({ amount, fiat: 'USD' })
+
+  return {
+    type: PositionType.Armada,
+    // amount is the deprecated alias of assets; both drive Market Value (= total exposure).
+    amount: ta(total),
+    assets: ta(total),
+    shares: ta('0'),
+    depositsAmount: ta(total),
+    withdrawalsAmount: ta('0'),
+    netDeposits: ta(total),
+    earnings: ta('0'),
+    assetPriceUSD: fiat(priceUsd),
+    assetsUSD: fiat(totalUsd),
+    depositsAmountUSD: fiat(totalUsd),
+    withdrawalsAmountUSD: fiat('0'),
+    netDepositsUSD: fiat(totalUsd),
+    earningsUSD: fiat('0'),
+    claimedSummerToken: ta('0'),
+    claimableSummerToken: ta('0'),
+    rewards: [],
+    deposits: [],
+    withdrawals: [],
+    // id/pool are not read by the manage subtree; minimal stubs keep the shape complete.
+    id: { id: vault.id },
+    pool: vault,
+    // Plain object intentionally cast: the manage view reads fields only and the value crosses a
+    // JSON boundary (the branded symbol / SDK instances are dropped there anyway).
+  } as unknown as IArmadaPosition
+}

--- a/apps/earn-protocol/app/server-handlers/vault-manage/get-vault-manage-core-data.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-manage/get-vault-manage-core-data.ts
@@ -14,12 +14,15 @@ import {
   supportedSDKNetwork,
 } from '@summerfi/app-utils'
 import { type IArmadaVaultInfo } from '@summerfi/sdk-common'
+import { BigNumber } from 'bignumber.js'
 
 import { getCachedClaimableWSTETHMerkleRewards } from '@/app/server-handlers/cached/claimable-merkle-rewards'
 import { getCachedPositionHistory } from '@/app/server-handlers/cached/get-position-history'
+import { getCachedRwaUserVaultExposure } from '@/app/server-handlers/cached/get-rwa-user-vault-exposure'
 import { getCachedVaultInfo } from '@/app/server-handlers/cached/get-vault-info'
 import { getCachedVaultsApy } from '@/app/server-handlers/cached/get-vaults-apy'
 import { getCachedRewardTokenPrice } from '@/app/server-handlers/reward-token-price'
+import { buildSyntheticRwaPosition } from '@/app/server-handlers/vault-manage/build-synthetic-rwa-position'
 import { resolveVaultManageContext } from '@/app/server-handlers/vault-manage/resolve-vault-manage-context'
 import {
   getMerkleNowClaimableTokenAddress,
@@ -55,7 +58,7 @@ export const getVaultManageCoreData = async ({
 }): Promise<VaultManageCoreData | null> => {
   const ctx = await resolveVaultManageContext({ network, vaultId, walletAddress })
 
-  if (!ctx.vault || !ctx.position || !ctx.vaultWithConfig) {
+  if (!ctx.vault || !ctx.vaultWithConfig) {
     return null
   }
 
@@ -68,6 +71,27 @@ export const getVaultManageCoreData = async ({
     vaultWithConfig,
     isRwaVault,
   } = ctx
+
+  // Resolve the effective position. A pre-claim RWA user has no settled Fleet position; if they hold
+  // exposure (pending/claimable deposits, pending withdrawals) we synthesize a position from it so
+  // the manage view renders a meaningful "settling" summary instead of bailing to the deposit view.
+  let { position } = ctx
+
+  if (!position && isRwaVault && parsedVaultId) {
+    const exposure = await getCachedRwaUserVaultExposure({
+      chainId: Number(parsedNetworkId),
+      fleetAddress: parsedVaultId,
+      walletAddress,
+    })
+
+    if (exposure && new BigNumber(exposure.total).gt(0)) {
+      position = buildSyntheticRwaPosition({ exposure, vault: vaultWithConfig })
+    }
+  }
+
+  if (!position) {
+    return null
+  }
 
   const [
     vaultsApyByNetworkMap,
@@ -121,7 +145,7 @@ export const getVaultManageCoreData = async ({
     vault: vaultWithConfig,
     vaults: ctx.allVaultsWithConfig,
     vaultsApyByNetworkMap,
-    position: parseServerResponseToClient<IArmadaPosition>(ctx.position),
+    position: parseServerResponseToClient<IArmadaPosition>(position),
     systemConfig,
     viewWalletAddress: walletAddress,
     vaultInfo: parseServerResponseToClient(vaultInfo),

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
@@ -314,11 +314,18 @@ export const VaultManageViewComponent = ({
     vault,
   })
 
+  // Pre-claim RWA user: the position is synthesized from exposure (no settled Fleet shares yet), so
+  // the manage view shows a "settling" summary rather than a real position.
+  const isRwaPendingPosition = isRwaVault && new BigNumber(position.shares.amount).lte(0)
+
   // Current vault share price (USDC per share); used to value RWA share receipts in USDC terms in
-  // both the sidebar pending positions and the manage-view deposits/withdrawals history.
+  // the manage-view deposits/withdrawals history. With no settled shares (pending RWA), fall back to
+  // the vault NAV per share so withdrawal-receipt valuation still works.
   const vaultSharePrice = new BigNumber(position.shares.amount).gt(0)
     ? netValue.div(new BigNumber(position.shares.amount))
-    : undefined
+    : vault.pricePerShare
+      ? new BigNumber(vault.pricePerShare)
+      : undefined
 
   const {
     amountParsed,
@@ -945,6 +952,7 @@ export const VaultManageViewComponent = ({
         vaultApyData={vaultApyData}
         vaults={vaults}
         position={position}
+        isRwaPendingPosition={isRwaPendingPosition}
         onRefresh={revalidatePositionData}
         viewWalletAddress={viewWalletAddress}
         connectedWalletAddress={userWalletAddress}
@@ -971,6 +979,7 @@ export const VaultManageViewComponent = ({
             vault={vault}
             vaultApyData={vaultApyData}
             isRwaVault={isRwaVault}
+            isRwaPendingPosition={isRwaPendingPosition}
             vaultSharePrice={vaultSharePrice}
             // Only the position owner can claim/cancel; non-owners view the history read-only.
             onRwaAction={ownerView ? executeRwaAction : undefined}

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewDetails.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewDetails.tsx
@@ -67,6 +67,9 @@ export const VaultManageViewDetails: FC<{
   // RWA-only: powers the "Deposits and Withdrawals" history expander. The receipt actions are
   // owned by the parent (shared useRwaClaim wiring) and passed down here.
   isRwaVault?: boolean
+  // RWA pre-claim (synthetic position from exposure): hide the position performance/forecast
+  // expander, which has no real position history to chart and whose section handler returns null.
+  isRwaPendingPosition?: boolean
   vaultSharePrice?: BigNumber
   onRwaAction?: (receipt: RwaReceipt) => void
   rwaActionInProgressKey?: string
@@ -78,6 +81,7 @@ export const VaultManageViewDetails: FC<{
   vault,
   vaultApyData,
   isRwaVault = false,
+  isRwaPendingPosition = false,
   vaultSharePrice,
   onRwaAction,
   rwaActionInProgressKey,
@@ -105,7 +109,9 @@ export const VaultManageViewDetails: FC<{
   // Each lazy expander tracks its own open state so the matching query is only `enabled` (and thus
   // only fetched) once the user reveals it. The performance chart is open by default, so it starts
   // enabled. Re-collapsing keeps the cached data; re-expanding doesn't refetch within staleTime.
-  const [performanceOpen, setPerformanceOpen] = useState(true)
+  // Pending RWA positions have no settled history/forecast to show, so the performance expander is
+  // hidden — keep its query disabled (start closed) to avoid a fetch for a section that won't render.
+  const [performanceOpen, setPerformanceOpen] = useState(!isRwaPendingPosition)
   const [rwaReceiptsOpen, setRwaReceiptsOpen] = useState(false)
   const [yieldOpen, setYieldOpen] = useState(false)
   const [exposureOpen, setExposureOpen] = useState(false)
@@ -152,26 +158,28 @@ export const VaultManageViewDetails: FC<{
     }
 
   return [
-    <div className={vaultManageViewStyles.leftContentWrapper} key="PerformanceBlock">
-      <Expander
-        title={
-          <Text as="p" variant="p1semi">
-            Forecasted Market Value
-          </Text>
-        }
-        onExpand={handleExpand('performance', setPerformanceOpen)}
-        defaultExpanded
-      >
-        {performanceQuery.data ? (
-          <PositionPerformanceChart
-            chartData={performanceQuery.data.performanceChartData}
-            inputToken={getDisplayToken(vault.inputToken.symbol)}
-          />
-        ) : (
-          <SectionLoader />
-        )}
-      </Expander>
-    </div>,
+    isRwaPendingPosition ? null : (
+      <div className={vaultManageViewStyles.leftContentWrapper} key="PerformanceBlock">
+        <Expander
+          title={
+            <Text as="p" variant="p1semi">
+              Forecasted Market Value
+            </Text>
+          }
+          onExpand={handleExpand('performance', setPerformanceOpen)}
+          defaultExpanded
+        >
+          {performanceQuery.data ? (
+            <PositionPerformanceChart
+              chartData={performanceQuery.data.performanceChartData}
+              inputToken={getDisplayToken(vault.inputToken.symbol)}
+            />
+          ) : (
+            <SectionLoader />
+          )}
+        </Expander>
+      </div>
+    ),
     <div className={vaultManageViewStyles.leftContentWrapper} key="AboutTheStrategy">
       <div>
         <Text

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -44,6 +44,7 @@ import {
   TransactionType,
 } from '@summerfi/sdk-common'
 import { useQueryClient } from '@tanstack/react-query'
+import BigNumber from 'bignumber.js'
 
 // import { type MigratablePosition } from '@/app/server-handlers/raw-calls/migration'
 import { ArbitrumNoticeBanner } from '@/components/layout/ArbitrumNoticeBanner/ArbitrumNoticeBanner'
@@ -79,6 +80,10 @@ import { useRevalidatePositionData, useRevalidateUser } from '@/hooks/use-revali
 import { useRwaClaim } from '@/hooks/use-rwa-claim'
 import { useRwaRoundInfo } from '@/hooks/use-rwa-round-info'
 import { useRwaSDK } from '@/hooks/use-rwa-sdk'
+import {
+  getRwaUserVaultExposureQueryKey,
+  useRwaUserVaultExposure,
+} from '@/hooks/use-rwa-user-vault-exposure'
 import { useTermsOfServiceSidebar } from '@/hooks/use-terms-of-service-sidebar'
 import { useTermsOfServiceSigner } from '@/hooks/use-terms-of-service-signer'
 import { useTokenBalance } from '@/hooks/use-token-balance'
@@ -367,8 +372,14 @@ export const VaultOpenViewComponent = ({
     queryClient.invalidateQueries({
       queryKey: getRwaReceiptsHistoryBaseQueryKey(network, vaultId, userWalletAddress),
     })
+    // Also refresh the exposure query so `hasRwaExposure` flips once the deposit is indexed, which
+    // forwards a receipts-only holder to their manage view (mirrors the regular-vault post-deposit
+    // redirect that fires when the settled position appears).
+    queryClient.invalidateQueries({
+      queryKey: getRwaUserVaultExposureQueryKey(vaultChainId, vault.id, userWalletAddress),
+    })
     revalidateUser(userWalletAddress)
-  }, [queryClient, network, vaultId, userWalletAddress, revalidateUser])
+  }, [queryClient, network, vaultId, userWalletAddress, revalidateUser, vaultChainId, vault.id])
 
   const {
     executeAction: executeRwaAction,
@@ -475,7 +486,18 @@ export const VaultOpenViewComponent = ({
       }
     }
   })
-  useRedirectToPositionView({ vault, position })
+  // A whitelisted, receipts-only RWA holder (no settled Fleet position) is forwarded to their manage
+  // view, which renders a "settling" position from this exposure.
+  const { data: rwaExposure } = useRwaUserVaultExposure({
+    enabled: isRwaVault && isWhitelisted,
+    sdk: rwaSdk,
+    fleetAddress: vault.id,
+    walletAddress: userWalletAddress,
+    chainId: vaultChainId,
+  })
+  const hasRwaExposure = !!rwaExposure && new BigNumber(rwaExposure.total.amount).gt(0)
+
+  useRedirectToPositionView({ vault, position, hasRwaExposure })
 
   const displaySimulationGraph = amountParsed.gt(0)
 

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -84,6 +84,10 @@ import {
   getRwaUserVaultExposureQueryKey,
   useRwaUserVaultExposure,
 } from '@/hooks/use-rwa-user-vault-exposure'
+import {
+  getRwaVaultMarketValueQueryKey,
+  useRwaVaultMarketValue,
+} from '@/hooks/use-rwa-vault-market-value'
 import { useTermsOfServiceSidebar } from '@/hooks/use-terms-of-service-sidebar'
 import { useTermsOfServiceSigner } from '@/hooks/use-terms-of-service-signer'
 import { useTokenBalance } from '@/hooks/use-token-balance'
@@ -378,6 +382,10 @@ export const VaultOpenViewComponent = ({
     queryClient.invalidateQueries({
       queryKey: getRwaUserVaultExposureQueryKey(vaultChainId, vault.id, userWalletAddress),
     })
+    // And the vault-wide market value, whose pending-deposits component grows with this deposit.
+    queryClient.invalidateQueries({
+      queryKey: getRwaVaultMarketValueQueryKey(vaultChainId, vault.id),
+    })
     revalidateUser(userWalletAddress)
   }, [queryClient, network, vaultId, userWalletAddress, revalidateUser, vaultChainId, vault.id])
 
@@ -496,6 +504,16 @@ export const VaultOpenViewComponent = ({
     chainId: vaultChainId,
   })
   const hasRwaExposure = !!rwaExposure && new BigNumber(rwaExposure.total.amount).gt(0)
+
+  // Vault-wide true TVL (Fleet assets + pending deposits + claimable withdrawals). The subgraph TVL
+  // only reflects settled Fleet assets, so the open-view "Market Value" uses this to include the
+  // settling deposits. Public (no wallet), so it loads for any visitor of an RWA vault.
+  const { data: rwaMarketValue } = useRwaVaultMarketValue({
+    enabled: isRwaVault,
+    sdk: rwaSdk,
+    fleetAddress: vault.id,
+    chainId: vaultChainId,
+  })
 
   useRedirectToPositionView({ vault, position, hasRwaExposure })
 
@@ -656,6 +674,7 @@ export const VaultOpenViewComponent = ({
         isMobileOrTablet={isMobileOrTablet}
         vault={vault}
         vaultInfo={vaultInfo}
+        rwaMarketValue={rwaMarketValue}
         rewardTokenPrices={rewardTokenPrices}
         vaults={vaults}
         medianDefiYield={medianDefiYield}

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -508,7 +508,7 @@ export const VaultOpenViewComponent = ({
   // Vault-wide true TVL (Fleet assets + pending deposits + claimable withdrawals). The subgraph TVL
   // only reflects settled Fleet assets, so the open-view "Market Value" uses this to include the
   // settling deposits. Public (no wallet), so it loads for any visitor of an RWA vault.
-  const { data: rwaMarketValue } = useRwaVaultMarketValue({
+  const { data: rwaMarketValue, isLoading: rwaMarketValueLoading } = useRwaVaultMarketValue({
     enabled: isRwaVault,
     sdk: rwaSdk,
     fleetAddress: vault.id,
@@ -675,6 +675,7 @@ export const VaultOpenViewComponent = ({
         vault={vault}
         vaultInfo={vaultInfo}
         rwaMarketValue={rwaMarketValue}
+        rwaMarketValueLoading={rwaMarketValueLoading}
         rewardTokenPrices={rewardTokenPrices}
         vaults={vaults}
         medianDefiYield={medianDefiYield}

--- a/apps/earn-protocol/hooks/use-redirect-to-position.ts
+++ b/apps/earn-protocol/hooks/use-redirect-to-position.ts
@@ -16,21 +16,27 @@ const minAmount = new BigNumber(0.01)
 export const useRedirectToPositionView = ({
   position,
   vault,
+  // RWA-only: a pre-claim holder has no Fleet position but does have exposure (pending/claimable
+  // receipts). When true, forward them from the open URL to their manage view (which renders a
+  // "settling" position from that exposure).
+  hasRwaExposure = false,
 }: {
   position?: IArmadaPosition
   vault: SDKVaultishType
+  hasRwaExposure?: boolean
 }) => {
   const pathname = usePathname()
   const { replace } = useRouter()
   const { address: userWalletAddress } = useEarnProtocolWallet()
 
   useEffect(() => {
-    if (!position || !userWalletAddress) {
+    if (!userWalletAddress) {
       return
     }
     const positionUsdValue =
-      vault.inputTokenPriceUSD &&
-      new BigNumber(position.amount.amount).times(vault.inputTokenPriceUSD)
+      position && vault.inputTokenPriceUSD
+        ? new BigNumber(position.amount.amount).times(vault.inputTokenPriceUSD)
+        : undefined
     const emptyPosition = positionUsdValue ? positionUsdValue.lt(minAmount) : true
 
     const vaultUrl = getVaultUrl(vault)
@@ -41,14 +47,19 @@ export const useRedirectToPositionView = ({
     })
 
     // RWA (rounds-based) vaults: a user with only receipts (no Fleet shares) is shown the deposit
-    // view on BOTH urls, so the position page must never be bounced back to the open page. We still
-    // forward the open page to the position page once the user actually holds shares (a Fleet
-    // position read via the RWA SDK), so claimed holders land on their manage view.
+    // view on BOTH urls, so the position page must never be bounced back to the open page. We
+    // forward the open page → position page once the user has a settled Fleet position OR pending/
+    // claimable exposure (the manage view renders a "settling" position from that exposure).
     if (vault.isRwaVault) {
-      if (pathname === vaultUrl && !emptyPosition) {
+      if (pathname === vaultUrl && (!emptyPosition || hasRwaExposure)) {
         replace(vaultPositionUrl)
       }
 
+      return
+    }
+
+    // Non-RWA redirects both ways but needs a real position to evaluate.
+    if (!position) {
       return
     }
 
@@ -57,5 +68,5 @@ export const useRedirectToPositionView = ({
     } else if (pathname === vaultPositionUrl && emptyPosition) {
       replace(vaultUrl)
     }
-  }, [pathname, position, replace, userWalletAddress, vault])
+  }, [pathname, position, replace, userWalletAddress, vault, hasRwaExposure])
 }

--- a/apps/earn-protocol/hooks/use-rwa-user-vault-exposure.ts
+++ b/apps/earn-protocol/hooks/use-rwa-user-vault-exposure.ts
@@ -1,0 +1,52 @@
+'use client'
+import { type SdkClient } from '@summerfi/sdk-client-react'
+import { type ChainId } from '@summerfi/sdk-common'
+import { useQuery } from '@tanstack/react-query'
+
+type UseRwaUserVaultExposureProps = {
+  // Only fetch when the vault is RWA, the wallet is whitelisted and connected.
+  enabled: boolean
+  sdk: SdkClient
+  fleetAddress: string
+  walletAddress?: string
+  chainId: number
+}
+
+// Shared so callers can invalidate this query after a deposit/claim/cancel (which changes exposure
+// and therefore whether the user is forwarded to their manage view).
+export const getRwaUserVaultExposureQueryKey = (
+  chainId: number,
+  fleetAddress: string,
+  walletAddress?: string,
+) => ['rwa-user-vault-exposure', chainId, fleetAddress.toLowerCase(), walletAddress?.toLowerCase()]
+
+/**
+ * Reads the connected wallet's total RWA vault exposure (settled + pending + claimable) client-side.
+ * Used on the open/deposit view to forward a receipts-only holder to their manage view, where the
+ * "settling" position summary is rendered.
+ */
+export const useRwaUserVaultExposure = ({
+  enabled,
+  sdk,
+  fleetAddress,
+  walletAddress,
+  chainId,
+}: UseRwaUserVaultExposureProps) =>
+  useQuery({
+    queryKey: [
+      'rwa-user-vault-exposure',
+      chainId,
+      fleetAddress.toLowerCase(),
+      walletAddress?.toLowerCase(),
+    ],
+    queryFn: () =>
+      sdk.getRwaUserVaultExposure({
+        fleetAddress: fleetAddress.toLowerCase() as `0x${string}`,
+        chainId: chainId as ChainId,
+        userAddress: (walletAddress as string).toLowerCase() as `0x${string}`,
+      }),
+    enabled: enabled && !!walletAddress,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  })

--- a/apps/earn-protocol/hooks/use-rwa-vault-market-value.ts
+++ b/apps/earn-protocol/hooks/use-rwa-vault-market-value.ts
@@ -1,0 +1,45 @@
+'use client'
+import { type SdkClient } from '@summerfi/sdk-client-react'
+import { type ChainId } from '@summerfi/sdk-common'
+import { useQuery } from '@tanstack/react-query'
+
+type UseRwaVaultMarketValueProps = {
+  // Only fetch for RWA (rounds-based) vaults.
+  enabled: boolean
+  sdk: SdkClient
+  fleetAddress: string
+  chainId: number
+}
+
+// Shared so the open view can invalidate this query after a deposit (which adds to the vault-wide
+// pending deposits and therefore the displayed market value).
+export const getRwaVaultMarketValueQueryKey = (chainId: number, fleetAddress: string) => [
+  'rwa-vault-market-value',
+  chainId,
+  fleetAddress.toLowerCase(),
+]
+
+/**
+ * Reads an RWA vault's total market value (true TVL) across all users — Fleet assets plus
+ * not-yet-settled pending deposits plus claimable withdrawals. The subgraph `totalValueLockedUSD` /
+ * `inputTokenBalance` only reflect the settled Fleet assets, so the open-view "Market Value" stat
+ * uses this to include the settling deposits. Vault-wide (no wallet), so it loads for any visitor.
+ */
+export const useRwaVaultMarketValue = ({
+  enabled,
+  sdk,
+  fleetAddress,
+  chainId,
+}: UseRwaVaultMarketValueProps) =>
+  useQuery({
+    queryKey: getRwaVaultMarketValueQueryKey(chainId, fleetAddress),
+    queryFn: () =>
+      sdk.getRwaVaultMarketValue({
+        fleetAddress: fleetAddress.toLowerCase() as `0x${string}`,
+        chainId: chainId as ChainId,
+      }),
+    enabled,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  })

--- a/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
@@ -55,6 +55,9 @@ interface VaultManageGridProps {
   vaults: SDKVaultsListType
   vaultInfo?: IArmadaVaultInfo
   position: IArmadaPosition
+  // RWA pre-claim: `position` is synthesized from exposure (no settled shares yet). Market Value
+  // shows the total exposure with a "Settling" caption, and the (zero) Earned subline is suppressed.
+  isRwaPendingPosition?: boolean
   detailsContent: ReactNode[] | ReactNode
   sidebarContent: ReactNode
   connectedWalletAddress?: string
@@ -85,6 +88,7 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
   detailsContent,
   sidebarContent,
   position,
+  isRwaPendingPosition = false,
   connectedWalletAddress,
   viewWalletAddress,
   isMobile,
@@ -393,25 +397,36 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
                   </Tooltip>
                 }
                 subValue={
-                  <Tooltip
-                    tooltip={<>USD&nbsp;Earned:&nbsp;${formatFiatBalance(netEarningsUSD)}</>}
-                    tooltipWrapperStyles={{
-                      maxWidth: '455px',
-                    }}
-                    onTooltipOpen={tooltipEventHandler}
-                    tooltipName="vault-manage-usd-earned-label"
-                  >
-                    <>
-                      Earned:&nbsp;
-                      {formatWithSeparators(netEarnings, {
-                        precision: 2,
-                      })}
-                      &nbsp;
-                      {getDisplayToken(vault.inputToken.symbol)}
-                    </>
-                  </Tooltip>
+                  isRwaPendingPosition ? (
+                    // Pre-claim RWA: nothing is "earned" yet; show the settling state instead.
+                    'Settling'
+                  ) : (
+                    <Tooltip
+                      tooltip={<>USD&nbsp;Earned:&nbsp;${formatFiatBalance(netEarningsUSD)}</>}
+                      tooltipWrapperStyles={{
+                        maxWidth: '455px',
+                      }}
+                      onTooltipOpen={tooltipEventHandler}
+                      tooltipName="vault-manage-usd-earned-label"
+                    >
+                      <>
+                        Earned:&nbsp;
+                        {formatWithSeparators(netEarnings, {
+                          precision: 2,
+                        })}
+                        &nbsp;
+                        {getDisplayToken(vault.inputToken.symbol)}
+                      </>
+                    </Tooltip>
+                  )
                 }
-                subValueType={netEarnings.isPositive() ? 'positive' : 'negative'}
+                subValueType={
+                  isRwaPendingPosition
+                    ? undefined
+                    : netEarnings.isPositive()
+                      ? 'positive'
+                      : 'negative'
+                }
                 subValueSize="small"
               />
             </Box>

--- a/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
@@ -397,10 +397,7 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
                   </Tooltip>
                 }
                 subValue={
-                  isRwaPendingPosition ? (
-                    // Pre-claim RWA: nothing is "earned" yet; show the settling state instead.
-                    'Settling'
-                  ) : (
+                  isRwaPendingPosition ? null : ( // Pre-claim RWA: nothing is "earned" yet
                     <Tooltip
                       tooltip={<>USD&nbsp;Earned:&nbsp;${formatFiatBalance(netEarningsUSD)}</>}
                       tooltipWrapperStyles={{

--- a/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
@@ -151,10 +151,14 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
   const apyUpdatedAt = useApyUpdatedAt({
     vaultApyData,
   })
-  // RWA (rounds-based) vaults accrue value as NAV per share, not a yield APY. The 30d block's "Live
-  // APY" subValue is replaced with NAV Price (the 30d value stays). `vault.isRwaVault` is reliable
-  // here (manage view receives the RWA detail vault, which the fleet-config decoration flags).
+  // RWA (rounds-based) vaults accrue value as NAV per share, not a yield APY. The 30d block shows a
+  // NAV-based net APY (NAV price change over 30d) instead of the yield SMA, and its "Live APY"
+  // subValue is replaced with NAV Price. `vault.isRwaVault` is reliable here (manage view receives
+  // the RWA detail vault, which the fleet-config decoration flags).
   const isRwaVault = vault.isRwaVault ?? false
+  // Mirror the open view's "30D Net APY": NAV price change over 30d (n/a until available), with a
+  // partial-days note while the vault is younger than 30 days.
+  const rwaNetApy30d = vault.navApy30d != null ? formatDecimalAsPercent(vault.navApy30d) : 'n/a'
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -447,11 +451,19 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
               <DataBlock
                 size="large"
                 titleSize="small"
-                title="30d Native Yield APY"
+                title={isRwaVault ? '30D Net APY' : '30d Native Yield APY'}
+                tooltipName={isRwaVault ? 'vault-manage-30d-net-apy' : undefined}
+                onTooltipOpen={isRwaVault ? tooltipEventHandler : undefined}
+                tooltipIconName={isRwaVault ? 'info' : undefined}
+                titleTooltip={
+                  isRwaVault && vault.navApy30dPartialDays != null
+                    ? `Vault has been deployed recently and the value is calculated using the last ${vault.navApy30dPartialDays} days`
+                    : undefined
+                }
                 value={
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Text variant="h4" style={{ marginRight: 'var(--general-space-8)' }}>
-                      {apy30d}
+                      {isRwaVault ? rwaNetApy30d : apy30d}
                     </Text>
                     <Icon iconName="stars_colorful" size={20} />
                   </div>

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/RwaVaultStatsGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/RwaVaultStatsGrid.tsx
@@ -14,21 +14,40 @@ import { NavPrice } from '@/components/molecules/NavPrice/NavPrice'
 import { Tooltip } from '@/components/molecules/Tooltip/Tooltip'
 import { getDisplayToken } from '@/helpers/get-display-token'
 
+// Vault-wide true TVL (Fleet assets + pending deposits + claimable withdrawals), denominated in the
+// Fleet input asset. Minimal structural shape of the SDK's `IRwaVaultMarketValue` (`.amount` is the
+// human-readable decimal string) so this shared component stays decoupled from the SDK type.
+export interface RwaVaultMarketValue {
+  total: { amount: string }
+  totalUsd: { amount: string }
+}
+
 interface RwaVaultStatsGridProps {
   vault: SDKVaultishType
+  // When provided, the "Market Value" stat uses this broader TVL (including settling deposits)
+  // instead of the subgraph TVL, which only reflects settled Fleet assets.
+  rwaMarketValue?: RwaVaultMarketValue
   isMobileOrTablet?: boolean
   tooltipEventHandler: (tooltipName: string) => void
 }
 
 export const RwaVaultStatsGrid: FC<RwaVaultStatsGridProps> = ({
   vault,
+  rwaMarketValue,
   isMobileOrTablet,
   tooltipEventHandler,
 }) => {
-  const totalValueLockedUSDParsed = formatCryptoBalance(new BigNumber(vault.totalValueLockedUSD))
-  const totalValueLockedTokenParsed = formatCryptoBalance(
-    new BigNumber(vault.inputTokenBalance.toString()).div(ten.pow(vault.inputToken.decimals)),
-  )
+  // Prefer the broader market value (includes not-yet-settled deposits); fall back to the subgraph
+  // settled-only TVL until it loads.
+  const marketValueToken = rwaMarketValue
+    ? new BigNumber(rwaMarketValue.total.amount)
+    : new BigNumber(vault.inputTokenBalance.toString()).div(ten.pow(vault.inputToken.decimals))
+  const marketValueUSD = rwaMarketValue
+    ? new BigNumber(rwaMarketValue.totalUsd.amount)
+    : new BigNumber(vault.totalValueLockedUSD)
+
+  const totalValueLockedUSDParsed = formatCryptoBalance(marketValueUSD)
+  const totalValueLockedTokenParsed = formatCryptoBalance(marketValueToken)
 
   return (
     <>

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/RwaVaultStatsGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/RwaVaultStatsGrid.tsx
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js'
 
 import { Box } from '@/components/atoms/Box/Box'
 import { Icon } from '@/components/atoms/Icon/Icon'
+import { SkeletonLine } from '@/components/atoms/SkeletonLine/SkeletonLine'
 import { Text } from '@/components/atoms/Text/Text'
 import { DataBlock } from '@/components/molecules/DataBlock/DataBlock'
 import { SimpleGrid } from '@/components/molecules/Grid/SimpleGrid'
@@ -27,6 +28,7 @@ interface RwaVaultStatsGridProps {
   // When provided, the "Market Value" stat uses this broader TVL (including settling deposits)
   // instead of the subgraph TVL, which only reflects settled Fleet assets.
   rwaMarketValue?: RwaVaultMarketValue
+  rwaMarketValueLoading?: boolean
   isMobileOrTablet?: boolean
   tooltipEventHandler: (tooltipName: string) => void
 }
@@ -34,6 +36,7 @@ interface RwaVaultStatsGridProps {
 export const RwaVaultStatsGrid: FC<RwaVaultStatsGridProps> = ({
   vault,
   rwaMarketValue,
+  rwaMarketValueLoading,
   isMobileOrTablet,
   tooltipEventHandler,
 }) => {
@@ -64,10 +67,21 @@ export const RwaVaultStatsGrid: FC<RwaVaultStatsGridProps> = ({
             title="Market Value"
             value={
               <>
-                {totalValueLockedTokenParsed}&nbsp;{getDisplayToken(vault.inputToken.symbol)}
+                {rwaMarketValueLoading ? (
+                  <SkeletonLine height={24} width={70} style={{ display: 'inline-block' }} />
+                ) : (
+                  totalValueLockedTokenParsed
+                )}
+                &nbsp;{getDisplayToken(vault.inputToken.symbol)}
               </>
             }
-            subValue={`$${totalValueLockedUSDParsed}`}
+            subValue={
+              rwaMarketValueLoading ? (
+                <SkeletonLine height={20} width={50} />
+              ) : (
+                `$${totalValueLockedUSDParsed}`
+              )
+            }
             subValueSize="small"
           />
         </Box>

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
@@ -37,7 +37,7 @@ import { getRewardsTokenBonus } from '@/helpers/get-reward-token-bonus'
 import { getVaultUrl } from '@/helpers/get-vault-url'
 import { isVaultAtLeastDaysOld } from '@/helpers/is-vault-at-least-days-old'
 
-import { RwaVaultStatsGrid } from './RwaVaultStatsGrid'
+import { type RwaVaultMarketValue, RwaVaultStatsGrid } from './RwaVaultStatsGrid'
 import { StandardVaultStatsGrid } from './StandardVaultStatsGrid'
 
 import vaultOpenGridStyles from './VaultOpenGrid.module.css'
@@ -46,6 +46,8 @@ interface VaultOpenGridProps {
   vault: SDKVaultishType
   vaults: SDKVaultsListType
   vaultInfo?: IArmadaVaultInfo
+  // RWA-only: vault-wide true TVL (incl. settling deposits) for the "Market Value" stat.
+  rwaMarketValue?: RwaVaultMarketValue
   displaySimulationGraph?: boolean
   simulationGraph: ReactNode
   detailsContent: ReactNode
@@ -75,6 +77,7 @@ interface VaultOpenGridProps {
 export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
   vault,
   vaultInfo,
+  rwaMarketValue,
   vaults,
   displaySimulationGraph,
   simulationGraph,
@@ -333,6 +336,7 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
           {isRwaVault ? (
             <RwaVaultStatsGrid
               vault={vault}
+              rwaMarketValue={rwaMarketValue}
               isMobileOrTablet={isMobileOrTablet}
               tooltipEventHandler={tooltipEventHandler}
             />

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
@@ -48,6 +48,7 @@ interface VaultOpenGridProps {
   vaultInfo?: IArmadaVaultInfo
   // RWA-only: vault-wide true TVL (incl. settling deposits) for the "Market Value" stat.
   rwaMarketValue?: RwaVaultMarketValue
+  rwaMarketValueLoading?: boolean
   displaySimulationGraph?: boolean
   simulationGraph: ReactNode
   detailsContent: ReactNode
@@ -78,6 +79,7 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
   vault,
   vaultInfo,
   rwaMarketValue,
+  rwaMarketValueLoading,
   vaults,
   displaySimulationGraph,
   simulationGraph,
@@ -337,6 +339,7 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
             <RwaVaultStatsGrid
               vault={vault}
               rwaMarketValue={rwaMarketValue}
+              rwaMarketValueLoading={rwaMarketValueLoading}
               isMobileOrTablet={isMobileOrTablet}
               tooltipEventHandler={tooltipEventHandler}
             />


### PR DESCRIPTION

Route pre-claim RWA users to the manage view with a "settling" position

Pre-claim RWA users (holding receipts but no settled Fleet position) were previously stuck on the deposit view with no visibility into their pending exposure. They are now routed to the manage view, which renders a synthetic position derived from getUserVaultExposure (Market Value = total exposure, Earned = 0, "Settling" caption). After a successful deposit the manage redirect fires automatically — same flow as regular vaults. The performance/forecast expander is hidden for pre-claim users since there's no position history to chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RWA vault exposure detection and visibility for pending positions
  * Pending positions now display "Settling" status instead of earned amounts

* **Improvements**
  * Enhanced navigation to correctly route users with RWA exposure to their position view
  * Optimized exposure data fetching with caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->