### PR TITLE
feat(protocol-info): add /vaults endpoint (per-vault NAV, TVL, APY, staleness)

### DIFF
--- a/external-api/get-protocol-info-function/CLAUDE.md
+++ b/external-api/get-protocol-info-function/CLAUDE.md
@@ -1,0 +1,60 @@
+# get-protocol-info-function — cross-package dependencies
+
+AWS Lambda serving protocol/vault info. Routes: `GET /` (protocol stats), `GET /users`, `GET /all-users`,
+`GET /circulating-supply`, and the vaults routes: `GET /vaults`, `GET /vaults/{chainId}`,
+`GET /vaults/{chainId}/{vaultAddress}` (per-vault NAV / TVL / APY).
+
+This file documents what the function depends on **across the monorepo** and, most importantly, the
+**"adding a new chain" coupling** — chain/config lists are duplicated across packages and drift silently.
+
+## Data sources & what each provides
+
+| Dependency | Provides | Used by |
+|---|---|---|
+| `@summerfi/summer-earn-protocol-subgraph` | Public vaults: `getVaults`, `getUsers`, `getUsersPositions`; **`subgraphNameByChainMap`**, **`supportedChains`** | `/`, `/users`, `/all-users`, `/vaults` |
+| `@summerfi/summer-earn-institutions-subgraph` | Institutional (v1) vaults: `getVaults`; **`subgraphNameByChainMap`**, **`supportedChains`** | `/`, `/vaults` |
+| RWA / institutions **v2** subgraphs (`summer-institutions-v2`, `summer-institutions-v2-base`) | New institutional vaults. Queried directly via `graphql-request` against `${SUBGRAPH_BASE}/<name>` — no typed client (the typed `GetVaults` needs an `institutionId` and omits `dailySnapshots`). Map lives inline in `src/handlers/vaults.ts`. | `/vaults` |
+| `@summerfi/redis-cache` (`getRedisInstance`) + `@summerfi/abstractions` (`DistributedCache`) | Response caching (lazy singleton, noop fallback when unset) | `/vaults` |
+| `@summerfi/serverless-shared` | `ChainId`, `Address`, `ResponseOk/BadRequest/...`, `chainIdSchema` | all routes |
+| `viem` + `src/abis/fleetRewardsManager.ts` | On-chain `earned(...)` multicalls | `/users`, `/circulating-supply` |
+
+## Environment variables
+
+- `SUBGRAPH_BASE` (required) — base host for **all** subgraphs; full URL is `${SUBGRAPH_BASE}/<subgraph-name>`.
+- `RPC_GATEWAY` (required for `/users`, `/circulating-supply`) — see `src/utils/rpc.ts`.
+- `REDIS_CACHE_URL`, `REDIS_CACHE_USER`, `REDIS_CACHE_PASSWORD`, `STAGE` (optional) — enable Redis caching for
+  `/vaults`. When `REDIS_CACHE_URL`/`STAGE` are unset the function uses a noop cache (still works, just uncached).
+
+## Adding a new chain — checklist
+
+Each source has a single source of truth for its chain → subgraph-name mapping; `supportedChains` derives from it.
+When a chain is added to one, the others do **not** update automatically. Touch the ones relevant to the routes
+you care about:
+
+1. **`ChainId` enum** — the chain must exist in `@summerfi/serverless-shared` (`src/domain-types.ts`) first.
+2. **Public vaults** — add `chainId → 'summer-protocol-<chain>'` in
+   `packages/summer-earn-protocol-subgraph/src/utils/subgraphNameByChainMap.ts`. `supportedChains` auto-derives.
+   Affects `/`, `/users`, `/all-users`, `/vaults`.
+3. **Institutional v1** — add `chainId → 'summer-institutions-<chain>'` in
+   `packages/summer-earn-institutions-subgraph/src/utils/subgraphNameByChainMap.ts`. Affects `/`, `/vaults`.
+4. **Institutional v2 (RWA)** — add `chainId → 'summer-institutions-v2[-<chain>]'` in the
+   `rwaSubgraphNameByChainMap` in **`src/handlers/vaults.ts`**. Affects `/vaults`.
+   - NB: the earn-protocol app's `rwaSubgraphsMap` (`apps/earn-protocol/app/server-handlers/subgraphs-map.ts`)
+     currently has the wrong `-staging` suffix — that map is **not** the reference; this handler's map is.
+5. **On-chain paths only** (`/users`, `/circulating-supply`), if the new chain participates:
+   - `src/utils/rpc.ts` — add the chain → network-name mapping.
+   - `src/index.ts` — add a `case` to `getChainConfig` (viem chain) and an entry in `SUMMER_TOKEN_ADDRESSES`.
+6. **Prerequisite**: the corresponding subgraph must actually be deployed and served by `SUBGRAPH_BASE`.
+
+## Notes
+
+- **`/vaults` APY** is computed from `dailySnapshots.pricePerShare` (7d change annualised + raw 24h change),
+  matching the earn-protocol UI helpers `get-nav-price-change-24h.ts` / `get-nav-price-change-30d.ts`, **not**
+  the subgraph's revenue-based `apr*` fields. See `src/handlers/vaults.ts` and the pure math in `src/utils/nav-apy.ts`.
+- **Staleness**: each vault carries a `staleness` object (`src/utils/nav-apy.ts` `computeNavStaleness`). The
+  query fetches `_meta { block { number timestamp } }` (same request, no extra call) and staleness is measured
+  as `subgraphBlockTimestamp - latestSnapshotTimestamp > threshold` (default 1 day), i.e. against the
+  subgraph's own indexed head to avoid clock skew, with a Lambda wall-clock fallback when the subgraph omits a
+  block timestamp. Consumers must check `staleness.isStale` before trusting `nav`/`apy`.
+- `/vaults` degrades gracefully: each `(source, chain)` subgraph call is isolated in try/catch, so one failing
+  subgraph returns an empty slice rather than failing the whole response.

--- a/external-api/get-protocol-info-function/README.md
+++ b/external-api/get-protocol-info-function/README.md
@@ -67,6 +67,60 @@ Retrieves overall protocol statistics.
 }
 ```
 
+## Get Vaults
+Retrieves per-vault metrics — NAV, TVL, and APY — across public, institutional (v1), and institutional v2
+(RWA) vaults.
+
+**Endpoints:** (all GET)
+- `/vaults` — all vaults across all supported chains
+- `/vaults/{chainId}` — all vaults on a specific chain
+- `/vaults/{chainId}/{vaultAddress}` — a single vault
+
+**Path Parameters:**
+- `chainId`: numeric chain ID (e.g. `8453` for Base). Must be a supported chain.
+- `vaultAddress`: the vault (FleetCommander) address.
+
+**Response (`/vaults`, `/vaults/{chainId}`):**
+```json
+{
+  "vaults": [
+    {
+      "chainId": number,
+      "type": "public" | "institutional" | "institutional-v2",
+      "vaultAddress": string,
+      "name": string | null,
+      "inputTokenSymbol": string | null,
+      "nav": string | null,        // NAV = pricePerShare (string preserves BigDecimal precision)
+      "tvlUSD": number,            // totalValueLockedUSD
+      "apy": {
+        "nav7dAnnualised": number | null,  // 7d pricePerShare change, annualised (decimal fraction, 0.0487 = 4.87%)
+        "nav24hChange": number | null      // 24h pricePerShare change, raw (decimal fraction, 0.0003 = 0.03%)
+      },
+      "staleness": {
+        "isStale": boolean,                  // true if the newest snapshot is missing or older than thresholdSeconds
+        "latestSnapshotTimestamp": number | null,  // unix seconds of the newest daily snapshot
+        "ageSeconds": number | null,         // how old that snapshot is vs the subgraph's latest indexed block
+        "thresholdSeconds": number,          // staleness threshold (default 86400 = 1 day)
+        "subgraphBlockNumber": number | null,     // subgraph's latest indexed block (from _meta)
+        "subgraphBlockTimestamp": number | null   // its timestamp — the reference "now" used
+      }
+    }
+  ]
+}
+```
+
+**Response (`/vaults/{chainId}/{vaultAddress}`):**
+```json
+{ "vault": { /* single vault object, same shape as above */ } }
+```
+Returns `404` when no vault matches the address on that chain; `400` for an invalid chainId or address.
+
+**Notes:**
+- `nav` is the vault's `pricePerShare`. APY is derived from daily NAV snapshots, not the subgraph's revenue-based `apr*` fields.
+- APY fields are `null` when a vault has fewer than 2 daily snapshots (e.g. a brand-new vault).
+- **Staleness:** consumers should check `staleness.isStale` before trusting `nav`/`apy`. Age is measured against the subgraph's latest indexed block timestamp (`subgraphBlockTimestamp`), so it also reflects the subgraph's own view of "now" — compare `subgraphBlockTimestamp` against your clock to additionally detect subgraph indexing lag. Daily snapshots are produced ~once/day, so a healthy low-activity vault can sit close to the 1-day threshold.
+- Responses are cached in Redis (~5 min TTL, keyed per chain) when `REDIS_CACHE_URL`/`STAGE` are configured; otherwise served uncached. Single-vault lookups reuse the per-chain cached list.
+
 ## Notes
 - All monetary values are normalized and represented in USD
 - Rewards values are normalized (divided by 10^18)

--- a/external-api/get-protocol-info-function/package.json
+++ b/external-api/get-protocol-info-function/package.json
@@ -13,10 +13,13 @@
     "@aws-lambda-powertools/logger": "^2.0.4",
     "@aws-lambda-powertools/metrics": "^2.0.4",
     "@aws-lambda-powertools/tracer": "^2.0.4",
+    "@summerfi/abstractions": "workspace:*",
+    "@summerfi/redis-cache": "workspace:*",
     "@summerfi/serverless-shared": "workspace:*",
     "@summerfi/summer-earn-protocol-subgraph": "workspace:*",
     "@summerfi/summer-earn-institutions-subgraph": "workspace:*",
     "bignumber.js": "^9.1.2",
+    "graphql-request": "^6.1.0",
     "viem": "2.43.5",
     "zod": "3.25.61"
   },

--- a/external-api/get-protocol-info-function/src/handlers/vaults.ts
+++ b/external-api/get-protocol-info-function/src/handlers/vaults.ts
@@ -1,0 +1,355 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+import { GraphQLClient } from 'graphql-request'
+import { Address, ChainId } from '@summerfi/serverless-shared'
+import { getRedisInstance } from '@summerfi/redis-cache'
+import { DistributedCache } from '@summerfi/abstractions'
+import {
+  subgraphNameByChainMap as protocolSubgraphNameByChainMap,
+  supportedChains as protocolSupportedChains,
+} from '@summerfi/summer-earn-protocol-subgraph'
+import {
+  subgraphNameByChainMap as institutionsSubgraphNameByChainMap,
+  supportedChains as institutionsSupportedChains,
+} from '@summerfi/summer-earn-institutions-subgraph'
+import {
+  NavSnapshot,
+  NavStaleness,
+  computeNavStaleness,
+  navChangeAnnualised,
+  navPriceChange24h,
+} from '../utils/nav-apy'
+
+const logger = new Logger({ serviceName: 'get-protocol-info-function' })
+
+// Cache TTL for the vaults payload. NAV/APY derive from daily snapshots (slow-moving), so a few minutes is
+// plenty fresh while keeping TVL reasonably current. Tunable without any other change.
+const VAULTS_CACHE_TTL_SECONDS = 300
+
+// New institutional (RWA) v2 subgraphs. These live on the same SUBGRAPH_BASE host as the public/v1 subgraphs.
+// NB: the earn-protocol app's `rwaSubgraphsMap` (app/server-handlers/subgraphs-map.ts) currently has the wrong
+// `-staging` suffix; the correct names follow the public/v1 pattern (`<name>` / `<name>-base`). This map is the
+// corrected source of truth for this function — see CLAUDE.md when adding a new RWA chain.
+const rwaSubgraphNameByChainMap: Partial<Record<ChainId, string>> = {
+  [ChainId.MAINNET]: 'summer-institutions-v2',
+  [ChainId.BASE]: 'summer-institutions-v2-base',
+}
+const rwaSupportedChains: ChainId[] = Object.keys(rwaSubgraphNameByChainMap).map((k) =>
+  parseInt(k),
+) as ChainId[]
+
+export type VaultType = 'public' | 'institutional' | 'institutional-v2'
+
+interface VaultSource {
+  type: VaultType
+  subgraphNameByChainMap: Partial<Record<ChainId, string>>
+  supportedChains: ChainId[]
+}
+
+const VAULT_SOURCES: VaultSource[] = [
+  {
+    type: 'public',
+    subgraphNameByChainMap: protocolSubgraphNameByChainMap,
+    supportedChains: protocolSupportedChains,
+  },
+  {
+    type: 'institutional',
+    subgraphNameByChainMap: institutionsSubgraphNameByChainMap,
+    supportedChains: institutionsSupportedChains,
+  },
+  {
+    type: 'institutional-v2',
+    subgraphNameByChainMap: rwaSubgraphNameByChainMap,
+    supportedChains: rwaSupportedChains,
+  },
+]
+
+// The union of chains any vault source serves. Used to reject `/vaults/{chainId}` for chains that are valid
+// `ChainId`s but not served by any vault subgraph (e.g. Optimism/Sepolia), rather than returning a misleading
+// empty 200 / 404.
+export const supportedVaultChainIds: ChainId[] = Array.from(
+  new Set(VAULT_SOURCES.flatMap((source) => source.supportedChains)),
+)
+
+// One lean query reused across all three subgraph schemas (they share the core Vault/VaultDailySnapshot
+// shape). `first: 8` daily snapshots covers day 0 + the 7 prior days needed for the 7d window. The RWA/v2
+// `vaults` root query is intentionally unfiltered here (no institution filter) so it returns every vault
+// across institutions in a single call, unlike the typed `GetVaults($institutionId)`.
+const VAULTS_NAV_QUERY = /* GraphQL */ `
+  query VaultsNav {
+    _meta {
+      block {
+        number
+        timestamp
+      }
+    }
+    vaults(first: 1000) {
+      id
+      name
+      pricePerShare
+      totalValueLockedUSD
+      inputToken {
+        symbol
+        decimals
+      }
+      dailySnapshots(first: 8, orderBy: timestamp, orderDirection: desc) {
+        pricePerShare
+        timestamp
+      }
+    }
+  }
+`
+
+// The Graph serialises BigDecimal/BigInt scalars as JSON strings, so numeric fields arrive as strings.
+interface SubgraphVault {
+  id: string
+  name: string | null
+  pricePerShare: string | null
+  totalValueLockedUSD: string | null
+  inputToken: { symbol: string | null; decimals: number } | null
+  dailySnapshots: NavSnapshot[] | null
+}
+
+interface SubgraphMeta {
+  block: {
+    number: number
+    timestamp: number | null
+  }
+}
+
+interface VaultsNavQueryResult {
+  _meta: SubgraphMeta | null
+  vaults: SubgraphVault[]
+}
+
+interface VaultApy {
+  /** 7-day pricePerShare change, annualised, as a decimal fraction (0.0487 = +4.87%). null when insufficient data. */
+  nav7dAnnualised: number | null
+  /** 24-hour pricePerShare change (raw, not annualised), as a decimal fraction (0.0003 = +0.03%). null when insufficient data. */
+  nav24hChange: number | null
+}
+
+export interface VaultInfo {
+  chainId: ChainId
+  type: VaultType
+  vaultAddress: Address
+  name: string | null
+  inputTokenSymbol: string | null
+  /** NAV = pricePerShare, kept as a string to preserve BigDecimal precision. null when the subgraph has no value. */
+  nav: string | null
+  tvlUSD: number
+  apy: VaultApy
+  /** Freshness of the NAV data. Consumers MUST check `staleness.isStale` before trusting nav/apy. */
+  staleness: NavStaleness
+}
+
+export interface VaultsResponseBody {
+  vaults: VaultInfo[]
+}
+
+function toNumberOrZero(value: string | null | undefined): number {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : 0
+}
+
+function mapVault(
+  vault: SubgraphVault,
+  chainId: ChainId,
+  type: VaultType,
+  meta: SubgraphMeta | null,
+  nowSeconds: number,
+): VaultInfo {
+  const snapshots = vault.dailySnapshots ?? []
+  return {
+    chainId,
+    type,
+    vaultAddress: vault.id as Address,
+    name: vault.name ?? null,
+    inputTokenSymbol: vault.inputToken?.symbol ?? null,
+    nav: vault.pricePerShare ?? null,
+    tvlUSD: toNumberOrZero(vault.totalValueLockedUSD),
+    apy: {
+      nav7dAnnualised: navChangeAnnualised(snapshots, 7),
+      nav24hChange: navPriceChange24h(snapshots),
+    },
+    staleness: computeNavStaleness({
+      snapshots,
+      subgraphBlockNumber: meta?.block.number ?? null,
+      subgraphBlockTimestamp: meta?.block.timestamp ?? null,
+      nowSeconds,
+    }),
+  }
+}
+
+async function fetchVaultsForSource(
+  source: VaultSource,
+  subgraphBase: string,
+  chainFilter?: ChainId,
+): Promise<{ vaults: VaultInfo[]; degraded: boolean }> {
+  const chains = source.supportedChains.filter(
+    (chainId) => chainFilter === undefined || chainId === chainFilter,
+  )
+
+  const perChain = await Promise.all(
+    chains.map(async (chainId): Promise<{ vaults: VaultInfo[]; failed: boolean }> => {
+      const subgraphName = source.subgraphNameByChainMap[chainId]
+      if (!subgraphName) {
+        return { vaults: [], failed: false }
+      }
+      const url = `${subgraphBase}/${subgraphName}`
+      try {
+        const client = new GraphQLClient(url)
+        const data = await client.request<VaultsNavQueryResult>(VAULTS_NAV_QUERY)
+        // Reference "now" for staleness: the subgraph's latest indexed block timestamp when available,
+        // else the Lambda wall clock (fallback handled inside computeNavStaleness).
+        const nowSeconds = Math.floor(Date.now() / 1000)
+        logger.info('Fetched vaults', {
+          source: source.type,
+          chainId,
+          count: data.vaults.length,
+          subgraphBlock: data._meta?.block.number ?? null,
+          subgraphBlockTimestamp: data._meta?.block.timestamp ?? null,
+        })
+        return {
+          vaults: data.vaults.map((vault) =>
+            mapVault(vault, chainId, source.type, data._meta, nowSeconds),
+          ),
+          failed: false,
+        }
+      } catch (error) {
+        // Degrade gracefully: a single failing subgraph must not fail the whole response. `failed: true`
+        // signals the caller to NOT cache this response, so a transient outage isn't persisted for the TTL.
+        logger.warn('Failed to fetch vaults for source/chain', {
+          source: source.type,
+          chainId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { vaults: [], failed: true }
+      }
+    }),
+  )
+
+  return {
+    vaults: perChain.flatMap((result) => result.vaults),
+    degraded: perChain.some((result) => result.failed),
+  }
+}
+
+const NOOP_CACHE: DistributedCache = {
+  get: async () => null,
+  set: async () => {},
+}
+
+let cachedDistributedCache: DistributedCache | undefined = undefined
+async function getVaultsCacheInstance(): Promise<DistributedCache> {
+  if (cachedDistributedCache !== undefined) {
+    return cachedDistributedCache
+  }
+
+  const REDIS_CACHE_URL = process.env.REDIS_CACHE_URL
+  const REDIS_CACHE_USER = process.env.REDIS_CACHE_USER
+  const REDIS_CACHE_PASSWORD = process.env.REDIS_CACHE_PASSWORD
+  const STAGE = process.env.STAGE
+
+  if (!REDIS_CACHE_URL || !STAGE) {
+    logger.warn('Redis not configured (REDIS_CACHE_URL/STAGE), using noop cache for vaults')
+    cachedDistributedCache = NOOP_CACHE
+    return cachedDistributedCache
+  }
+
+  try {
+    cachedDistributedCache = await getRedisInstance(
+      {
+        url: REDIS_CACHE_URL,
+        ttlInSeconds: VAULTS_CACHE_TTL_SECONDS,
+        username: REDIS_CACHE_USER,
+        password: REDIS_CACHE_PASSWORD,
+        stage: STAGE,
+      },
+      logger,
+    )
+  } catch (error) {
+    // The cache is optional — a Redis connection failure must not take down the endpoint. Fall back to the
+    // noop cache (and memoize it so we don't retry connecting on every request in this container).
+    logger.warn('Redis init failed, falling back to noop cache for vaults', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    cachedDistributedCache = NOOP_CACHE
+  }
+  return cachedDistributedCache
+}
+
+/**
+ * Fetches all vaults (across public / institutional / institutional-v2 sources), optionally filtered to a
+ * single chain. Cached per chain-filter so single-vault lookups reuse the same per-chain list.
+ */
+async function getAllVaults(subgraphBase: string, chainFilter?: ChainId): Promise<VaultInfo[]> {
+  const cache = await getVaultsCacheInstance()
+  const cacheKey = `vaults-v1:${chainFilter ?? 'all'}`
+
+  // Cache reads are best-effort: a Redis failure must not fail the request, just fall through to a fresh fetch.
+  try {
+    const cached = await cache.get(cacheKey)
+    if (cached) {
+      logger.info('Returning cached vaults', { cacheKey })
+      return JSON.parse(cached) as VaultInfo[]
+    }
+  } catch (error) {
+    logger.warn('Cache read failed, fetching fresh', {
+      cacheKey,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  const perSource = await Promise.all(
+    VAULT_SOURCES.map((source) => fetchVaultsForSource(source, subgraphBase, chainFilter)),
+  )
+  const vaults = perSource.flatMap((result) => result.vaults)
+  const degraded = perSource.some((result) => result.degraded)
+  logger.info('Vaults fetched', { total: vaults.length, chainId: chainFilter ?? 'all', degraded })
+
+  // Only persist complete results. If any source degraded, skip the write so a transient outage isn't cached
+  // as authoritative for the full TTL (which would also make single-vault lookups 404 for real vaults).
+  if (degraded) {
+    logger.warn('Skipping cache write due to degraded source(s)', { cacheKey })
+  } else {
+    try {
+      await cache.set(cacheKey, JSON.stringify(vaults))
+    } catch (error) {
+      logger.warn('Cache write failed', {
+        cacheKey,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return vaults
+}
+
+/**
+ * `GET /vaults` (all chains) and `GET /vaults/{chainId}` (single chain) — returns the vault list.
+ */
+export async function handleVaultsListRoute(
+  params: { chainId?: ChainId },
+  subgraphBase: string,
+): Promise<VaultsResponseBody> {
+  logger.info('Handling vaults list route', { chainId: params.chainId ?? 'all' })
+  const vaults = await getAllVaults(subgraphBase, params.chainId)
+  return { vaults }
+}
+
+/**
+ * `GET /vaults/{chainId}/{vaultAddress}` — returns the single matching vault, or null when not found.
+ * Reuses the per-chain cached list and filters by address (case-insensitive).
+ */
+export async function handleVaultRoute(
+  params: { chainId: ChainId; vaultAddress: Address },
+  subgraphBase: string,
+): Promise<VaultInfo | null> {
+  logger.info('Handling single vault route', {
+    chainId: params.chainId,
+    vaultAddress: params.vaultAddress,
+  })
+  const vaults = await getAllVaults(subgraphBase, params.chainId)
+  const target = params.vaultAddress.toLowerCase()
+  return vaults.find((vault) => vault.vaultAddress.toLowerCase() === target) ?? null
+}

--- a/external-api/get-protocol-info-function/src/index.ts
+++ b/external-api/get-protocol-info-function/src/index.ts
@@ -23,11 +23,7 @@ import { mainnet, optimism, arbitrum, base, sonic, hyperliquid } from 'viem/chai
 import { supportedChains } from '@summerfi/summer-earn-protocol-subgraph'
 import { fleetRewardsManagerAbi } from './abis/fleetRewardsManager'
 import { handleCirculatingSupplyRoute } from './handlers/circulating-supply'
-import {
-  handleVaultRoute,
-  handleVaultsListRoute,
-  supportedVaultChainIds,
-} from './handlers/vaults'
+import { handleVaultRoute, handleVaultsListRoute, supportedVaultChainIds } from './handlers/vaults'
 import { getRpcUrl } from './utils/rpc'
 
 // Token addresses per chain (same as rewardTokenPerChain in index.ts)

--- a/external-api/get-protocol-info-function/src/index.ts
+++ b/external-api/get-protocol-info-function/src/index.ts
@@ -3,6 +3,7 @@ import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2, Context } from 'a
 import {
   ResponseBadRequest,
   ResponseInternalServerError,
+  ResponseNotFound,
   ResponseOk,
 } from '@summerfi/serverless-shared/responses'
 import { chainIdSchema } from '@summerfi/serverless-shared/validators'
@@ -22,6 +23,11 @@ import { mainnet, optimism, arbitrum, base, sonic, hyperliquid } from 'viem/chai
 import { supportedChains } from '@summerfi/summer-earn-protocol-subgraph'
 import { fleetRewardsManagerAbi } from './abis/fleetRewardsManager'
 import { handleCirculatingSupplyRoute } from './handlers/circulating-supply'
+import {
+  handleVaultRoute,
+  handleVaultsListRoute,
+  supportedVaultChainIds,
+} from './handlers/vaults'
 import { getRpcUrl } from './utils/rpc'
 
 // Token addresses per chain (same as rewardTokenPerChain in index.ts)
@@ -491,11 +497,64 @@ export const handler = async (
   const isAllUsersRoute = event.rawPath.endsWith('/all-users')
   const isCirculatingSupplyRoute = event.rawPath.endsWith('/circulating-supply')
 
+  // Path-based vaults routes: /vaults, /vaults/{chainId}, /vaults/{chainId}/{vaultAddress}
+  const pathSegments = event.rawPath.split('/').filter(Boolean)
+  const vaultsSegmentIndex = pathSegments.indexOf('vaults')
+  const isVaultsRoute = vaultsSegmentIndex !== -1
+
   try {
     switch (true) {
       case isCirculatingSupplyRoute: {
         const response = await handleCirculatingSupplyRoute()
         return ResponseOk({ body: response })
+      }
+      case isVaultsRoute: {
+        const chainIdSegment = pathSegments[vaultsSegmentIndex + 1]
+        const vaultAddressSegment = pathSegments[vaultsSegmentIndex + 2]
+
+        // /vaults — all vaults across all chains
+        if (!chainIdSegment) {
+          const response = await handleVaultsListRoute({}, SUBGRAPH_BASE)
+          return ResponseOk({ body: response })
+        }
+
+        const chainIdParse = chainIdSchema.safeParse(chainIdSegment)
+        if (!chainIdParse.success) {
+          logger.warn('Invalid chainId in vaults route', { chainIdSegment })
+          return ResponseBadRequest({
+            message: 'Invalid chainId',
+            errors: chainIdParse.error.errors,
+          })
+        }
+        const chainId = chainIdParse.data
+
+        // Reject chains that are valid ChainIds but not served by any vault source.
+        if (!supportedVaultChainIds.includes(chainId)) {
+          logger.warn('Unsupported chainId for vaults route', { chainId })
+          return ResponseBadRequest({
+            message: `Unsupported chainId ${chainId}. Supported chains: ${supportedVaultChainIds.join(', ')}`,
+          })
+        }
+
+        // /vaults/{chainId} — all vaults on a chain
+        if (!vaultAddressSegment) {
+          const response = await handleVaultsListRoute({ chainId }, SUBGRAPH_BASE)
+          return ResponseOk({ body: response })
+        }
+
+        // /vaults/{chainId}/{vaultAddress} — a single vault
+        if (!isValidAddress(vaultAddressSegment)) {
+          logger.warn('Invalid vault address in vaults route', { vaultAddressSegment })
+          return ResponseBadRequest({ message: 'Invalid vault address' })
+        }
+        const vault = await handleVaultRoute(
+          { chainId, vaultAddress: vaultAddressSegment as Address },
+          SUBGRAPH_BASE,
+        )
+        if (!vault) {
+          return ResponseNotFound()
+        }
+        return ResponseOk({ body: { vault } })
       }
       case isAllUsersRoute: {
         const response = await handleAllUsersRoute(SUBGRAPH_BASE)

--- a/external-api/get-protocol-info-function/src/utils/nav-apy.spec.ts
+++ b/external-api/get-protocol-info-function/src/utils/nav-apy.spec.ts
@@ -1,0 +1,142 @@
+import { computeNavStaleness, navChangeAnnualised, navPriceChange24h } from './nav-apy'
+
+const DAY = 86_400
+
+// newest-first daily snapshots (as the subgraph query returns them, orderDirection: desc)
+const snap = (pricePerShare: string | null, daysAgo: number) => ({
+  pricePerShare,
+  timestamp: String(1_000_000 - daysAgo * DAY),
+})
+
+describe('navPriceChange24h', () => {
+  it('computes (latest - previous)/previous over the two newest snapshots', () => {
+    expect(navPriceChange24h([snap('1.01', 0), snap('1.00', 1)])).toBeCloseTo(0.01, 10)
+  })
+
+  it('returns null with fewer than two snapshots', () => {
+    expect(navPriceChange24h([])).toBeNull()
+    expect(navPriceChange24h([snap('1.01', 0)])).toBeNull()
+  })
+
+  it('returns null when the previous price is <= 0 or non-finite', () => {
+    expect(navPriceChange24h([snap('1.01', 0), snap('0', 1)])).toBeNull()
+    expect(navPriceChange24h([snap('1.01', 0), snap(null, 1)])).toBeNull()
+  })
+})
+
+describe('navChangeAnnualised (7d)', () => {
+  it('annualises a full 7-day window: 7% over 7 days -> 3.65', () => {
+    const snapshots = [
+      snap('1.07', 0),
+      snap('1.06', 1),
+      snap('1.05', 2),
+      snap('1.04', 3),
+      snap('1.03', 4),
+      snap('1.02', 5),
+      snap('1.01', 6),
+      snap('1.00', 7),
+    ]
+    // change = (1.07-1.00)/1.00 = 0.07 ; daysUsed = 7 ; apy = 0.07/7*365 = 3.65
+    expect(navChangeAnnualised(snapshots, 7)).toBeCloseTo(3.65, 8)
+  })
+
+  it('picks the most recent snapshot at least 7 days old when extra history exists', () => {
+    // 9 snapshots: day8 exists but the target is day7; result should use day7 (1.00), not day8.
+    const snapshots = [
+      snap('1.07', 0),
+      snap('1.065', 1),
+      snap('1.05', 2),
+      snap('1.04', 3),
+      snap('1.03', 4),
+      snap('1.02', 5),
+      snap('1.01', 6),
+      snap('1.00', 7),
+      snap('0.90', 8),
+    ]
+    expect(navChangeAnnualised(snapshots, 7)).toBeCloseTo(3.65, 8)
+  })
+
+  it('young-fleet fallback: only 2 snapshots 1 day apart annualises over the actual 1-day window', () => {
+    // change = (1.01-1.00)/1.00 = 0.01 ; daysUsed = 1 ; apy = 0.01*365 = 3.65
+    expect(navChangeAnnualised([snap('1.01', 0), snap('1.00', 1)], 7)).toBeCloseTo(3.65, 8)
+  })
+
+  it('returns null with fewer than two snapshots or a bad past price', () => {
+    expect(navChangeAnnualised([snap('1.01', 0)], 7)).toBeNull()
+    expect(navChangeAnnualised([snap('1.01', 0), snap('0', 7)], 7)).toBeNull()
+  })
+})
+
+describe('computeNavStaleness', () => {
+  const REF = 1_000_000 // reference block timestamp; snap(_, 0) has timestamp === REF
+
+  it('is not stale when the newest snapshot is within 1 day of the subgraph head', () => {
+    const result = computeNavStaleness({
+      snapshots: [snap('1.01', 0), snap('1.00', 1)],
+      subgraphBlockNumber: 123,
+      subgraphBlockTimestamp: REF,
+      nowSeconds: REF + 5 * DAY, // wall clock ignored when the subgraph reports a block timestamp
+    })
+    expect(result.isStale).toBe(false)
+    expect(result.ageSeconds).toBe(0)
+    expect(result.latestSnapshotTimestamp).toBe(REF)
+    expect(result.subgraphBlockNumber).toBe(123)
+    expect(result.subgraphBlockTimestamp).toBe(REF)
+  })
+
+  it('is stale when the newest snapshot is older than 1 day vs the subgraph head', () => {
+    const result = computeNavStaleness({
+      snapshots: [snap('1.01', 2), snap('1.00', 3)],
+      subgraphBlockNumber: 123,
+      subgraphBlockTimestamp: REF,
+      nowSeconds: REF,
+    })
+    expect(result.isStale).toBe(true)
+    expect(result.ageSeconds).toBe(2 * DAY)
+  })
+
+  it('treats missing snapshots as stale', () => {
+    const result = computeNavStaleness({
+      snapshots: [],
+      subgraphBlockNumber: 1,
+      subgraphBlockTimestamp: REF,
+      nowSeconds: REF,
+    })
+    expect(result.isStale).toBe(true)
+    expect(result.latestSnapshotTimestamp).toBeNull()
+    expect(result.ageSeconds).toBeNull()
+  })
+
+  it('falls back to nowSeconds when the subgraph omits a block timestamp', () => {
+    const result = computeNavStaleness({
+      snapshots: [snap('1.01', 0)], // ts === REF
+      subgraphBlockNumber: 5,
+      subgraphBlockTimestamp: null,
+      nowSeconds: REF + 2 * DAY,
+    })
+    expect(result.subgraphBlockTimestamp).toBeNull()
+    expect(result.subgraphBlockNumber).toBe(5)
+    expect(result.ageSeconds).toBe(2 * DAY)
+    expect(result.isStale).toBe(true)
+  })
+
+  it('is not stale exactly at the threshold, stale one second past it', () => {
+    const atThreshold = computeNavStaleness({
+      snapshots: [{ pricePerShare: '1.0', timestamp: String(REF - DAY) }],
+      subgraphBlockNumber: 1,
+      subgraphBlockTimestamp: REF,
+      nowSeconds: REF,
+    })
+    expect(atThreshold.ageSeconds).toBe(DAY)
+    expect(atThreshold.isStale).toBe(false)
+
+    const pastThreshold = computeNavStaleness({
+      snapshots: [{ pricePerShare: '1.0', timestamp: String(REF - DAY - 1) }],
+      subgraphBlockNumber: 1,
+      subgraphBlockTimestamp: REF,
+      nowSeconds: REF,
+    })
+    expect(pastThreshold.ageSeconds).toBe(DAY + 1)
+    expect(pastThreshold.isStale).toBe(true)
+  })
+})

--- a/external-api/get-protocol-info-function/src/utils/nav-apy.ts
+++ b/external-api/get-protocol-info-function/src/utils/nav-apy.ts
@@ -1,0 +1,132 @@
+import BigNumber from 'bignumber.js'
+
+const SECONDS_PER_DAY = 86_400
+const DAYS_PER_YEAR = 365
+
+// Default staleness threshold: a vault's newest daily snapshot older than this (relative to the subgraph's
+// latest indexed block) is considered stale. Daily snapshots are produced ~once/day, so 1 day is the
+// tightest sensible bound — a healthy but low-activity vault can legitimately sit near this.
+export const DEFAULT_STALENESS_THRESHOLD_SECONDS = SECONDS_PER_DAY
+
+// A vault daily snapshot as returned by the subgraph. The Graph serialises BigDecimal/BigInt scalars as JSON
+// strings, so both fields arrive as strings. Snapshots are expected newest-first (orderDirection: desc).
+export interface NavSnapshot {
+  pricePerShare: string | null
+  timestamp: string
+}
+
+export interface NavStaleness {
+  /** true when the newest snapshot is missing, has a bad timestamp, or is older than `thresholdSeconds`. */
+  isStale: boolean
+  /** unix seconds of the newest daily snapshot, or null when there are none / it is non-finite. */
+  latestSnapshotTimestamp: number | null
+  /** referenceTimestamp - latestSnapshotTimestamp (how old the newest snapshot is), or null when unavailable. */
+  ageSeconds: number | null
+  /** the staleness threshold applied, in seconds. */
+  thresholdSeconds: number
+  /** the subgraph's latest indexed block number (from `_meta`), or null when unavailable. */
+  subgraphBlockNumber: number | null
+  /** the subgraph's latest indexed block timestamp (from `_meta`) — the reference "now" used, or null. */
+  subgraphBlockTimestamp: number | null
+}
+
+/**
+ * Computes staleness of a vault's NAV data from its daily snapshots. The reference "now" is the subgraph's
+ * latest indexed block timestamp (`_meta.block.timestamp`) — comparing against the subgraph's own head avoids
+ * Lambda/chain clock skew and detects a vault that has stopped producing snapshots. When the subgraph does not
+ * report a block timestamp, `nowSeconds` (the caller's wall clock) is used as a fallback so a verdict is always
+ * produced. Consumers can additionally detect subgraph indexing lag by comparing `subgraphBlockTimestamp`
+ * against their own clock. Snapshots are expected newest-first.
+ */
+export function computeNavStaleness(params: {
+  snapshots: NavSnapshot[]
+  subgraphBlockNumber: number | null
+  subgraphBlockTimestamp: number | null
+  nowSeconds: number
+  thresholdSeconds?: number
+}): NavStaleness {
+  const thresholdSeconds = params.thresholdSeconds ?? DEFAULT_STALENESS_THRESHOLD_SECONDS
+
+  const latestTsRaw = params.snapshots.length > 0 ? Number(params.snapshots[0]?.timestamp) : NaN
+  const latestSnapshotTimestamp = Number.isFinite(latestTsRaw) ? latestTsRaw : null
+
+  const blockTimestamp =
+    params.subgraphBlockTimestamp != null && Number.isFinite(params.subgraphBlockTimestamp)
+      ? params.subgraphBlockTimestamp
+      : null
+  const blockNumber =
+    params.subgraphBlockNumber != null && Number.isFinite(params.subgraphBlockNumber)
+      ? params.subgraphBlockNumber
+      : null
+
+  const referenceTimestamp = blockTimestamp ?? params.nowSeconds
+  const ageSeconds =
+    latestSnapshotTimestamp != null ? referenceTimestamp - latestSnapshotTimestamp : null
+  const isStale = ageSeconds === null || ageSeconds > thresholdSeconds
+
+  return {
+    isStale,
+    latestSnapshotTimestamp,
+    ageSeconds,
+    thresholdSeconds,
+    subgraphBlockNumber: blockNumber,
+    subgraphBlockTimestamp: blockTimestamp,
+  }
+}
+
+/**
+ * 24-hour NAV (pricePerShare) change: (latest - previous) / previous over the two most recent daily
+ * snapshots. Returns a decimal fraction (0.0003 = +0.03%), or null when there aren't two snapshots / a price
+ * is non-finite / the previous price is <= 0. Mirrors apps/earn-protocol/helpers/get-nav-price-change-24h.ts.
+ */
+export function navPriceChange24h(snapshots: NavSnapshot[]): number | null {
+  if (snapshots.length < 2) {
+    return null
+  }
+  const latest = Number(snapshots[0]?.pricePerShare)
+  const previous = Number(snapshots[1]?.pricePerShare)
+  if (!Number.isFinite(latest) || !Number.isFinite(previous) || previous <= 0) {
+    return null
+  }
+  return new BigNumber(latest).minus(previous).div(previous).toNumber()
+}
+
+/**
+ * N-day NAV (pricePerShare) change, annualised: ((latest - past) / past) / daysUsed * 365. Picks the most
+ * recent snapshot at least `targetDays` old; if none exists (young fleet) falls back to the oldest available
+ * snapshot and annualises by the actual window spanned. Returns a decimal fraction (0.0487 = +4.87%), or null
+ * when there aren't two snapshots / a price/timestamp is non-finite / a price is <= 0. Generalised from
+ * apps/earn-protocol/helpers/get-nav-price-change-30d.ts.
+ */
+export function navChangeAnnualised(snapshots: NavSnapshot[], targetDays: number): number | null {
+  if (snapshots.length < 2) {
+    return null
+  }
+  const latestPrice = Number(snapshots[0]?.pricePerShare)
+  const latestTs = Number(snapshots[0]?.timestamp)
+  if (!Number.isFinite(latestPrice) || latestPrice <= 0 || !Number.isFinite(latestTs)) {
+    return null
+  }
+
+  const targetTs = latestTs - targetDays * SECONDS_PER_DAY
+
+  // snapshots are ordered newest -> oldest; default to the oldest available (young-fleet fallback), then walk
+  // newest -> oldest to find the most recent snapshot at least `targetDays` old.
+  let past = snapshots[snapshots.length - 1]
+  for (let i = 1; i < snapshots.length; i++) {
+    if (Number(snapshots[i]?.timestamp) <= targetTs) {
+      past = snapshots[i]
+      break
+    }
+  }
+
+  const pastPrice = Number(past.pricePerShare)
+  const pastTs = Number(past.timestamp)
+  if (!Number.isFinite(pastPrice) || pastPrice <= 0 || !Number.isFinite(pastTs)) {
+    return null
+  }
+
+  const change = new BigNumber(latestPrice).minus(pastPrice).div(pastPrice).toNumber()
+  const daysUsed = Math.max(1, Math.round((latestTs - pastTs) / SECONDS_PER_DAY))
+  return new BigNumber(change).div(daysUsed).times(DAYS_PER_YEAR).toNumber()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,6 +891,12 @@ importers:
       '@aws-lambda-powertools/tracer':
         specifier: ^2.0.4
         version: 2.32.0
+      '@summerfi/abstractions':
+        specifier: workspace:*
+        version: link:../../packages/abstractions
+      '@summerfi/redis-cache':
+        specifier: workspace:*
+        version: link:../../packages/redis-cache
       '@summerfi/serverless-shared':
         specifier: workspace:*
         version: link:../../packages/serverless-shared
@@ -903,6 +909,9 @@ importers:
       bignumber.js:
         specifier: ^9.1.2
         version: 9.3.1
+      graphql-request:
+        specifier: ^6.1.0
+        version: 6.1.0(graphql@16.11.0)
       viem:
         specifier: 2.43.5
         version: 2.43.5(typescript@5.9.3)(zod@3.25.61)

--- a/stacks/partners-stack.ts
+++ b/stacks/partners-stack.ts
@@ -61,12 +61,26 @@ export function ExternalAPI(stackContext: StackContext) {
       SUBGRAPH_BASE: SUBGRAPH_BASE,
       POWERTOOLS_LOG_LEVEL: process.env.POWERTOOLS_LOG_LEVEL || 'INFO',
       RPC_GATEWAY: RPC_GATEWAY,
+      STAGE: stack.stage,
     },
     tracing: 'active',
     disableCloudWatchLogs: false,
     applicationLogLevel: 'INFO',
     systemLogLevel: 'INFO',
   })
+
+  // Optional Redis cache for the /vaults route. Passed through from the deploy env when present; the handler
+  // falls back to a noop cache when unset, so the function is fully functional without Redis configured.
+  const { REDIS_CACHE_URL, REDIS_CACHE_USER, REDIS_CACHE_PASSWORD } = process.env
+  if (REDIS_CACHE_URL) {
+    getProtocolInfo.addEnvironment('REDIS_CACHE_URL', REDIS_CACHE_URL)
+  }
+  if (REDIS_CACHE_USER) {
+    getProtocolInfo.addEnvironment('REDIS_CACHE_USER', REDIS_CACHE_USER)
+  }
+  if (REDIS_CACHE_PASSWORD) {
+    getProtocolInfo.addEnvironment('REDIS_CACHE_PASSWORD', REDIS_CACHE_PASSWORD)
+  }
 
   const getCampaignData = new Function(stack, 'get-campaign-data', {
     handler: 'external-api/get-campaign-data-function/src/index.handler',
@@ -98,6 +112,9 @@ export function ExternalAPI(stackContext: StackContext) {
     'GET /api/protocol-info/protocol': getProtocolInfo,
     'GET /api/protocol-info/all-users': getProtocolInfo,
     'GET /api/protocol-info/circulating-supply': getProtocolInfo,
+    'GET /api/protocol-info/vaults': getProtocolInfo,
+    'GET /api/protocol-info/vaults/{chainId}': getProtocolInfo,
+    'GET /api/protocol-info/vaults/{chainId}/{vaultAddress}': getProtocolInfo,
     'GET /api/campaigns/{campaign}/{questNumber}/{walletAddress}': getCampaignData,
   })
 


### PR DESCRIPTION
## What

Adds per-vault metrics to `get-protocol-info-function` via new path-based routes:

| Route | Returns |
|---|---|
| `GET /api/protocol-info/vaults` | all vaults, all chains → `{ "vaults": [...] }` |
| `GET /api/protocol-info/vaults/{chainId}` | all vaults on a chain → `{ "vaults": [...] }` |
| `GET /api/protocol-info/vaults/{chainId}/{vaultAddress}` | one vault → `{ "vault": {...} }` (404 if not found) |

Each vault carries **NAV** (`pricePerShare`), **TVL** (`totalValueLockedUSD`), **APY** (`nav7dAnnualised` + `nav24hChange`), and a **`staleness`** object — across **public**, **institutional (v1)**, and **institutional v2 (RWA)** subgraphs.

## Why / how

- **Least calls:** one lean GraphQL query per `(source, chain)` (~11 total, in parallel), each returning all vaults + their last 8 daily snapshots + `_meta` in a single request. NAV, TVL, both APY components, and staleness are all derived from that one payload.
- **APY** is computed from `dailySnapshots.pricePerShare` — 7d change annualised (`change / daysUsed * 365`) and raw 24h change — matching the earn-protocol UI helpers (`get-nav-price-change-24h.ts` / `-30d.ts`), **not** the subgraph's revenue-based `apr*` fields. Values are decimal fractions (`0.0487` = 4.87%), `null` when there's insufficient snapshot history.
- **Staleness:** age is measured against the subgraph's latest indexed block timestamp (`_meta.block.timestamp`), with a Lambda wall-clock fallback. Each vault exposes `isStale`, `latestSnapshotTimestamp`, `ageSeconds`, `thresholdSeconds` (default 1 day), and the subgraph block number/timestamp so consumers can also detect subgraph indexing lag. **Consumers must check `staleness.isStale` before trusting nav/apy.**
- **Caching:** best-effort Redis (`@summerfi/redis-cache`), per-chain key, ~5-min TTL; noop fallback when unset or on connection failure. Single-vault lookups reuse the per-chain cached list.
- **Robustness:** per-source/chain isolation (one failing subgraph doesn't fail the response); partial-outage responses are **not** cached (avoids serving/persisting incomplete data for the TTL); unsupported-but-valid chains return `400`.
- **Docs:** adds `CLAUDE.md` mapping the function's cross-package dependencies and an "adding a new chain" checklist (chain config is duplicated across packages and drifts silently).

## Notes

- New `summer-institutions-v2` subgraph names use `summer-institutions-v2` / `summer-institutions-v2-base`. The earn-protocol app's `rwaSubgraphsMap` has a stale `-staging` suffix — **not** copied here; worth a follow-up to fix that map.
- Redis env passthrough (`REDIS_CACHE_URL` / `REDIS_CACHE_USER` / `REDIS_CACHE_PASSWORD` / `STAGE`) added to the `get-protocol-info` function in `partners-stack.ts`; caching is a no-op until those are set.
- An external code review (OpenAI Codex `gpt-5.5`) was run; its three findings (partial-outage caching, Redis on the critical path, unsupported-chain validation) are all addressed in this PR.

## Verification

- `pnpm --filter @summerfi/get-protocol-info-function build` ✅
- `eslint` ✅
- `jest` ✅ (12 tests: NAV 24h/7d-annualised math + staleness thresholds/fallbacks)
- Live end-to-end still needs the deployment `SUBGRAPH_BASE` (a redeploy of the ExternalAPI stack is required to expose the new routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new vault API endpoints to list vaults by chain and fetch a single vault by address.
  * Added support for vault performance details, including NAV, APY, and freshness indicators.
  * Expanded API routing to handle the new vault-related paths.

* **Bug Fixes**
  * Improved resilience when some data sources fail so vault responses still return where possible.
  * Added safer caching behavior to avoid storing incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->