### PR TITLE
RWA: multi-institution support + vault-name titles

### DIFF
--- a/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
+++ b/apps/earn-protocol/app/[network]/position/[vaultId]/[walletAddress]/page.tsx
@@ -33,6 +33,7 @@ import { getSeoKeywords } from '@/helpers/seo-keywords'
 import {
   getVaultCuratedBy,
   getVaultIdByVaultCustomName,
+  getVaultRwaClientId,
 } from '@/helpers/vault-custom-value-helpers'
 
 type EarnVaultManagePageProps = {
@@ -71,21 +72,26 @@ const VaultManageWithData = async ({
     !!parsedVaultId && !!getVaultCuratedBy(parsedVaultId, parsedNetworkId, systemConfig)
 
   if (isRwaVault) {
-    const [position, exposure] = parsedVaultId
-      ? await Promise.all([
-          getUserPosition({
-            vaultAddress: parsedVaultId,
-            network: parsedNetwork,
-            walletAddress,
-            isRwaVault,
-          }),
-          getCachedRwaUserVaultExposure({
-            chainId: parsedNetworkId,
-            fleetAddress: parsedVaultId,
-            walletAddress,
-          }),
-        ])
-      : [undefined, null]
+    const rwaClientId = parsedVaultId
+      ? getVaultRwaClientId(parsedVaultId, parsedNetworkId, systemConfig)
+      : undefined
+    const [position, exposure] =
+      parsedVaultId && rwaClientId
+        ? await Promise.all([
+            getUserPosition({
+              vaultAddress: parsedVaultId,
+              network: parsedNetwork,
+              walletAddress,
+              isRwaVault,
+            }),
+            getCachedRwaUserVaultExposure({
+              chainId: parsedNetworkId,
+              fleetAddress: parsedVaultId,
+              walletAddress,
+              clientId: rwaClientId,
+            }),
+          ])
+        : [undefined, null]
     const hasShares = !!position && new BigNumber(position.amount.amount).gt(0)
     // A pre-claim user with no settled shares but pending/claimable exposure still belongs on the
     // manage view (it synthesizes a "settling" position from this exposure). Only fall back to the

--- a/apps/earn-protocol/app/server-handlers/cached/get-rwa-user-vault-exposure/index.ts
+++ b/apps/earn-protocol/app/server-handlers/cached/get-rwa-user-vault-exposure/index.ts
@@ -11,15 +11,19 @@ export const getCachedRwaUserVaultExposure = ({
   chainId,
   fleetAddress,
   walletAddress,
+  clientId,
 }: {
   chainId: number
   fleetAddress: string
   walletAddress: string
+  // Institution that owns the vault (its `vaultInstitutionId`) — selects the SDK deployment to read
+  // exposure from, and is part of the cache key via the forwarded args.
+  clientId: string
 }) => {
   const userKey = walletAddress.toLowerCase()
 
   return unstableCache(getRwaUserVaultExposure, ['rwaUserExposure'], {
     revalidate: CACHE_TIMES.PORTFOLIO_DATA,
     tags: [getUserDataCacheHandler(userKey)],
-  })({ chainId, fleetAddress, walletAddress })
+  })({ chainId, fleetAddress, walletAddress, clientId })
 }

--- a/apps/earn-protocol/app/server-handlers/sdk/get-rwa-user-positions.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-rwa-user-positions.ts
@@ -1,21 +1,28 @@
 import { type IArmadaPosition } from '@summerfi/app-types'
 import { Address, getChainInfoByChainId, User, Wallet } from '@summerfi/sdk-common'
 
-import { backendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
+import { getBackendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
 import { rwaSupportedChainIds } from '@/app/server-handlers/subgraphs-map'
+import { getRwaClientIdsForChain, isVaultDisabled } from '@/helpers/vault-custom-value-helpers'
 
 /**
  * Fetches the wallet's claimed RWA Fleet positions (shares). These live in the institutional
- * subgraph, so they must be read through {@link backendInstiSDK} (Client-Id + Insti-Version
- * headers) — the public SDK returns nothing for them. The shape is the standard IArmadaPosition,
- * so these positions flow through the same portfolio pipeline as regular vault positions.
+ * subgraph, so they must be read through the institutional SDK ({@link getBackendInstiSDK}: Client-Id
+ * + Insti-Version headers) — the public SDK returns nothing for them. The shape is the standard
+ * IArmadaPosition, so these positions flow through the same portfolio pipeline as regular vault
+ * positions.
  *
- * Supported networks are derived from rwaSubgraphsMap (the single RWA-network source of truth).
+ * Supported networks are derived from rwaSubgraphsMap; the institutions per network are derived from
+ * the fleet config's `vaultInstitutionId`. `getUserPositions` has no clientId param — it's scoped to
+ * the SDK instance's `Client-Id` header — so we fetch once per (network, institution) instance.
  */
 export async function getRwaUserPositions({ walletAddress }: { walletAddress: string }) {
   try {
-    const positionsByNetwork = await Promise.all(
-      rwaSupportedChainIds.map(async (chainId) => {
+    const systemConfig = await getCachedConfig()
+
+    const positionsByChainAndClient = await Promise.all(
+      rwaSupportedChainIds.flatMap((chainId) => {
         const chainInfo = getChainInfoByChainId(Number(chainId))
 
         const wallet = Wallet.createFrom({
@@ -28,20 +35,32 @@ export async function getRwaUserPositions({ walletAddress }: { walletAddress: st
           wallet,
         })
 
-        // Per-network resilience: one network (e.g. a newly-enabled Mainnet) failing must not drop
-        // the other networks' positions. The outer catch is the last-resort safety net.
-        return await backendInstiSDK.armada.users
-          .getUserPositions({ user })
-          .catch((error: unknown) => {
-            // eslint-disable-next-line no-console
-            console.error(`getRwaUserPositions failed for chainId ${chainId}`, error)
+        // Per (network, institution) resilience: one failing must not drop the others' positions.
+        // The outer catch is the last-resort safety net.
+        return getRwaClientIdsForChain(chainId, systemConfig).map((clientId) =>
+          getBackendInstiSDK(clientId)
+            .armada.users.getUserPositions({ user })
+            // Exclude positions in vaults flagged `disabled: true` in config (hidden/unused).
+            .then((positions) =>
+              positions.filter(
+                (position) =>
+                  !isVaultDisabled(position.pool.id.fleetAddress.value, chainId, systemConfig),
+              ),
+            )
+            .catch((error: unknown) => {
+              // eslint-disable-next-line no-console
+              console.error(
+                `getRwaUserPositions failed for chainId ${chainId} clientId ${clientId}`,
+                error,
+              )
 
-            return [] as IArmadaPosition[]
-          })
+              return [] as IArmadaPosition[]
+            }),
+        )
       }),
     )
 
-    const positionsList = positionsByNetwork
+    const positionsList = positionsByChainAndClient
       .filter(Boolean)
       .reduce<IArmadaPosition[]>((acc, positions) => [...acc, ...positions], [])
 

--- a/apps/earn-protocol/app/server-handlers/sdk/get-rwa-user-vault-exposure.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-rwa-user-vault-exposure.ts
@@ -1,6 +1,6 @@
 import { type AddressValue, type ChainId } from '@summerfi/sdk-common'
 
-import { backendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { getBackendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
 
 /**
  * Server-side, JSON-safe view of a wallet's total RWA exposure to a fleet, split into the settlement
@@ -23,21 +23,24 @@ export type RwaUserExposure = {
 }
 
 /**
- * Reads the wallet's RWA vault exposure through {@link backendInstiSDK} (institutional subgraph +
- * Client-Id/Insti-Version headers). Additive to the page, so it degrades to `null` rather than
+ * Reads the wallet's RWA vault exposure through the institution's SDK ({@link getBackendInstiSDK}:
+ * institutional subgraph + Client-Id/Insti-Version headers). `clientId` selects the institution that
+ * owns the vault (its `vaultInstitutionId`). Additive to the page, so it degrades to `null` rather than
  * throwing — a missing exposure simply means the manage view falls back to the deposit view.
  */
 export async function getRwaUserVaultExposure({
   chainId,
   fleetAddress,
   walletAddress,
+  clientId,
 }: {
   chainId: number
   fleetAddress: string
   walletAddress: string
+  clientId: string
 }): Promise<RwaUserExposure | null> {
   try {
-    const exposure = await backendInstiSDK.rwa.getUserVaultExposure({
+    const exposure = await getBackendInstiSDK(clientId).rwa.getUserVaultExposure({
       chainId: chainId as ChainId,
       fleetAddress: fleetAddress.toLowerCase() as AddressValue,
       userAddress: walletAddress.toLowerCase() as AddressValue,

--- a/apps/earn-protocol/app/server-handlers/sdk/get-rwa-vault-details.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-rwa-vault-details.ts
@@ -4,10 +4,13 @@ import { Address, ArmadaVaultId, getChainInfoByChainId } from '@summerfi/sdk-com
 
 import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
 import { serverOnlyErrorHandler } from '@/app/server-handlers/error-handler'
-import { backendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { getBackendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
 import { getNavPriceChange24h } from '@/helpers/get-nav-price-change-24h'
 import { getNavPriceChange30d } from '@/helpers/get-nav-price-change-30d'
-import { getVaultNavPriceSkipFirstNDays } from '@/helpers/vault-custom-value-helpers'
+import {
+  getVaultNavPriceSkipFirstNDays,
+  getVaultRwaClientId,
+} from '@/helpers/vault-custom-value-helpers'
 
 export async function getRwaVaultDetails({
   vaultAddress,
@@ -24,6 +27,16 @@ export async function getRwaVaultDetails({
     const chainId = subgraphNetworkToId(network)
     const chainInfo = getChainInfoByChainId(chainId)
 
+    // Resolve config up front: it carries both the institution routing (`vaultInstitutionId`) and the
+    // `navPriceSkipFirstNDays` read below. A disabled/unconfigured RWA vault has no client id, so it
+    // cannot be routed to an institution → treat as not found.
+    const systemConfig = await getCachedConfig()
+    const clientId = getVaultRwaClientId(vaultAddress, chainId, systemConfig)
+
+    if (!clientId) {
+      return undefined
+    }
+
     const fleetAddress = Address.createFromEthereum({
       value: vaultAddress,
     })
@@ -31,7 +44,7 @@ export async function getRwaVaultDetails({
       chainInfo,
       fleetAddress,
     })
-    const { vault } = await backendInstiSDK.rwa.getVaultRaw({
+    const { vault } = await getBackendInstiSDK(clientId).rwa.getVaultRaw({
       vaultId: poolId,
     })
 
@@ -42,9 +55,7 @@ export async function getRwaVaultDetails({
     // NAV (pricePerShare) changes, computed here where the raw RWA query shape still carries the
     // typed `dailySnapshots`. These survive the later `decorateWithFleetConfig` spread.
     // The 30d Net APY can exclude the vault's volatile first N days via the fleet config's
-    // `navPriceSkipFirstNDays`; resolve it from config here since fleet-config decoration (which
-    // merges it into customFields) only runs after this point.
-    const systemConfig = await getCachedConfig()
+    // `navPriceSkipFirstNDays`.
     const navPriceSkipFirstNDays = getVaultNavPriceSkipFirstNDays(
       vaultAddress,
       chainId,

--- a/apps/earn-protocol/app/server-handlers/sdk/get-rwa-vaults-info-list.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-rwa-vaults-info-list.ts
@@ -1,30 +1,47 @@
-import { getChainInfoByChainId } from '@summerfi/sdk-common'
+import { getChainInfoByChainId, type IRwaVaultInfo } from '@summerfi/sdk-common'
 
-import { backendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
+import { getBackendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
 import { rwaSupportedChainIds } from '@/app/server-handlers/subgraphs-map'
-import { RWA_CLIENT_ID } from '@/constants/rwa'
+import { getRwaClientIdsForChain, isVaultDisabled } from '@/helpers/vault-custom-value-helpers'
 
 export const getRwaVaultsInfoListRaw = async () => {
-  // Supported RWA networks are derived from rwaSubgraphsMap; each is fetched independently and
-  // degrades to an empty list so one failing/empty network never takes down the whole info list.
-  const vaultsListByNetwork = await Promise.all(
-    rwaSupportedChainIds.map((chainId) =>
-      backendInstiSDK.rwa
-        .getVaultInfoListPerChain({
-          chainId: getChainInfoByChainId(chainId).chainId,
-          clientId: RWA_CLIENT_ID,
-        })
-        .catch((error: unknown) => {
-          // eslint-disable-next-line no-console
-          console.error(`getRwaVaultsInfoListRaw failed for chainId ${chainId}`, error)
+  const systemConfig = await getCachedConfig()
 
-          return { list: [] }
-        }),
+  // Supported RWA networks come from rwaSubgraphsMap; the institutions per network are derived from
+  // the fleet config's `vaultInstitutionId`. Each (network, institution) is fetched independently and
+  // degrades to an empty list so one failing/empty pair never takes down the whole info list.
+  const vaultsListByChainAndClient = await Promise.all(
+    rwaSupportedChainIds.flatMap((chainId) =>
+      getRwaClientIdsForChain(chainId, systemConfig).map((clientId) =>
+        getBackendInstiSDK(clientId)
+          .rwa.getVaultInfoListPerChain({
+            chainId: getChainInfoByChainId(chainId).chainId,
+            clientId,
+          })
+          // Drop vaults flagged `disabled: true` in config (an active institution can still own
+          // hidden/unused vaults the subgraph returns alongside the live ones).
+          .then(({ list }) =>
+            list.filter(
+              (vaultInfo) =>
+                !isVaultDisabled(vaultInfo.id.fleetAddress.value, chainId, systemConfig),
+            ),
+          )
+          .catch((error: unknown) => {
+            // eslint-disable-next-line no-console
+            console.error(
+              `getRwaVaultsInfoListRaw failed for chainId ${chainId} clientId ${clientId}`,
+              error,
+            )
+
+            return [] as IRwaVaultInfo[]
+          }),
+      ),
     ),
   )
 
   return {
-    vaults: vaultsListByNetwork.flatMap(({ list }) => list),
+    vaults: vaultsListByChainAndClient.flat(),
     callDataTimestamp: Date.now(),
   }
 }

--- a/apps/earn-protocol/app/server-handlers/sdk/get-rwa-vaults-list.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-rwa-vaults-list.ts
@@ -1,35 +1,50 @@
 import { getChainInfoByChainId } from '@summerfi/sdk-common'
 import { type GetVaultsQueryRwa } from '@summerfi/subgraph-manager-common'
 
-import { backendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
+import { getBackendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
 import { rwaSupportedChainIds } from '@/app/server-handlers/subgraphs-map'
-import { RWA_CLIENT_ID } from '@/constants/rwa'
+import { getRwaClientIdsForChain, isVaultDisabled } from '@/helpers/vault-custom-value-helpers'
 
 export const getRwaVaultsListRaw: () => Promise<{
   vaults: GetVaultsQueryRwa['vaults']
   callDataTimestamp: number
 }> = async () => {
-  // Supported RWA networks are derived from rwaSubgraphsMap. Each network is fetched independently
-  // and degrades to an empty list, so one network (e.g. a newly-enabled Mainnet) failing or having
-  // no vaults never takes down the whole RWA list.
-  const vaultsListByNetwork = await Promise.all(
-    rwaSupportedChainIds.map((chainId) =>
-      backendInstiSDK.rwa
-        .getVaultsRaw({
-          chainInfo: getChainInfoByChainId(chainId),
-          clientId: RWA_CLIENT_ID,
-        })
-        .catch((error: unknown) => {
-          // eslint-disable-next-line no-console
-          console.error(`getRwaVaultsListRaw failed for chainId ${chainId}`, error)
+  const systemConfig = await getCachedConfig()
 
-          return { vaults: [] as GetVaultsQueryRwa['vaults'] }
-        }),
+  // Supported RWA networks come from rwaSubgraphsMap; the institutions per network are derived from
+  // the fleet config's `vaultInstitutionId` (single source of truth). Each (network, institution) is
+  // fetched independently and degrades to an empty list, so one failing/empty pair never takes down
+  // the whole RWA list.
+  const vaultsListByChainAndClient = await Promise.all(
+    rwaSupportedChainIds.flatMap((chainId) =>
+      getRwaClientIdsForChain(chainId, systemConfig).map((clientId) =>
+        getBackendInstiSDK(clientId)
+          .rwa.getVaultsRaw({
+            chainInfo: getChainInfoByChainId(chainId),
+            clientId,
+          })
+          // An active institution can still own vaults flagged `disabled: true` in config (hidden/
+          // unused), which the subgraph returns alongside the live ones — drop them here so they
+          // never enter the data pipeline.
+          .then(({ vaults }) =>
+            vaults.filter((vault) => !isVaultDisabled(vault.id, chainId, systemConfig)),
+          )
+          .catch((error: unknown) => {
+            // eslint-disable-next-line no-console
+            console.error(
+              `getRwaVaultsListRaw failed for chainId ${chainId} clientId ${clientId}`,
+              error,
+            )
+
+            return [] as GetVaultsQueryRwa['vaults']
+          }),
+      ),
     ),
   )
 
   return {
-    vaults: vaultsListByNetwork.flatMap(({ vaults }) => vaults),
+    vaults: vaultsListByChainAndClient.flat(),
     callDataTimestamp: Date.now(),
   }
 }

--- a/apps/earn-protocol/app/server-handlers/sdk/get-user-position.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/get-user-position.ts
@@ -2,8 +2,10 @@ import { type IArmadaPosition, type SupportedSDKNetworks } from '@summerfi/app-t
 import { subgraphNetworkToId } from '@summerfi/app-utils'
 import { Address, getChainInfoByChainId, User, Wallet } from '@summerfi/sdk-common'
 
+import { getCachedConfig } from '@/app/server-handlers/cached/get-config'
 import { serverOnlyErrorHandler } from '@/app/server-handlers/error-handler'
-import { backendInstiSDK, backendSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { backendSDK, getBackendInstiSDK } from '@/app/server-handlers/sdk/sdk-backend-client'
+import { getVaultRwaClientId } from '@/helpers/vault-custom-value-helpers'
 
 export async function getUserPosition({
   network,
@@ -40,12 +42,26 @@ export async function getUserPosition({
       wallet,
     })
 
-    const position = await (isRwaVault ? backendInstiSDK : backendSDK).armada.users.getUserPosition(
-      {
-        fleetAddress,
-        user,
-      },
-    )
+    // RWA Fleet positions are read through the institution's SDK instance (its Client-Id header selects
+    // the right deployment). The institution is resolved from the vault's `vaultInstitutionId`; a
+    // disabled/unconfigured RWA vault has no client id → no position to read.
+    let instiSdk: ReturnType<typeof getBackendInstiSDK> | undefined
+
+    if (isRwaVault) {
+      const systemConfig = await getCachedConfig()
+      const clientId = getVaultRwaClientId(vaultAddress, chainId, systemConfig)
+
+      if (!clientId) {
+        return undefined
+      }
+
+      instiSdk = getBackendInstiSDK(clientId)
+    }
+
+    const position = await (instiSdk ?? backendSDK).armada.users.getUserPosition({
+      fleetAddress,
+      user,
+    })
 
     return position as IArmadaPosition | undefined
   } catch (error) {

--- a/apps/earn-protocol/app/server-handlers/sdk/sdk-backend-client.ts
+++ b/apps/earn-protocol/app/server-handlers/sdk/sdk-backend-client.ts
@@ -1,6 +1,6 @@
 import { makeInstiSdk, makeSDK } from '@summerfi/sdk-client'
 
-import { RWA_CLIENT_ID, RWA_INSTI_VERSION } from '@/constants/rwa'
+import { RWA_INSTI_VERSION } from '@/constants/rwa'
 
 if (!process.env.SDK_API_URL) {
   throw new Error('SDK_API_URL is not set')
@@ -11,14 +11,33 @@ export const backendSDK = makeSDK({
   version: 'v2',
 })
 
+// One institutional SDK instance per RWA client id. `makeInstiSdk` bakes `clientId` into the
+// `Client-Id` header on every request, and the SDK server resolves that institution's deployment
+// contracts + institutions-v2 subgraph from it — so per-vault reads/tx-builds must run on the instance
+// whose client id owns the vault. Memoised so repeated reads for the same institution reuse one client.
+const instiSdkByClientId = new Map<string, ReturnType<typeof makeInstiSdk>>()
+
 /**
- * Institutional backend SDK for RWA (rounds-based) vault reads. Built with `makeInstiSdk` so the
- * request carries the `Client-Id` + `Insti-Version` headers the SDK server needs to resolve the
- * RWA / institutions-v2 deployment config + subgraph (it defaults to 'v1' otherwise).
+ * Returns the institutional backend SDK for a given RWA institution `clientId`, creating + caching it on
+ * first use. Built with `makeInstiSdk` so the request carries the `Client-Id` + `Insti-Version` headers
+ * the SDK server needs to resolve the RWA / institutions-v2 deployment config + subgraph (it defaults to
+ * 'v1' otherwise). The client id for a vault comes from its `vaultInstitutionId` fleet-config field.
  */
-export const backendInstiSDK = makeInstiSdk({
-  apiURL: `${process.env.SDK_API_URL}/sdk/trpc`,
-  version: 'v2',
-  clientId: RWA_CLIENT_ID,
-  instiVersion: RWA_INSTI_VERSION,
-})
+export const getBackendInstiSDK = (clientId: string) => {
+  const existing = instiSdkByClientId.get(clientId)
+
+  if (existing) {
+    return existing
+  }
+
+  const sdk = makeInstiSdk({
+    apiURL: `${process.env.SDK_API_URL}/sdk/trpc`,
+    version: 'v2',
+    clientId,
+    instiVersion: RWA_INSTI_VERSION,
+  })
+
+  instiSdkByClientId.set(clientId, sdk)
+
+  return sdk
+}

--- a/apps/earn-protocol/app/server-handlers/subgraphs-map.ts
+++ b/apps/earn-protocol/app/server-handlers/subgraphs-map.ts
@@ -10,7 +10,7 @@ export const subgraphsMap = {
 }
 
 export const rwaSubgraphsMap = {
-  [SupportedSDKNetworks.Mainnet]: `${process.env.SUBGRAPH_BASE}/summer-institutions-v2`,
+  [SupportedSDKNetworks.Mainnet]: `${process.env.SUBGRAPH_BASE}/summer-institutions-v2-staging`,
   [SupportedSDKNetworks.Base]: `${process.env.SUBGRAPH_BASE}/summer-institutions-v2-base`,
 }
 

--- a/apps/earn-protocol/app/server-handlers/vault-manage/get-vault-manage-core-data.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-manage/get-vault-manage-core-data.ts
@@ -70,6 +70,7 @@ export const getVaultManageCoreData = async ({
     vault,
     vaultWithConfig,
     isRwaVault,
+    rwaClientId,
   } = ctx
 
   // Resolve the effective position. A pre-claim RWA user has no settled Fleet position; if they hold
@@ -77,11 +78,12 @@ export const getVaultManageCoreData = async ({
   // the manage view renders a meaningful "settling" summary instead of bailing to the deposit view.
   let { position } = ctx
 
-  if (!position && isRwaVault && parsedVaultId) {
+  if (!position && isRwaVault && parsedVaultId && rwaClientId) {
     const exposure = await getCachedRwaUserVaultExposure({
       chainId: Number(parsedNetworkId),
       fleetAddress: parsedVaultId,
       walletAddress,
+      clientId: rwaClientId,
     })
 
     if (exposure && new BigNumber(exposure.total).gt(0)) {

--- a/apps/earn-protocol/app/server-handlers/vault-manage/resolve-vault-manage-context.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-manage/resolve-vault-manage-context.ts
@@ -18,6 +18,8 @@ import {
   decorateVaultsWithConfig,
   getVaultCuratedBy,
   getVaultIdByVaultCustomName,
+  getVaultRwaClientId,
+  isVaultDisabled,
 } from '@/helpers/vault-custom-value-helpers'
 
 // Shared resolution step for the vault-manage query units. The core + per-section handlers each
@@ -51,13 +53,24 @@ export const resolveVaultManageContext = async ({
   // return nothing and the page reports "no such vault".
   const isRwaVault = !!getVaultCuratedBy(parsedVaultId ?? '', parsedNetworkId, systemConfig)
 
-  if (!parsedVaultId || !isAddress(walletAddress)) {
+  // Institution that owns this (RWA) vault, from its `vaultInstitutionId` — selects the SDK instance
+  // for the exposure read below and is threaded to the client for RWA SDK calls.
+  const rwaClientId = getVaultRwaClientId(parsedVaultId ?? '', parsedNetworkId, systemConfig)
+
+  // A vault flagged `disabled: true` in config is hidden/unused: resolve to not-found before any data
+  // fetch, so a direct URL never displays or pulls data for it.
+  if (
+    !parsedVaultId ||
+    !isAddress(walletAddress) ||
+    isVaultDisabled(parsedVaultId, parsedNetworkId, systemConfig)
+  ) {
     return {
       systemConfig,
       parsedNetwork,
       parsedNetworkId,
       parsedVaultId,
       isRwaVault,
+      rwaClientId,
       vault: null,
       position: null,
       vaultWithConfig: null,
@@ -94,6 +107,7 @@ export const resolveVaultManageContext = async ({
       parsedNetworkId,
       parsedVaultId,
       isRwaVault,
+      rwaClientId,
       vault: vault ?? null,
       position: position ?? null,
       vaultWithConfig: null,
@@ -127,6 +141,7 @@ export const resolveVaultManageContext = async ({
     parsedNetworkId,
     parsedVaultId,
     isRwaVault,
+    rwaClientId,
     vault,
     position,
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/apps/earn-protocol/app/server-handlers/vault-open/resolve-vault-open-context.ts
+++ b/apps/earn-protocol/app/server-handlers/vault-open/resolve-vault-open-context.ts
@@ -17,6 +17,8 @@ import {
   decorateVaultsWithConfig,
   getVaultCuratedBy,
   getVaultIdByVaultCustomName,
+  getVaultRwaClientId,
+  isVaultDisabled,
 } from '@/helpers/vault-custom-value-helpers'
 
 // Shared resolution step for both vault-open query units. The core and details handlers each
@@ -43,6 +45,26 @@ export const resolveVaultOpenContext = async ({
 
   const isRwaVault = !!getVaultCuratedBy(parsedVaultId, parsedNetworkId, systemConfig) // rough check
 
+  // Institution that owns this (RWA) vault, from its `vaultInstitutionId` — threaded to the client so
+  // its RWA SDK calls route to the right deployment.
+  const rwaClientId = getVaultRwaClientId(parsedVaultId, parsedNetworkId, systemConfig)
+
+  // A vault flagged `disabled: true` in config is hidden/unused: resolve to not-found before any data
+  // fetch, so a direct URL never displays or pulls data for it.
+  if (isVaultDisabled(parsedVaultId, parsedNetworkId, systemConfig)) {
+    return {
+      systemConfig,
+      parsedNetwork,
+      parsedNetworkId,
+      parsedVaultId,
+      isRwaVault,
+      rwaClientId,
+      vault: null,
+      vaultWithConfig: null,
+      allVaultsWithConfig: [],
+    }
+  }
+
   const [vault, { vaults }, { vaults: rwaVaults }] = await Promise.all([
     (isRwaVault ? getCachedRwaVaultDetails : getCachedVaultDetails)({
       vaultAddress: parsedVaultId,
@@ -59,6 +81,7 @@ export const resolveVaultOpenContext = async ({
       parsedNetworkId,
       parsedVaultId,
       isRwaVault,
+      rwaClientId,
       vault: null,
       vaultWithConfig: null,
       allVaultsWithConfig: [],
@@ -91,6 +114,7 @@ export const resolveVaultOpenContext = async ({
     parsedNetworkId,
     parsedVaultId,
     isRwaVault,
+    rwaClientId,
     vault,
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     vaultWithConfig: vaultWithConfig ?? null,

--- a/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultManageView/VaultManageViewComponent.tsx
@@ -60,7 +60,6 @@ import dynamic from 'next/dynamic'
 // import { type MigratablePosition } from '@/app/server-handlers/raw-calls/migration'
 import { ArbitrumNoticeBanner } from '@/components/layout/ArbitrumNoticeBanner/ArbitrumNoticeBanner'
 import { RebalancingNoticeBanner } from '@/components/layout/RebalancingNoticeBanner/RebalancingNoticeBanner'
-import { RwaSidebarInfo } from '@/components/layout/RwaVault/RwaSidebarInfo'
 import { RewardTokenClaimBox } from '@/components/layout/VaultManageView/RewardTokenClaimBox'
 import { getRwaReceiptsHistoryBaseQueryKey } from '@/components/layout/VaultManageView/vault-manage-query-keys'
 import { VaultManageViewDetails } from '@/components/layout/VaultManageView/VaultManageViewDetails'
@@ -205,8 +204,9 @@ export const VaultManageViewComponent = ({
   const isRwaVault = vault.isRwaVault ?? false
 
   // RWA (rounds-based) calls go through the institutional SDK; standard vault calls use `sdk`.
-  // Defined ahead of useTransaction so its success callback can refresh the pending receipts.
-  const rwaSdk = useRwaSDK()
+  // Defined ahead of useTransaction so its success callback can refresh the pending receipts. The
+  // institution is the vault's `vaultInstitutionId` (merged into customFields on decoration).
+  const rwaSdk = useRwaSDK(vault.customFields?.vaultInstitutionId)
 
   const { isWhitelisted } = useIsWhitelisted({
     isRwaVault,
@@ -989,11 +989,7 @@ export const VaultManageViewComponent = ({
         }
         sidebarContent={<Sidebar {...resovledSidebarProps} />}
         rightExtraContent={
-          isRwaVault ? (
-            // Pending positions now live in the "Deposits and Withdrawals" history table (details
-            // view), which is a superset of the old sidebar list.
-            <RwaSidebarInfo />
-          ) : (
+          isRwaVault ? null : (
             <>
               <RewardTokenClaimBox
                 vaultChainId={vaultChainId}

--- a/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
+++ b/apps/earn-protocol/components/layout/VaultOpenView/VaultOpenViewComponent.tsx
@@ -161,8 +161,10 @@ export const VaultOpenViewComponent = ({
     state: { slippageConfig },
   } = useLocalConfig()
   const sdk = useAppSDK()
-  // RWA (rounds-based) calls go through the institutional SDK; standard vault calls use `sdk`.
-  const rwaSdk = useRwaSDK()
+  // RWA (rounds-based) calls go through the institutional SDK; standard vault calls use `sdk`. The
+  // institution is the vault's `vaultInstitutionId` (merged into customFields on decoration).
+  const rwaClientId = vault.customFields?.vaultInstitutionId
+  const rwaSdk = useRwaSDK(rwaClientId)
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   // const [migratablePositions, setMigratablePositions] = useState<MigratablePosition[]>([])
@@ -438,6 +440,7 @@ export const VaultOpenViewComponent = ({
     // RWA Fleet positions live in the institutional subgraph; read them via the RWA SDK so a
     // whitelisted holder who has claimed shares is redirected from the open page to their position.
     isRwaVault,
+    rwaClientId,
   })
 
   const { amountDisplayUSDWithSwap, rawToTokenAmount } = useAmountWithSwap({

--- a/apps/earn-protocol/constants/rwa.ts
+++ b/apps/earn-protocol/constants/rwa.ts
@@ -1,13 +1,10 @@
 /**
- * Institution client id used to resolve the RWA deployment config + subgraph.
+ * Institutional deployment-config version for RWA (selects the RWA / institutions-v2 subgraph).
  *
  * RWA (rounds-based) vault calls must be served by an institutional SDK (`makeInstiSdk`) so the
  * request carries the `Client-Id` and `Insti-Version` headers — without them the SDK server
- * defaults `Insti-Version` to 'v1' and resolves the wrong deployment/subgraph.
- *
- * NOTE: placeholder value for now — to be replaced with the real institution id when available.
+ * defaults `Insti-Version` to 'v1' and resolves the wrong deployment/subgraph. Shared by every RWA
+ * institution; the per-institution `Client-Id` is derived from each vault's `vaultInstitutionId`
+ * fleet-config field (see `getVaultRwaClientId` / `getRwaClientIdsForChain`).
  */
-export const RWA_CLIENT_ID = 'ExtDemoCorp_v2'
-
-/** Institutional deployment-config version for RWA (selects the RWA / institutions-v2 subgraph). */
 export const RWA_INSTI_VERSION = 'v2' as const

--- a/apps/earn-protocol/helpers/vault-custom-value-helpers.ts
+++ b/apps/earn-protocol/helpers/vault-custom-value-helpers.ts
@@ -138,9 +138,22 @@ export const getVaultRwaClientId = (
 
   const vaultNetworkConfig = fleetMap[String(chainId) as keyof typeof fleetMap]
 
+  // fleetMap is not guaranteed to carry a section for every chain (the generated type assumes it
+  // does); guard so Object.values doesn't throw on undefined.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!vaultNetworkConfig) {
+    return undefined
+  }
+
   const vaultConfig = (Object.values(vaultNetworkConfig) as EarnAppFleetCustomConfigType[]).find(
     (fleet) => fleet.address.toLowerCase() === vaultAddress.toLowerCase(),
   )
+
+  // A disabled vault must never resolve to a client id, so downstream reads (e.g. getUserPosition,
+  // getRwaVaultDetails) treat it as unconfigured rather than routing to an institution.
+  if (vaultConfig?.disabled) {
+    return undefined
+  }
 
   return vaultConfig?.vaultInstitutionId
 }
@@ -162,6 +175,13 @@ export const isVaultDisabled = (
   }
 
   const vaultNetworkConfig = fleetMap[String(chainId) as keyof typeof fleetMap]
+
+  // fleetMap is not guaranteed to carry a section for every chain (the generated type assumes it
+  // does); guard so Object.values doesn't throw on undefined.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!vaultNetworkConfig) {
+    return false
+  }
 
   const vaultConfig = (Object.values(vaultNetworkConfig) as EarnAppFleetCustomConfigType[]).find(
     (fleet) => fleet.address.toLowerCase() === vaultAddress.toLowerCase(),

--- a/apps/earn-protocol/helpers/vault-custom-value-helpers.ts
+++ b/apps/earn-protocol/helpers/vault-custom-value-helpers.ts
@@ -117,3 +117,89 @@ export const getVaultNavPriceSkipFirstNDays = (
     ? vaultConfig.navPriceSkipFirstNDays
     : 0
 }
+
+/**
+ * Resolves the RWA institution client id a vault belongs to, read from the fleet config's
+ * `vaultInstitutionId`. This is the single per-vault routing point: RWA SDK calls for this vault must
+ * be served by the institutional SDK instance built with this client id (its `Client-Id` header selects
+ * the right deployment contracts + institutions-v2 subgraph). Returns `undefined` for non-RWA / disabled
+ * / unconfigured vaults (which carry no `vaultInstitutionId`).
+ */
+export const getVaultRwaClientId = (
+  vaultAddress: string,
+  chainId: number | string,
+  systemConfig: Partial<EarnAppConfigType>,
+): string | undefined => {
+  const { fleetMap } = systemConfig
+
+  if (!fleetMap) {
+    return undefined
+  }
+
+  const vaultNetworkConfig = fleetMap[String(chainId) as keyof typeof fleetMap]
+
+  const vaultConfig = (Object.values(vaultNetworkConfig) as EarnAppFleetCustomConfigType[]).find(
+    (fleet) => fleet.address.toLowerCase() === vaultAddress.toLowerCase(),
+  )
+
+  return vaultConfig?.vaultInstitutionId
+}
+
+/**
+ * Whether a vault is flagged `disabled: true` in the fleet config — i.e. hidden/unused and must not be
+ * displayed or fetched. Mirrors the `customFields?.disabled` filter `decorateWithFleetConfig` applies to
+ * rendered lists, but usable before the data fetch (e.g. to short-circuit a disabled vault's page).
+ */
+export const isVaultDisabled = (
+  vaultAddress: string,
+  chainId: number | string,
+  systemConfig: Partial<EarnAppConfigType>,
+): boolean => {
+  const { fleetMap } = systemConfig
+
+  if (!fleetMap) {
+    return false
+  }
+
+  const vaultNetworkConfig = fleetMap[String(chainId) as keyof typeof fleetMap]
+
+  const vaultConfig = (Object.values(vaultNetworkConfig) as EarnAppFleetCustomConfigType[]).find(
+    (fleet) => fleet.address.toLowerCase() === vaultAddress.toLowerCase(),
+  )
+
+  return vaultConfig?.disabled === true
+}
+
+/**
+ * The distinct RWA institution client ids configured on a chain — the fan-out source for the per-chain
+ * RWA list/positions reads. Derived from the fleet config's `vaultInstitutionId` across **non-disabled**
+ * vaults, so it is the single source of truth for "which institutions do we query" (no hardcoded list to
+ * keep in sync). The truthiness filter also excludes the `'0x'`/emptyConfig template entry each chain map
+ * carries and any disabled entry (which has no `vaultInstitutionId`).
+ */
+export const getRwaClientIdsForChain = (
+  chainId: number | string,
+  systemConfig: Partial<EarnAppConfigType>,
+): string[] => {
+  const { fleetMap } = systemConfig
+
+  if (!fleetMap) {
+    return []
+  }
+
+  const vaultNetworkConfig = fleetMap[String(chainId) as keyof typeof fleetMap]
+
+  // This helper is called for every supported RWA chain, not just chains we know carry vaults — and
+  // fleetMap is not guaranteed to have a section for each (the generated type assumes it does). Guard
+  // against a missing chain so Object.values doesn't throw on undefined and take down the whole list.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!vaultNetworkConfig) {
+    return []
+  }
+
+  const clientIds = (Object.values(vaultNetworkConfig) as EarnAppFleetCustomConfigType[])
+    .filter((fleet) => !fleet.disabled && !!fleet.vaultInstitutionId)
+    .map((fleet) => fleet.vaultInstitutionId)
+
+  return [...new Set(clientIds)]
+}

--- a/apps/earn-protocol/hooks/use-position.ts
+++ b/apps/earn-protocol/hooks/use-position.ts
@@ -58,6 +58,7 @@ export const usePosition = ({
   onlyActive,
   cached,
   isRwaVault = false,
+  rwaClientId,
 }: {
   vaultId: string
   chainId: SupportedNetworkIds
@@ -66,10 +67,13 @@ export const usePosition = ({
   // RWA (rounds-based) Fleet positions are indexed in the institutional subgraph and must be read
   // through the RWA SDK (Client-Id + Insti-Version headers); the public SDK returns nothing for them.
   isRwaVault?: boolean
+  // Institution that owns the vault (its `vaultInstitutionId`) — selects the RWA SDK deployment.
+  // Only needed when `isRwaVault` is true.
+  rwaClientId?: string
 }) => {
   const [position, setPosition] = useState<IArmadaPosition>()
   const { getUserPosition: getUserPositionPublic } = useAppSDK()
-  const { getUserPosition: getUserPositionRwa } = useRwaSDK()
+  const { getUserPosition: getUserPositionRwa } = useRwaSDK(rwaClientId)
   const getUserPosition = isRwaVault ? getUserPositionRwa : getUserPositionPublic
   const { address: userWalletAddress } = useEarnProtocolWallet()
   const [isLoading, setIsLoading] = useState(false)

--- a/apps/earn-protocol/hooks/use-rwa-sdk.ts
+++ b/apps/earn-protocol/hooks/use-rwa-sdk.ts
@@ -1,26 +1,30 @@
 import { useEarnProtocolChain, useEarnProtocolWallet } from '@summerfi/app-earn-ui'
 import { useSDK } from '@summerfi/sdk-client-react'
 
-import { RWA_CLIENT_ID } from '@/constants/rwa'
-
 /**
- * SDK instance for RWA (rounds-based) vault calls.
+ * SDK instance for RWA (rounds-based) vault calls, scoped to the institution that owns the vault.
  *
- * RWA handlers live only on the institutional SDK surface (`ISDKInstiManager`), and the SDK server
- * needs the `Client-Id` + `Insti-Version` headers to resolve the RWA deployment/subgraph — both of
- * which `makeInstiSdk` sends. Passing `clientId` + `insti` selects that path.
+ * `clientId` is the vault's `vaultInstitutionId` (resolved via `getVaultRwaClientId`); it sets the
+ * `Client-Id` header so the SDK server resolves that institution's deployment contracts + subgraph.
+ * RWA handlers live only on the institutional SDK surface (`ISDKInstiManager`), which `clientId` +
+ * `insti: true` selects.
  *
- * Kept separate from `useAppSDK` (the public client used for standard vaults) so standard-vault
- * calls are NOT routed through the institutional deployment.
+ * `clientId` is optional because the vault views call this hook unconditionally (it must run on every
+ * render), but the returned RWA handlers are only ever invoked for RWA vaults — where a real client id
+ * is always present. For non-RWA vaults `clientId` is empty and the result goes unused. The `?? ''`
+ * keeps the static type on the full institutional surface so consumers retain the RWA methods.
+ *
+ * Kept separate from `useAppSDK` (the public client used for standard vaults) so standard-vault calls
+ * are NOT routed through an institutional deployment.
  */
-export const useRwaSDK = () => {
+export const useRwaSDK = (clientId?: string) => {
   const { chain } = useEarnProtocolChain()
   const { address: userWalletAddress } = useEarnProtocolWallet()
 
   return useSDK({
     chainId: chain.id,
     walletAddress: userWalletAddress,
-    clientId: RWA_CLIENT_ID,
+    clientId: clientId ?? '',
     insti: true,
   })
 }

--- a/apps/earn-protocol/hooks/use-transaction.ts
+++ b/apps/earn-protocol/hooks/use-transaction.ts
@@ -91,8 +91,11 @@ export const useTransaction = ({
   const transactionEventHandler = useHandleTransactionEvent()
   const { address: userWalletAddress } = useEarnProtocolWallet()
   const { getDepositTx: getDepositTX, getWithdrawTx: getWithdrawTX, getVaultSwitchTx } = useAppSDK()
-  // RWA tx builders live only on the institutional SDK surface.
-  const { getRwaDepositTx: getRwaDepositTX, getRwaWithdrawTx: getRwaWithdrawTX } = useRwaSDK()
+  // RWA tx builders live only on the institutional SDK surface, scoped to the institution that owns
+  // this vault (its `vaultInstitutionId`).
+  const { getRwaDepositTx: getRwaDepositTX, getRwaWithdrawTx: getRwaWithdrawTX } = useRwaSDK(
+    vault.customFields?.vaultInstitutionId,
+  )
   const { login, isOpen: isAuthModalOpen } = useEarnProtocolLogin()
   const [isTransakOpen, setIsTransakOpen] = useState(false)
   const { setChain, isSettingChain, chain } = useEarnProtocolChain()

--- a/apps/earn-protocol/hooks/use-transactions-with-cow.ts
+++ b/apps/earn-protocol/hooks/use-transactions-with-cow.ts
@@ -108,8 +108,11 @@ export const useTransaction = ({
     getPermit2AuthorizationTx,
     isPermit2AuthorizationNeeded,
   } = useAppSDK()
-  // RWA deposit/withdraw builders live only on the institutional SDK surface.
-  const { getRwaDepositTx: getRwaDepositTX, getRwaWithdrawTx: getRwaWithdrawTX } = useRwaSDK()
+  // RWA deposit/withdraw builders live only on the institutional SDK surface, scoped to the
+  // institution that owns this vault (its `vaultInstitutionId`).
+  const { getRwaDepositTx: getRwaDepositTX, getRwaWithdrawTx: getRwaWithdrawTX } = useRwaSDK(
+    vault.customFields?.vaultInstitutionId,
+  )
   const { login, isOpen: isAuthModalOpen } = useEarnProtocolLogin()
   const [isTransakOpen, setIsTransakOpen] = useState(false)
   const { setChain, isSettingChain, chain } = useEarnProtocolChain()

--- a/packages/app-earn-ui/src/components/layout/VaultGridDetails/VaultGridDetails.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultGridDetails/VaultGridDetails.tsx
@@ -157,6 +157,7 @@ export const VaultGridDetails = ({
               isNewVault={isNewVault}
               isDaoManagedVault={vault.isDaoManaged}
               isRwaVault={vault.isRwaVault}
+              vaultName={vault.customFields?.name}
             />
           </Dropdown>
           <Button

--- a/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultManageGrid/VaultManageGrid.tsx
@@ -356,6 +356,7 @@ export const VaultManageGrid: FC<VaultManageGridProps> = ({
                 isNewVault={isNewVault}
                 isDaoManagedVault={vault.isDaoManaged}
                 isRwaVault={vault.isRwaVault}
+                vaultName={vault.customFields?.name}
               />
             </Dropdown>
             <div className={vaultManageGridStyles.vaultBonusWrapper}>

--- a/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
+++ b/packages/app-earn-ui/src/components/layout/VaultOpenGrid/VaultOpenGrid.tsx
@@ -319,6 +319,7 @@ export const VaultOpenGrid: FC<VaultOpenGridProps> = ({
                 isNewVault={isNewVault}
                 isDaoManagedVault={vault.isDaoManaged}
                 isRwaVault={vault.isRwaVault}
+                vaultName={vault.customFields?.name}
               />
             </Dropdown>
             <div className={vaultOpenGridStyles.vaultBonusWrapper}>

--- a/packages/app-earn-ui/src/components/molecules/VaultCard/VaultCard.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultCard/VaultCard.tsx
@@ -144,6 +144,7 @@ export const VaultCard: FC<VaultCardProps> = (props) => {
             onTooltipOpen={onTooltipOpen}
             isNewVault={isNewVault}
             isRwaVault={isRwaVault}
+            vaultName={customFields?.name}
           />
           <div className={vaultCardStyles.vaultBonusWrapper}>
             <Text style={{ color: 'var(--earn-protocol-secondary-100)' }}>

--- a/packages/app-earn-ui/src/components/molecules/VaultCardHomepage/VaultCardHomepage.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultCardHomepage/VaultCardHomepage.tsx
@@ -315,6 +315,8 @@ export const VaultCardHomepage = ({
             networkName={supportedSDKNetwork(protocol.network)}
             isVaultCard
             isNewVault={isNewVault}
+            isRwaVault={vault.isRwaVault}
+            vaultName={customFields?.name}
           />
         </div>
         <div className={vaultCardHomepageStyles.vaultCardHomepageDatablocksWrapper}>

--- a/packages/app-earn-ui/src/components/molecules/VaultTitle/VaultTitle.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultTitle/VaultTitle.tsx
@@ -32,6 +32,9 @@ interface VaultTitleProps {
   isNewVault?: boolean
   isDaoManagedVault?: boolean
   isRwaVault?: boolean
+  // RWA (institutional) vaults are titled by their configured name (`customFields.name`) rather than
+  // the input-token symbol; ignored for non-RWA vaults and falls back to the symbol when unset.
+  vaultName?: string
 }
 
 export const VaultTitle: FC<VaultTitleProps> = ({
@@ -47,9 +50,12 @@ export const VaultTitle: FC<VaultTitleProps> = ({
   isNewVault = false,
   isDaoManagedVault,
   isRwaVault,
+  vaultName,
 }) => {
   const resolvedSymbol = getDisplayToken(symbol)
   const isIconDefined = getTokenGuarded(resolvedSymbol)?.iconName
+  // RWA vaults show their configured name; everything else (and RWA vaults without a name) shows the token.
+  const resolvedTitle = isRwaVault && vaultName ? vaultName : resolvedSymbol
 
   return (
     <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
@@ -92,7 +98,7 @@ export const VaultTitle: FC<VaultTitleProps> = ({
             }}
             data-testid="vault-token"
           >
-            {isLoading ? <SkeletonLine height={40} width={70} /> : resolvedSymbol}
+            {isLoading ? <SkeletonLine height={40} width={70} /> : resolvedTitle}
             {isNewVault && !isLoading && <Emphasis variant="p2semiColorful">New!</Emphasis>}
             {!isLoading && (!!isRwaVault || typeof isDaoManagedVault !== 'undefined') ? (
               <VaultLabelPill isDaoManagedVault={isDaoManagedVault} isRwaVault={isRwaVault} />

--- a/packages/app-earn-ui/src/components/molecules/VaultTitle/VaultTitle.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultTitle/VaultTitle.tsx
@@ -95,6 +95,7 @@ export const VaultTitle: FC<VaultTitleProps> = ({
               display: 'flex',
               alignItems: 'center',
               gap: '14px',
+              whiteSpace: 'pre',
             }}
             data-testid="vault-token"
           >

--- a/packages/app-earn-ui/src/components/molecules/VaultTitleWithRisk/VaultTitleWithRisk.tsx
+++ b/packages/app-earn-ui/src/components/molecules/VaultTitleWithRisk/VaultTitleWithRisk.tsx
@@ -27,6 +27,8 @@ interface VaultTitleWithRiskProps {
   isNewVault?: boolean
   isDaoManagedVault?: boolean
   isRwaVault?: boolean
+  // RWA vaults are titled by their configured name (`customFields.name`) instead of the token symbol.
+  vaultName?: string
 }
 
 export const VaultTitleWithRisk: FC<VaultTitleWithRiskProps> = ({
@@ -42,6 +44,7 @@ export const VaultTitleWithRisk: FC<VaultTitleWithRiskProps> = ({
   isNewVault = false,
   isDaoManagedVault,
   isRwaVault,
+  vaultName,
 }) => {
   const resolvedRisk = isDaoManagedVault ? 'higher' : risk
   const color = riskColors[resolvedRisk]
@@ -60,6 +63,7 @@ export const VaultTitleWithRisk: FC<VaultTitleWithRiskProps> = ({
       isNewVault={isNewVault}
       isDaoManagedVault={isDaoManagedVault}
       isRwaVault={isRwaVault}
+      vaultName={vaultName}
       /* networkName should work 99% of the time, because SDKVault returns very similar results for that */
       networkName={networkName}
       value={

--- a/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.module.css
+++ b/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.module.css
@@ -43,7 +43,7 @@
 
 @media (min-width: 1024px) {
   .basicInfoWrapper .titleWithRisk {
-    width: 30%;
+    width: 40%;
   }
 }
 

--- a/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx
+++ b/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx
@@ -168,6 +168,7 @@ export const PortfolioPosition = ({
               isNewVault={isNewVault}
               isRwaVault={portfolioPosition.vault.isRwaVault}
               isDaoManagedVault={portfolioPosition.vault.isDaoManaged}
+              vaultName={customFields?.name}
             />
             {isMobile && buttonsWrapper}
           </div>

--- a/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx
+++ b/packages/app-earn-ui/src/components/organisms/PortfolioPosition/PortfolioPosition.tsx
@@ -106,11 +106,12 @@ export const PortfolioPosition = ({
       : 'n/a'
     : 'New Strategy'
 
-  const { tokenBonus } = getRewardsTokenBonus({
+  const { tokenBonus, rawTokenBonus } = getRewardsTokenBonus({
     merklRewards: portfolioPosition.vaultInfo.merklRewards,
     tokensPriceMap: sumrPrice ? { SUMR: sumrPrice } : {},
     totalValueLockedUSD,
   })
+  const hasTokenBonus = Number(rawTokenBonus) > 0
 
   const linkToPosition = (
     <Link
@@ -172,16 +173,18 @@ export const PortfolioPosition = ({
             />
             {isMobile && buttonsWrapper}
           </div>
-          <PortfolioPositionHeaderValue
-            titleVariant="p3semiColorful"
-            title={
-              <>
-                $SUMR&nbsp;
-                <Icon iconName="stars_colorful" size={24} style={{ display: 'inline' }} />
-              </>
-            }
-            value={tokenBonus}
-          />
+          {hasTokenBonus && (
+            <PortfolioPositionHeaderValue
+              titleVariant="p3semiColorful"
+              title={
+                <>
+                  $SUMR&nbsp;
+                  <Icon iconName="stars_colorful" size={24} style={{ display: 'inline' }} />
+                </>
+              }
+              value={tokenBonus}
+            />
+          )}
           <PortfolioPositionHeaderValue title="30d APY" value={apy30dParsed} />
           {isRwaVault ? (
             <PortfolioPositionHeaderValue


### PR DESCRIPTION
## Summary

- **Multi-institution RWA** — replaced the single hardcoded `RWA_CLIENT_ID` with multi-institution support. Institution client IDs now derive from the config's per-vault `vaultInstitutionId` field (no hardcoded list).
- **Per-institution SDK routing** — `getBackendInstiSDK(clientId)` (server) and `useRwaSDK(clientId)` (client); list/positions fetches fan out across all institutions, and per-vault reads/tx-builds route to the institution that owns the vault.
- **Respect `disabled`** — vaults flagged `disabled: true` are excluded from RWA lists/data and their open/manage URLs resolve to not-found.
- **RWA vault titles** — `VaultTitle` now shows the configured vault name (`customFields.name`) instead of the token symbol for RWA vaults (falls back to the symbol when unset). Wired through the list cards, open/manage/details headers, portfolio, and homepage card.
- **Portfolio tweak** — hide the `$SUMR` bonus value on a portfolio position when the bonus is zero.

## Notes

- App-only change — no SDK package changes (the SDK already supported per-call `clientId` and per-instance `Client-Id` headers).
- RWA vault configs must populate `vaultInstitutionId` (routing) and `name` (title); missing values degrade gracefully (vault not routed / title falls back to token symbol).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault custom names now display in vault cards and management interfaces.
  * Token bonus section conditionally displays only when applicable.

* **Bug Fixes**
  * Improved RWA vault institution-specific handling and position fetching.
  * Portfolio position title layout optimized for larger screens.

* **Refactor**
  * Enhanced vault data routing and multi-institution support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->