### PR TITLE
fix(protocol-info): make /vaults bulletproof against a dead/slow Redis

### DIFF
--- a/external-api/get-protocol-info-function/src/handlers/vaults.ts
+++ b/external-api/get-protocol-info-function/src/handlers/vaults.ts
@@ -18,12 +18,19 @@ import {
   navChangeAnnualised,
   navPriceChange24h,
 } from '../utils/nav-apy'
+import { withTimeout } from '../utils/with-timeout'
 
 const logger = new Logger({ serviceName: 'get-protocol-info-function' })
 
 // Cache TTL for the vaults payload. NAV/APY derive from daily snapshots (slow-moving), so a few minutes is
 // plenty fresh while keeping TVL reasonably current. Tunable without any other change.
 const VAULTS_CACHE_TTL_SECONDS = 300
+
+// Redis is a best-effort optimisation, never a hard dependency. These bound how long the endpoint will wait
+// on it before falling back to serving fresh (uncached) data.
+const CACHE_CONNECT_TIMEOUT_MS = 2000 // budget for establishing the Redis connection
+const CACHE_MAX_RECONNECT_ATTEMPTS = 2 // give up fast on an unreachable host instead of retrying forever
+const CACHE_OP_TIMEOUT_MS = 750 // budget for a single get/set once connected
 
 // New institutional (RWA) v2 subgraphs. These live on the same SUBGRAPH_BASE host as the public/v1 subgraphs.
 // NB: the earn-protocol app's `rwaSubgraphsMap` (app/server-handlers/subgraphs-map.ts) currently has the wrong
@@ -239,9 +246,17 @@ const NOOP_CACHE: DistributedCache = {
   set: async () => {},
 }
 
+// After a failed Redis init we serve the noop cache, but only until this cooldown elapses — then the next
+// request retries the connection. This avoids both extremes: retrying a dead host on every request (latency)
+// and permanently disabling caching for the whole container after a single transient hiccup.
+const CACHE_INIT_RETRY_COOLDOWN_MS = 60_000
+
 let cachedDistributedCache: DistributedCache | undefined = undefined
+let cacheRetryAfter = 0 // epoch ms; while on the noop cache, the earliest time to re-attempt a real connection
+
 async function getVaultsCacheInstance(): Promise<DistributedCache> {
-  if (cachedDistributedCache !== undefined) {
+  // A successfully-connected client is reused for the container's lifetime.
+  if (cachedDistributedCache !== undefined && cachedDistributedCache !== NOOP_CACHE) {
     return cachedDistributedCache
   }
 
@@ -251,31 +266,50 @@ async function getVaultsCacheInstance(): Promise<DistributedCache> {
   const STAGE = process.env.STAGE
 
   if (!REDIS_CACHE_URL || !STAGE) {
-    logger.warn('Redis not configured (REDIS_CACHE_URL/STAGE), using noop cache for vaults')
+    // Not configured — there's nothing to retry, so memoize the noop cache permanently.
+    if (cachedDistributedCache === undefined) {
+      logger.warn('Redis not configured (REDIS_CACHE_URL/STAGE), using noop cache for vaults')
+    }
     cachedDistributedCache = NOOP_CACHE
     return cachedDistributedCache
   }
 
-  try {
-    cachedDistributedCache = await getRedisInstance(
-      {
-        url: REDIS_CACHE_URL,
-        ttlInSeconds: VAULTS_CACHE_TTL_SECONDS,
-        username: REDIS_CACHE_USER,
-        password: REDIS_CACHE_PASSWORD,
-        stage: STAGE,
-      },
-      logger,
-    )
-  } catch (error) {
-    // The cache is optional — a Redis connection failure must not take down the endpoint. Fall back to the
-    // noop cache (and memoize it so we don't retry connecting on every request in this container).
-    logger.warn('Redis init failed, falling back to noop cache for vaults', {
-      error: error instanceof Error ? error.message : String(error),
-    })
-    cachedDistributedCache = NOOP_CACHE
+  // We fell back to the noop cache from a prior failure — keep serving it until the cooldown elapses.
+  if (cachedDistributedCache === NOOP_CACHE && Date.now() < cacheRetryAfter) {
+    return NOOP_CACHE
   }
-  return cachedDistributedCache
+
+  // The cache is optional — a Redis connection failure or a slow/dead endpoint must never take down or hang
+  // the endpoint. `getRedisInstance` is fail-fast (connect timeout + bounded reconnect), and `withTimeout` is
+  // a hard ceiling on top of that.
+  const instance = await withTimeout(
+    () =>
+      getRedisInstance(
+        {
+          url: REDIS_CACHE_URL,
+          ttlInSeconds: VAULTS_CACHE_TTL_SECONDS,
+          username: REDIS_CACHE_USER,
+          password: REDIS_CACHE_PASSWORD,
+          stage: STAGE,
+          connectTimeoutMs: CACHE_CONNECT_TIMEOUT_MS,
+          maxReconnectAttempts: CACHE_MAX_RECONNECT_ATTEMPTS,
+        },
+        logger,
+      ),
+    CACHE_CONNECT_TIMEOUT_MS + 500,
+    NOOP_CACHE,
+    (reason, error) =>
+      logger.warn('Redis init failed, using noop cache for vaults (will retry after cooldown)', {
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+  )
+
+  cachedDistributedCache = instance
+  if (instance === NOOP_CACHE) {
+    cacheRetryAfter = Date.now() + CACHE_INIT_RETRY_COOLDOWN_MS
+  }
+  return instance
 }
 
 /**
@@ -286,18 +320,31 @@ async function getAllVaults(subgraphBase: string, chainFilter?: ChainId): Promis
   const cache = await getVaultsCacheInstance()
   const cacheKey = `vaults-v1:${chainFilter ?? 'all'}`
 
-  // Cache reads are best-effort: a Redis failure must not fail the request, just fall through to a fresh fetch.
-  try {
-    const cached = await cache.get(cacheKey)
-    if (cached) {
+  // Cache reads are best-effort and time-bounded: a Redis failure or a slow/hung read must not fail or delay
+  // the request beyond CACHE_OP_TIMEOUT_MS — it just falls through to a fresh fetch.
+  const cached = await withTimeout(
+    () => cache.get(cacheKey),
+    CACHE_OP_TIMEOUT_MS,
+    null,
+    (reason, error) =>
+      logger.warn('Cache read failed, fetching fresh', {
+        cacheKey,
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+  )
+  if (cached) {
+    // Guard the parse too: a corrupt/stale-format cached value must fall through to a fresh fetch, not throw.
+    try {
+      const parsed = JSON.parse(cached) as VaultInfo[]
       logger.info('Returning cached vaults', { cacheKey })
-      return JSON.parse(cached) as VaultInfo[]
+      return parsed
+    } catch (error) {
+      logger.warn('Cached vaults payload was unparseable, fetching fresh', {
+        cacheKey,
+        error: error instanceof Error ? error.message : String(error),
+      })
     }
-  } catch (error) {
-    logger.warn('Cache read failed, fetching fresh', {
-      cacheKey,
-      error: error instanceof Error ? error.message : String(error),
-    })
   }
 
   const perSource = await Promise.all(
@@ -309,17 +356,21 @@ async function getAllVaults(subgraphBase: string, chainFilter?: ChainId): Promis
 
   // Only persist complete results. If any source degraded, skip the write so a transient outage isn't cached
   // as authoritative for the full TTL (which would also make single-vault lookups 404 for real vaults).
+  // The write is also time-bounded and never throws.
   if (degraded) {
     logger.warn('Skipping cache write due to degraded source(s)', { cacheKey })
   } else {
-    try {
-      await cache.set(cacheKey, JSON.stringify(vaults))
-    } catch (error) {
-      logger.warn('Cache write failed', {
-        cacheKey,
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
+    await withTimeout(
+      () => cache.set(cacheKey, JSON.stringify(vaults)),
+      CACHE_OP_TIMEOUT_MS,
+      undefined,
+      (reason, error) =>
+        logger.warn('Cache write failed', {
+          cacheKey,
+          reason,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+    )
   }
 
   return vaults

--- a/external-api/get-protocol-info-function/src/index.ts
+++ b/external-api/get-protocol-info-function/src/index.ts
@@ -482,6 +482,11 @@ export const handler = async (
 ): Promise<APIGatewayProxyResultV2> => {
   const SUBGRAPH_BASE = process.env.SUBGRAPH_BASE
 
+  // Return the response as soon as the handler resolves, without waiting for the event loop to drain. This
+  // prevents a best-effort background Redis reconnect (which may still be retrying a slow/dead endpoint) from
+  // holding the invocation open and inflating billed duration.
+  context.callbackWaitsForEmptyEventLoop = false
+
   logger.addContext(context)
 
   if (!SUBGRAPH_BASE) {

--- a/external-api/get-protocol-info-function/src/utils/with-timeout.spec.ts
+++ b/external-api/get-protocol-info-function/src/utils/with-timeout.spec.ts
@@ -1,0 +1,63 @@
+import { withTimeout } from './with-timeout'
+
+const delay = <T>(ms: number, value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms))
+
+describe('withTimeout', () => {
+  it('resolves to the value when the factory settles before the timeout', async () => {
+    const onFallback = jest.fn()
+    const result = await withTimeout(() => delay(5, 'ok'), 200, 'fallback', onFallback)
+    expect(result).toBe('ok')
+    expect(onFallback).not.toHaveBeenCalled()
+  })
+
+  it('returns the fallback and reports "timeout" when the factory is too slow', async () => {
+    const onFallback = jest.fn()
+    const result = await withTimeout(() => delay(200, 'ok'), 20, 'fallback', onFallback)
+    expect(result).toBe('fallback')
+    expect(onFallback).toHaveBeenCalledWith('timeout')
+  })
+
+  it('returns the fallback and reports "error" when the factory rejects', async () => {
+    const onFallback = jest.fn()
+    const boom = new Error('boom')
+    const result = await withTimeout(() => Promise.reject(boom), 200, 'fallback', onFallback)
+    expect(result).toBe('fallback')
+    expect(onFallback).toHaveBeenCalledWith('error', boom)
+  })
+
+  it('returns the fallback when the factory throws synchronously (does not reject)', async () => {
+    const onFallback = jest.fn()
+    const boom = new Error('sync boom')
+    const result = await withTimeout(
+      () => {
+        throw boom
+      },
+      200,
+      'fallback',
+      onFallback,
+    )
+    expect(result).toBe('fallback')
+    expect(onFallback).toHaveBeenCalledWith('error', boom)
+  })
+
+  it('reports the fallback reason at most once (timeout wins, late rejection ignored)', async () => {
+    const onFallback = jest.fn()
+    // Rejects after 100ms, but the timeout is 20ms → timeout wins; the late rejection must not double-report.
+    const result = await withTimeout(
+      () => new Promise<string>((_, reject) => setTimeout(() => reject(new Error('late')), 100)),
+      20,
+      'fallback',
+      onFallback,
+    )
+    expect(result).toBe('fallback')
+    await delay(150, null) // let the late rejection settle
+    expect(onFallback).toHaveBeenCalledTimes(1)
+    expect(onFallback).toHaveBeenCalledWith('timeout')
+  })
+
+  it('works without an onFallback callback', async () => {
+    await expect(withTimeout(() => Promise.reject(new Error('x')), 200, 42)).resolves.toBe(42)
+    await expect(withTimeout(() => delay(100, 1), 10, 42)).resolves.toBe(42)
+  })
+})

--- a/external-api/get-protocol-info-function/src/utils/with-timeout.ts
+++ b/external-api/get-protocol-info-function/src/utils/with-timeout.ts
@@ -1,0 +1,59 @@
+/**
+ * Runs `factory()` but never lets it block longer than `timeoutMs`, and never rejects. Resolves to the
+ * promise's value on success, or to `fallback` if the promise rejects or exceeds the timeout. `onFallback`
+ * is invoked (if provided) so the caller can log why the fallback was taken.
+ *
+ * Used to keep an optional dependency (Redis) strictly off the critical path: a dead/slow endpoint yields the
+ * fallback within a bounded time instead of hanging the request until the Lambda times out. The internal
+ * timer is `unref`'d so it never keeps the event loop alive on its own.
+ */
+export async function withTimeout<T>(
+  factory: () => Promise<T>,
+  timeoutMs: number,
+  fallback: T,
+  onFallback?: (reason: 'timeout' | 'error', error?: unknown) => void,
+): Promise<T> {
+  // Report the fallback reason at most once. Without this, when the timeout wins the race the underlying
+  // promise keeps running and a late rejection would fire `onFallback('error')` a second time (confusing
+  // logs, possibly on a later invocation once the container unfreezes).
+  let reported = false
+  const reportTimeout = () => {
+    if (reported) {
+      return
+    }
+    reported = true
+    onFallback?.('timeout')
+  }
+  const reportError = (error: unknown) => {
+    if (reported) {
+      return
+    }
+    reported = true
+    onFallback?.('error', error)
+  }
+
+  // `guarded` never rejects: both a rejected promise AND a synchronous throw from `factory()` are mapped to
+  // the fallback (the `Promise.resolve().then(factory)` boundary converts a sync throw into a rejection).
+  const guarded = Promise.resolve()
+    .then(factory)
+    .catch((error) => {
+      reportError(error)
+      return fallback
+    })
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => {
+      reportTimeout()
+      resolve(fallback)
+    }, timeoutMs)
+    // Don't let the timeout timer alone hold the process open.
+    timer.unref?.()
+  })
+
+  const result = await Promise.race([guarded, timeout])
+  if (timer) {
+    clearTimeout(timer)
+  }
+  return result
+}

--- a/packages/redis-cache/src/index.ts
+++ b/packages/redis-cache/src/index.ts
@@ -8,6 +8,17 @@ export interface RedisConfig {
   database?: number
   ttlInSeconds: number
   stage: string
+  /**
+   * Socket connect timeout in ms. When set, a connection that can't be established within this window fails
+   * instead of hanging. Omit to preserve the node-redis default (no explicit connect timeout).
+   */
+  connectTimeoutMs?: number
+  /**
+   * Max reconnect attempts before `connect()` gives up and rejects. When set, a permanently unreachable
+   * endpoint (e.g. a deleted host that returns NXDOMAIN on every retry) rejects quickly rather than retrying
+   * forever. Omit to preserve the node-redis default reconnect behaviour (retries indefinitely).
+   */
+  maxReconnectAttempts?: number
 }
 
 export async function getRedisInstance(
@@ -23,6 +34,16 @@ export async function getRedisInstance(
     database: config.database,
     socket: {
       tls: true,
+      ...(config.connectTimeoutMs !== undefined && { connectTimeout: config.connectTimeoutMs }),
+      ...(config.maxReconnectAttempts !== undefined && {
+        // Returning an Error stops node-redis from retrying and makes connect() reject; a number keeps
+        // retrying with that backoff. Without this, a permanently-unreachable host retries forever and
+        // connect() never settles.
+        reconnectStrategy: (retries: number) =>
+          retries >= config.maxReconnectAttempts! // eslint-disable-line @typescript-eslint/no-non-null-assertion
+            ? new Error('Redis reconnect attempts exhausted')
+            : Math.min(retries * 100, 500),
+      }),
     },
   })
     .on('error', (err) => logger.error('Redis Client Error', err))


### PR DESCRIPTION
## Problem

The `/vaults` endpoint hung when Redis was unreachable. Root cause: the configured `REDIS_CACHE_URL` points at a **deleted Redis Cloud database** — its host returns **NXDOMAIN** (the parent cluster zone still resolves, the DB endpoint doesn't). It's not a permissions or VPC issue — `get-protocol-info` isn't in a VPC and the host is public.

Why that hung the endpoint: node-redis retries the **initial** connect indefinitely by default, so `.connect()` never rejected, the handler's `try/catch` around cache init never fired, and the request blocked until the Lambda timed out.

## Fix — three layers so Redis can never break or slow `/vaults`

1. **`@summerfi/redis-cache`** — new **opt-in** `RedisConfig` fields `connectTimeoutMs` and `maxReconnectAttempts`. When set, the socket gets a connect timeout and a `reconnectStrategy` that returns an `Error` once attempts are exhausted, so `.connect()` **rejects fast** instead of retrying forever. Both omitted by default → **zero behaviour change** for existing consumers (`get-apy`, `get-rates`, `get-vault-rates`).
2. **vaults handler** — bounds cache **init / get / set** with a new pure `withTimeout` util (hard ceilings) and opts into the fail-fast Redis options. Any failure/slowness falls back to the noop cache / a fresh subgraph fetch.
3. **index handler** — `context.callbackWaitsForEmptyEventLoop = false`, so any residual background reconnect can't hold the invocation open or inflate billed duration.

With Redis healthy, behaviour is unchanged. With Redis dead/slow/misconfigured, `/vaults` serves fresh uncached data within a bounded time instead of hanging.

## Review hardening (CodeRabbit + external second opinions)

- `withTimeout` maps **synchronous** factory throws to the fallback (via a promise boundary) and reports the fallback reason **at most once** (no duplicate `onFallback` on a late background rejection).
- `getAllVaults` guards `JSON.parse` of the cached payload — a corrupt/stale value now falls through to a fresh fetch instead of failing the request.
- A failed Redis init serves the noop cache only until a **cooldown** elapses, then the next request retries — a transient hiccup no longer disables caching for the whole container lifetime.
- One flagged "off-by-one in `reconnectStrategy`" was checked against `@redis/client@1.6.1` (`socket.js` passes `retries++`, 0-indexed) and is **not** a bug for our config — left as-is.

## Tests / checks

- Unit tests for `withTimeout` (resolve / timeout / reject / sync-throw / single-report / no-callback).
- `jest` ✅ 18 tests · `tsc -b` ✅ · `eslint` ✅ (function + redis-cache) · `prettier --check` ✅

## Follow-up (ops, not code)

The stale `REDIS_CACHE_URL` should be repointed to a live Redis or unset. This PR makes the endpoint independent of that being correct, but caching stays a no-op until it is.
