### PR TITLE
fix(protocol-info): point /vaults cache at the SST-managed ElastiCache

### DIFF
--- a/external-api/get-protocol-info-function/CLAUDE.md
+++ b/external-api/get-protocol-info-function/CLAUDE.md
@@ -1,60 +1,94 @@
 # get-protocol-info-function — cross-package dependencies
 
-AWS Lambda serving protocol/vault info. Routes: `GET /` (protocol stats), `GET /users`, `GET /all-users`,
-`GET /circulating-supply`, and the vaults routes: `GET /vaults`, `GET /vaults/{chainId}`,
-`GET /vaults/{chainId}/{vaultAddress}` (per-vault NAV / TVL / APY).
+AWS Lambda serving protocol/vault info. Routes: `GET /` (protocol stats), `GET /users`,
+`GET /all-users`, `GET /circulating-supply`, and the vaults routes: `GET /vaults`,
+`GET /vaults/{chainId}`, `GET /vaults/{chainId}/{vaultAddress}` (per-vault NAV / TVL / APY).
 
 This file documents what the function depends on **across the monorepo** and, most importantly, the
-**"adding a new chain" coupling** — chain/config lists are duplicated across packages and drift silently.
+**"adding a new chain" coupling** — chain/config lists are duplicated across packages and drift
+silently.
 
 ## Data sources & what each provides
 
-| Dependency | Provides | Used by |
-|---|---|---|
-| `@summerfi/summer-earn-protocol-subgraph` | Public vaults: `getVaults`, `getUsers`, `getUsersPositions`; **`subgraphNameByChainMap`**, **`supportedChains`** | `/`, `/users`, `/all-users`, `/vaults` |
-| `@summerfi/summer-earn-institutions-subgraph` | Institutional (v1) vaults: `getVaults`; **`subgraphNameByChainMap`**, **`supportedChains`** | `/`, `/vaults` |
-| RWA / institutions **v2** subgraphs (`summer-institutions-v2`, `summer-institutions-v2-base`) | New institutional vaults. Queried directly via `graphql-request` against `${SUBGRAPH_BASE}/<name>` — no typed client (the typed `GetVaults` needs an `institutionId` and omits `dailySnapshots`). Map lives inline in `src/handlers/vaults.ts`. | `/vaults` |
-| `@summerfi/redis-cache` (`getRedisInstance`) + `@summerfi/abstractions` (`DistributedCache`) | Response caching (lazy singleton, noop fallback when unset) | `/vaults` |
-| `@summerfi/serverless-shared` | `ChainId`, `Address`, `ResponseOk/BadRequest/...`, `chainIdSchema` | all routes |
-| `viem` + `src/abis/fleetRewardsManager.ts` | On-chain `earned(...)` multicalls | `/users`, `/circulating-supply` |
+| Dependency                                                                                    | Provides                                                                                                                                                                                                                                        | Used by                                |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `@summerfi/summer-earn-protocol-subgraph`                                                     | Public vaults: `getVaults`, `getUsers`, `getUsersPositions`; **`subgraphNameByChainMap`**, **`supportedChains`**                                                                                                                                | `/`, `/users`, `/all-users`, `/vaults` |
+| `@summerfi/summer-earn-institutions-subgraph`                                                 | Institutional (v1) vaults: `getVaults`; **`subgraphNameByChainMap`**, **`supportedChains`**                                                                                                                                                     | `/`, `/vaults`                         |
+| RWA / institutions **v2** subgraphs (`summer-institutions-v2`, `summer-institutions-v2-base`) | New institutional vaults. Queried directly via `graphql-request` against `${SUBGRAPH_BASE}/<name>` — no typed client (the typed `GetVaults` needs an `institutionId` and omits `dailySnapshots`). Map lives inline in `src/handlers/vaults.ts`. | `/vaults`                              |
+| `@summerfi/redis-cache` (`getRedisInstance`) + `@summerfi/abstractions` (`DistributedCache`)  | Response caching against the SST-managed ElastiCache (lazy singleton, fail-fast, noop fallback when unset) — see "Cache & VPC" below                                                                                                            | `/vaults`                              |
+| `@summerfi/serverless-shared`                                                                 | `ChainId`, `Address`, `ResponseOk/BadRequest/...`, `chainIdSchema`                                                                                                                                                                              | all routes                             |
+| `viem` + `src/abis/fleetRewardsManager.ts`                                                    | On-chain `earned(...)` multicalls                                                                                                                                                                                                               | `/users`, `/circulating-supply`        |
 
 ## Environment variables
 
-- `SUBGRAPH_BASE` (required) — base host for **all** subgraphs; full URL is `${SUBGRAPH_BASE}/<subgraph-name>`.
+- `SUBGRAPH_BASE` (required) — base host for **all** subgraphs; full URL is
+  `${SUBGRAPH_BASE}/<subgraph-name>`.
 - `RPC_GATEWAY` (required for `/users`, `/circulating-supply`) — see `src/utils/rpc.ts`.
-- `REDIS_CACHE_URL`, `REDIS_CACHE_USER`, `REDIS_CACHE_PASSWORD`, `STAGE` (optional) — enable Redis caching for
-  `/vaults`. When `REDIS_CACHE_URL`/`STAGE` are unset the function uses a noop cache (still works, just uncached).
+- `REDIS_CACHE_URL`, `STAGE` (optional) — enable Redis caching for `/vaults`. In staging/prod both
+  are wired by the stack: `STAGE` from `stack.stage` and `REDIS_CACHE_URL` from the **SST-managed
+  ElastiCache** (see the cross-stack note below). When unset (dev stages) the handler uses a noop
+  cache — still works, just uncached. `REDIS_CACHE_USER`/`REDIS_CACHE_PASSWORD` are read by the
+  handler if present but are **not** set for the managed ElastiCache (access is via the VPC security
+  group + the `elasticache:Connect` IAM policy, over TLS).
+
+## Cache & VPC (cross-stack dependency)
+
+`/vaults` reuses the **same ElastiCache serverless Redis that `get-rates-function` uses**. That
+cache is created in the `API` stack (`stacks/redis.ts`, via `stacks/summer-stack.ts`) and is
+**VPC-internal**, so:
+
+- `stacks/partners-stack.ts` (`ExternalAPI`) pulls it cross-stack with SST `use(API)` (the `API`
+  stack now `return`s `{ cache, vpc }`), then wires `get-protocol-info` with
+  `cache.policyStatement` + `REDIS_CACHE_URL = cache.url`. **`ExternalAPI` therefore deploys after
+  `API`.**
+- `get-protocol-info` runs **in the VPC** (private subnets + the shared security group) — required
+  to reach the cache. The private subnets have NAT egress, so `SUBGRAPH_BASE` / `RPC_GATEWAY` stay
+  reachable (same setup as `get-campaign-data` and `get-rates-function`).
+- Because the cache URL/ARN cross the stack boundary, CloudFormation creates exports on the `API`
+  stack; changing or removing the ElastiCache requires updating `ExternalAPI` first. The cache is
+  `RETAIN`, so this is rare.
+- The handler treats Redis as best-effort only: fail-fast connect + `withTimeout` ceilings + a retry
+  cooldown mean a dead/slow cache never hangs or fails a request (`src/handlers/vaults.ts`
+  `getVaultsCacheInstance`).
 
 ## Adding a new chain — checklist
 
-Each source has a single source of truth for its chain → subgraph-name mapping; `supportedChains` derives from it.
-When a chain is added to one, the others do **not** update automatically. Touch the ones relevant to the routes
-you care about:
+Each source has a single source of truth for its chain → subgraph-name mapping; `supportedChains`
+derives from it. When a chain is added to one, the others do **not** update automatically. Touch the
+ones relevant to the routes you care about:
 
-1. **`ChainId` enum** — the chain must exist in `@summerfi/serverless-shared` (`src/domain-types.ts`) first.
+1. **`ChainId` enum** — the chain must exist in `@summerfi/serverless-shared`
+   (`src/domain-types.ts`) first.
 2. **Public vaults** — add `chainId → 'summer-protocol-<chain>'` in
-   `packages/summer-earn-protocol-subgraph/src/utils/subgraphNameByChainMap.ts`. `supportedChains` auto-derives.
-   Affects `/`, `/users`, `/all-users`, `/vaults`.
+   `packages/summer-earn-protocol-subgraph/src/utils/subgraphNameByChainMap.ts`. `supportedChains`
+   auto-derives. Affects `/`, `/users`, `/all-users`, `/vaults`.
 3. **Institutional v1** — add `chainId → 'summer-institutions-<chain>'` in
-   `packages/summer-earn-institutions-subgraph/src/utils/subgraphNameByChainMap.ts`. Affects `/`, `/vaults`.
+   `packages/summer-earn-institutions-subgraph/src/utils/subgraphNameByChainMap.ts`. Affects `/`,
+   `/vaults`.
 4. **Institutional v2 (RWA)** — add `chainId → 'summer-institutions-v2[-<chain>]'` in the
    `rwaSubgraphNameByChainMap` in **`src/handlers/vaults.ts`**. Affects `/vaults`.
-   - NB: the earn-protocol app's `rwaSubgraphsMap` (`apps/earn-protocol/app/server-handlers/subgraphs-map.ts`)
-     currently has the wrong `-staging` suffix — that map is **not** the reference; this handler's map is.
+   - NB: the earn-protocol app's `rwaSubgraphsMap`
+     (`apps/earn-protocol/app/server-handlers/subgraphs-map.ts`) currently has the wrong `-staging`
+     suffix — that map is **not** the reference; this handler's map is.
 5. **On-chain paths only** (`/users`, `/circulating-supply`), if the new chain participates:
    - `src/utils/rpc.ts` — add the chain → network-name mapping.
-   - `src/index.ts` — add a `case` to `getChainConfig` (viem chain) and an entry in `SUMMER_TOKEN_ADDRESSES`.
-6. **Prerequisite**: the corresponding subgraph must actually be deployed and served by `SUBGRAPH_BASE`.
+   - `src/index.ts` — add a `case` to `getChainConfig` (viem chain) and an entry in
+     `SUMMER_TOKEN_ADDRESSES`.
+6. **Prerequisite**: the corresponding subgraph must actually be deployed and served by
+   `SUBGRAPH_BASE`.
 
 ## Notes
 
-- **`/vaults` APY** is computed from `dailySnapshots.pricePerShare` (7d change annualised + raw 24h change),
-  matching the earn-protocol UI helpers `get-nav-price-change-24h.ts` / `get-nav-price-change-30d.ts`, **not**
-  the subgraph's revenue-based `apr*` fields. See `src/handlers/vaults.ts` and the pure math in `src/utils/nav-apy.ts`.
-- **Staleness**: each vault carries a `staleness` object (`src/utils/nav-apy.ts` `computeNavStaleness`). The
-  query fetches `_meta { block { number timestamp } }` (same request, no extra call) and staleness is measured
-  as `subgraphBlockTimestamp - latestSnapshotTimestamp > threshold` (default 1 day), i.e. against the
-  subgraph's own indexed head to avoid clock skew, with a Lambda wall-clock fallback when the subgraph omits a
-  block timestamp. Consumers must check `staleness.isStale` before trusting `nav`/`apy`.
-- `/vaults` degrades gracefully: each `(source, chain)` subgraph call is isolated in try/catch, so one failing
-  subgraph returns an empty slice rather than failing the whole response.
+- **`/vaults` APY** is computed from `dailySnapshots.pricePerShare` (7d change annualised + raw 24h
+  change), matching the earn-protocol UI helpers `get-nav-price-change-24h.ts` /
+  `get-nav-price-change-30d.ts`, **not** the subgraph's revenue-based `apr*` fields. See
+  `src/handlers/vaults.ts` and the pure math in `src/utils/nav-apy.ts`.
+- **Staleness**: each vault carries a `staleness` object (`src/utils/nav-apy.ts`
+  `computeNavStaleness`). The query fetches `_meta { block { number timestamp } }` (same request, no
+  extra call) and staleness is measured as
+  `subgraphBlockTimestamp - latestSnapshotTimestamp > threshold` (default 1 day), i.e. against the
+  subgraph's own indexed head to avoid clock skew, with a Lambda wall-clock fallback when the
+  subgraph omits a block timestamp. Consumers must check `staleness.isStale` before trusting
+  `nav`/`apy`.
+- `/vaults` degrades gracefully: each `(source, chain)` subgraph call is isolated in try/catch, so
+  one failing subgraph returns an empty slice rather than failing the whole response.

--- a/stacks/partners-stack.ts
+++ b/stacks/partners-stack.ts
@@ -1,5 +1,6 @@
-import { Api, Function, StackContext } from 'sst/constructs'
+import { Api, Function, StackContext, use } from 'sst/constructs'
 import { attachVPC } from './vpc'
+import { API } from './summer-stack'
 
 export function ExternalAPI(stackContext: StackContext) {
   const { stack } = stackContext
@@ -21,6 +22,11 @@ export function ExternalAPI(stackContext: StackContext) {
         : undefined,
   })
   const vpc = attachVPC({ ...stackContext, isDev })
+
+  // Reuse the SST-managed ElastiCache created in the `API` stack (same cache get-rates-function uses) instead
+  // of a separate/external Redis. `cache` is null in dev stages (no managed cache) — consumers fall back to a
+  // noop cache. This is a cross-stack dependency: `ExternalAPI` deploys after `API`.
+  const { cache } = use(API)
 
   const { SUBGRAPH_BASE } = process.env
   if (!SUBGRAPH_BASE) {
@@ -67,19 +73,24 @@ export function ExternalAPI(stackContext: StackContext) {
     disableCloudWatchLogs: false,
     applicationLogLevel: 'INFO',
     systemLogLevel: 'INFO',
+    // The /vaults route caches in the SST-managed ElastiCache, which is VPC-internal, so the function must run
+    // in the VPC to reach it (mirrors get-rates-function and get-campaign-data in this stack). The private
+    // subnets have NAT egress, so SUBGRAPH_BASE / RPC_GATEWAY remain reachable.
+    ...(vpc && {
+      vpc: vpc.vpc,
+      vpcSubnets: {
+        subnets: [...vpc.vpc.privateSubnets],
+      },
+      securityGroups: [vpc.securityGroup],
+    }),
   })
 
-  // Optional Redis cache for the /vaults route. Passed through from the deploy env when present; the handler
-  // falls back to a noop cache when unset, so the function is fully functional without Redis configured.
-  const { REDIS_CACHE_URL, REDIS_CACHE_USER, REDIS_CACHE_PASSWORD } = process.env
-  if (REDIS_CACHE_URL) {
-    getProtocolInfo.addEnvironment('REDIS_CACHE_URL', REDIS_CACHE_URL)
-  }
-  if (REDIS_CACHE_USER) {
-    getProtocolInfo.addEnvironment('REDIS_CACHE_USER', REDIS_CACHE_USER)
-  }
-  if (REDIS_CACHE_PASSWORD) {
-    getProtocolInfo.addEnvironment('REDIS_CACHE_PASSWORD', REDIS_CACHE_PASSWORD)
+  // Redis cache for the /vaults route: reuse the SST-managed ElastiCache from the `API` stack (same cache
+  // get-rates-function uses). This replaces the previous external Redis Cloud env passthrough. When there is no
+  // managed cache (dev stages, `cache === null`) the handler falls back to a noop cache and still works.
+  if (cache) {
+    getProtocolInfo.addToRolePolicy(cache.policyStatement)
+    getProtocolInfo.addEnvironment('REDIS_CACHE_URL', cache.url)
   }
 
   const getCampaignData = new Function(stack, 'get-campaign-data', {

--- a/stacks/summer-stack.ts
+++ b/stacks/summer-stack.ts
@@ -53,4 +53,8 @@ export function API(stackContext: StackContext) {
   stack.addOutputs({
     ApiEndpoint: api.url,
   })
+
+  // Exposed for cross-stack consumers (e.g. the partners `ExternalAPI` stack) via SST `use(API)`, so they can
+  // reuse the SST-managed ElastiCache instead of standing up their own. `cache`/`vpc` are null in dev stages.
+  return { cache, vpc }
 }


### PR DESCRIPTION
## What

Point the `/vaults` route's Redis cache at the **SST-managed ElastiCache serverless Redis** — the same cache `get-rates-function` uses — instead of the external Redis Cloud DB that was passed via the `REDIS_CACHE_URL` secret.

## Why

That external Redis Cloud DB was deleted, so the endpoint host now returns `getaddrinfo ENOTFOUND` — which is what surfaced the dead-Redis behaviour hardened against in #1371. The SST-managed ElastiCache is created and kept alive by our own infra, so it's the reliable choice, and reusing it means one less external dependency.

## How

The managed ElastiCache is created in the `API` stack and is **VPC-internal**, so:

- **`stacks/summer-stack.ts`** — the `API` stack now `return`s `{ cache, vpc }` so other stacks can reuse it.
- **`stacks/partners-stack.ts`** (`ExternalAPI`) — mirrors how `get-rates-function` is wired in `apy.ts`:
  - pulls the cache cross-stack via SST `use(API)`;
  - runs `get-protocol-info` **in the VPC** (private subnets + shared security group) so it can reach the cache. The private subnets have NAT egress, so `SUBGRAPH_BASE` / `RPC_GATEWAY` stay reachable — same setup as `get-campaign-data` (same stack) and `get-rates-function`;
  - wires `cache.policyStatement` (`elasticache:Connect`) + `REDIS_CACHE_URL = cache.url`, and **drops** the external Redis Cloud env passthrough (`REDIS_CACHE_URL`/`USER`/`PASSWORD` secrets).
- **`CLAUDE.md`** — documents the new cache source, the VPC requirement, and the cross-stack dependency.

The **handler code is unchanged** — it already used `getRedisInstance` and the same env vars. `REDIS_CACHE_USER`/`PASSWORD` are simply left unset (like `get-rates`); access is via the VPC security group + IAM over TLS. In dev stages there's no managed cache (`cache === null`), so the handler's noop fallback behaves exactly as before, and the existing fail-fast + `withTimeout` hardening is untouched.

## Notes / implications

- **`ExternalAPI` now deploys after `API`** (cross-stack `use()` dependency).
- Because the cache URL/ARN cross the stack boundary, CloudFormation creates exports on the `API` stack; changing/removing the ElastiCache later requires updating `ExternalAPI` first. The cache is `RETAIN`, so this is rare.
- This places the **whole** `get-protocol-info` function (all routes) into the VPC in staging/prod — the only way to reach the VPC-internal cache, and consistent with `get-rates`/`get-campaign-data`.
- Follow-up (ops, not in this PR): the now-unused external `REDIS_CACHE_URL`/`USER`/`PASSWORD` secrets are no longer read by this function.

## Verification

- Stacks typecheck (`tsc -p stacks/tsconfig.json`) — pass
- Function build — pass; tests — 18/18 pass
- Function lint — clean; prettier — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved protocol info handling by using the shared cache and VPC resources when available, making the service more consistent across environments.
* **Bug Fixes**
  * Added a resilient fallback for environments without shared cache access, so the endpoint continues to work without interruption.
* **Documentation**
  * Expanded guidance on cache usage, network requirements, environment variables, and stack setup for protocol info-related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->